### PR TITLE
Fix Logic for Parallel Large Video Conversion

### DIFF
--- a/config/trossen_ai_stationary.json
+++ b/config/trossen_ai_stationary.json
@@ -27,7 +27,7 @@
       "fps": 30,
       "width": 640,
       "height": 480,
-      "use_depth": true
+      "use_depth": false
     },
    {
       "name": "cam_low",

--- a/docs/readme/usage.md
+++ b/docs/readme/usage.md
@@ -7,21 +7,19 @@ You can run the following commands from the root of the repository after buildin
 
 ```bash
 ./build/record \
-  --robot trossen_ai_stationary\
+  --robot trossen_ai_stationary \
   --recording_time 10 \
   --num_episodes 1 --fps 30 \
   --display_cameras true \
   --tags test \
-  --overwrite false \
-  --dataset trossen_ai_stationary_coffee_cup \
+  --overwrite true \
+  --dataset test_dataset_00 \
   --repo_id TrossenRoboticsCommunity \
-  --single_task Put the spoon in the coffee cup \
+  --single_task pick_place \
   --num_image_writer_threads_per_camera 4 \
   --num_image_writer_processes 1 \
   --video true \
-  --run_compute_stats true \
-  --warmup_time 2 \
-  --reset_time 2
+  --run_compute_stats true
 ```
 
 Arguments:

--- a/docs/readme/usage.md
+++ b/docs/readme/usage.md
@@ -7,19 +7,21 @@ You can run the following commands from the root of the repository after buildin
 
 ```bash
 ./build/record \
-  --robot trossen_ai_stationary \
+  --robot trossen_ai_stationary\
   --recording_time 10 \
   --num_episodes 1 --fps 30 \
   --display_cameras true \
   --tags test \
-  --overwrite true \
-  --dataset test_dataset_00 \
+  --overwrite false \
+  --dataset trossen_ai_stationary_coffee_cup \
   --repo_id TrossenRoboticsCommunity \
-  --single_task pick_place \
+  --single_task Put the spoon in the coffee cup \
   --num_image_writer_threads_per_camera 4 \
   --num_image_writer_processes 1 \
   --video true \
-  --run_compute_stats true
+  --run_compute_stats true \
+  --warmup_time 2 \
+  --reset_time 2
 ```
 
 Arguments:

--- a/scripts/record.cpp
+++ b/scripts/record.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[]) {
 
   spdlog::info("Initializing dataset [control_script.cpp]: {}", dataset_name);
   trossen_dataset::TrossenAIDataset dataset(
-      dataset_name, "test_task", robot_controller, root_path, repo_id,
+      dataset_name, single_task, robot_controller, root_path, repo_id,
       run_compute_stats, overwrite, num_image_writer_threads_per_camera, fps);
 
   spdlog::info("Connecting to robot: {}", robot_name);

--- a/scripts/record.cpp
+++ b/scripts/record.cpp
@@ -159,12 +159,12 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  // If enabled, convert images to videos after all episodes are done
-  if (video) dataset.convert_to_videos();
-
   // Sleep the arms and disconnect at the end of the control script
   robot_controller->disconnect();
   teleop_robot->disconnect();
+
+  // If enabled, convert images to videos after all episodes are done
+  if (video) dataset.convert_to_videos();
 
   spdlog::info("Control script finished.");
   return 0;

--- a/src/trossen_dataset/dataset.cpp
+++ b/src/trossen_dataset/dataset.cpp
@@ -641,6 +641,9 @@ void TrossenAIDataset::compute_statistics(std::shared_ptr<arrow::Table> table,
 }
 
 void TrossenAIDataset::convert_to_videos() const {
+
+  spdlog::info("Encoding images to videos...");
+
   int fps = static_cast<int>(fps_);
   int episode_chunk = 0;
 

--- a/src/trossen_dataset/dataset.cpp
+++ b/src/trossen_dataset/dataset.cpp
@@ -53,6 +53,7 @@ TrossenAIDataset::TrossenAIDataset(
       metadata_ = std::make_unique<Metadata>(dataset_name_, repo_id_,
                                              task_name_, root_, false);
     } else {
+      spdlog::info("Loading existing dataset: {}", dataset_name_);
       // If overwrite is false, load existing metadata and verify the dataset
       metadata_ = std::make_unique<Metadata>(dataset_name_, repo_id_,
                                              task_name_, root_, true);
@@ -64,6 +65,7 @@ TrossenAIDataset::TrossenAIDataset(
       // If the dataset directory already exists, we assume it is an existing
       // dataset
       int existing_episodes = get_num_existing_episodes();
+      spdlog::info("Existing episodes found: {}", existing_episodes);
       for (int i = 0; i < existing_episodes; ++i) {
         // Load each episode and add it to the buffer
         auto episode_data = std::make_unique<EpisodeData>(i);
@@ -653,6 +655,10 @@ void TrossenAIDataset::convert_to_videos() const {
   auto start_time = std::chrono::steady_clock::now();
 
   // Iterate over each camera directory in the images path
+  // Limit the number of concurrent threads to avoid CPU overload
+  const size_t max_concurrent_threads = std::thread::hardware_concurrency();
+  std::atomic<size_t> active_threads{0};
+
   for (const auto &cam_dir : std::filesystem::directory_iterator(images_path)) {
     if (!cam_dir.is_directory()) continue;
     // Create output directory for the camera videos based on camera directory
@@ -681,8 +687,15 @@ void TrossenAIDataset::convert_to_videos() const {
                       output_video_path.string());
         continue;
       }
-      // Launch a thread to encode the video using FFmpeg
-      threads.emplace_back([=, &log_mutex]() {
+
+      // Wait if too many threads are running
+      while (active_threads >= max_concurrent_threads) {
+        // Yield to allow other threads to finish
+        std::this_thread::yield();
+      }
+
+      active_threads++;
+      threads.emplace_back([=, &log_mutex, &active_threads]() {
         try {
           spdlog::debug("Started encoding {}", output_video_path.string());
           // Collect image files
@@ -702,6 +715,7 @@ void TrossenAIDataset::convert_to_videos() const {
           if (image_paths.empty()) {
             std::lock_guard<std::mutex> lock(log_mutex);
             spdlog::warn("No images found in episode folder: {}", episode_name);
+            active_threads--;
             return;
           }
           // Use a pattern for FFmpeg input to match image files with sequential
@@ -750,6 +764,7 @@ void TrossenAIDataset::convert_to_videos() const {
           spdlog::error("Exception in video thread for {}: {}", episode_name,
                         e.what());
         }
+        active_threads--;
       });
     }
   }

--- a/src/trossen_dataset/dataset.cpp
+++ b/src/trossen_dataset/dataset.cpp
@@ -663,6 +663,10 @@ void TrossenAIDataset::convert_to_videos() const {
   const size_t max_concurrent_threads = std::thread::hardware_concurrency();
   std::atomic<size_t> active_threads{0};
 
+
+  // Atomic counter for the number of videos processed
+  std::atomic<int> video_count{0};
+
   // Condition variable and mutex for thread synchronization
   std::condition_variable cv;
 
@@ -689,6 +693,7 @@ void TrossenAIDataset::convert_to_videos() const {
           videos_cam_dir / (episode_name + ".mp4");
       // Skip if the video already exists
       if (std::filesystem::exists(output_video_path)) {
+        video_count++;
         std::lock_guard<std::mutex> lock(log_mutex);
         spdlog::debug("Skipping existing video: {}",
                       output_video_path.string());
@@ -702,7 +707,7 @@ void TrossenAIDataset::convert_to_videos() const {
         active_threads++;
       }
 
-      threads.emplace_back([=, &log_mutex, &active_threads, &cv]() {
+      threads.emplace_back([=, &log_mutex, &active_threads, &cv, &video_count]() {
         try {
           spdlog::debug("Started encoding {}", output_video_path.string());
           // Collect image files
@@ -769,6 +774,7 @@ void TrossenAIDataset::convert_to_videos() const {
                           ret_code);
           } else {
             spdlog::debug("Created video: {}", output_video_path.string());
+            video_count++;
           }
         } catch (const std::exception &e) {
           std::lock_guard<std::mutex> lock(log_mutex);
@@ -788,6 +794,11 @@ void TrossenAIDataset::convert_to_videos() const {
   for (auto &t : threads) {
     if (t.joinable()) t.join();
   }
+
+  // Set the total videos in metadata after processing each camera directory
+  int total_videos = video_count.load();
+  metadata_->set_info_entry("total_videos", std::to_string(total_videos));
+  metadata_->save_info_file();
 
   auto end_time = std::chrono::steady_clock::now();
   auto duration_sec =
@@ -1022,15 +1033,6 @@ void Metadata::update_info(int additional_frames) {
       info_.contains("total_episodes") ? info_["total_episodes"].get<int>() : 0;
   total_episodes += 1;
   info_["total_episodes"] = total_episodes;
-
-  // Increment the total videos by the number of cameras (assuming 4 cameras for
-  // now)
-  int total_videos =
-      info_.contains("total_videos") ? info_["total_videos"].get<int>() : 0;
-  // TODO(shantanuparab-tr): [TDS-17]: Determine the correct number of videos to
-  // add based on cameras
-  total_videos += 4;
-  info_["total_videos"] = total_videos;
 
   // Update training split range
   if (!info_.contains("splits")) {

--- a/src/trossen_dataset/dataset.cpp
+++ b/src/trossen_dataset/dataset.cpp
@@ -84,10 +84,11 @@ TrossenAIDataset::TrossenAIDataset(
     std::filesystem::create_directories(dataset_dir / trossen_sdk::IMAGES_DIR);
     metadata_ = std::make_unique<Metadata>(dataset_name_, repo_id_, task_name_,
                                            root_, false);
+    // Set robot name and features in metadata
+    metadata_->set_info_entry("robot_name", robot_->name());
+    metadata_->add_features(*robot_);
   }
-  // Set robot name and features in metadata
-  metadata_->set_info_entry("robot_name", robot_->name());
-  metadata_->add_features(*robot_);
+
 
   // Start image writer threads for each camera
   trossen_ai_robot_devices::AsyncImageWriter image_writer_(

--- a/src/trossen_dataset/dataset.cpp
+++ b/src/trossen_dataset/dataset.cpp
@@ -660,6 +660,9 @@ void TrossenAIDataset::convert_to_videos() const {
   const size_t max_concurrent_threads = std::thread::hardware_concurrency();
   std::atomic<size_t> active_threads{0};
 
+  // Condition variable and mutex for thread synchronization
+  std::condition_variable cv;
+
   for (const auto &cam_dir : std::filesystem::directory_iterator(images_path)) {
     if (!cam_dir.is_directory()) continue;
     // Create output directory for the camera videos based on camera directory
@@ -690,13 +693,13 @@ void TrossenAIDataset::convert_to_videos() const {
       }
 
       // Wait if too many threads are running
-      while (active_threads >= max_concurrent_threads) {
-        // Yield to allow other threads to finish
-        std::this_thread::yield();
+      {
+        std::unique_lock<std::mutex> cv_lock(log_mutex);
+        cv.wait(cv_lock, [&] { return active_threads < max_concurrent_threads; });
+        active_threads++;
       }
 
-      active_threads++;
-      threads.emplace_back([=, &log_mutex, &active_threads]() {
+      threads.emplace_back([=, &log_mutex, &active_threads, &cv]() {
         try {
           spdlog::debug("Started encoding {}", output_video_path.string());
           // Collect image files
@@ -716,7 +719,11 @@ void TrossenAIDataset::convert_to_videos() const {
           if (image_paths.empty()) {
             std::lock_guard<std::mutex> lock(log_mutex);
             spdlog::warn("No images found in episode folder: {}", episode_name);
-            active_threads--;
+            {
+              std::lock_guard<std::mutex> cv_lock(log_mutex);
+              active_threads--;
+            }
+            cv.notify_one();
             return;
           }
           // Use a pattern for FFmpeg input to match image files with sequential
@@ -765,7 +772,11 @@ void TrossenAIDataset::convert_to_videos() const {
           spdlog::error("Exception in video thread for {}: {}", episode_name,
                         e.what());
         }
-        active_threads--;
+        {
+          std::lock_guard<std::mutex> cv_lock(log_mutex);
+          active_threads--;
+        }
+        cv.notify_one();
       });
     }
   }


### PR DESCRIPTION
This PR fixes the problem with encoding large number of videos concurrently.

- The initial video conversion logic did not check the maximum number of threads available on the given hardware.
- This led the system to assume infinite number of threads that led to crashing of the system.

This fix checks for the total number of hardware concurrent threads available on the system, and keeps a track of all active threads. New threads that are added after hitting the hardware limit wait until the existing threads are free.

Minor Fix:
 - Single task description is now used in dataset. 
 - Fix rewriting of metadata when resuming episode recording
 - Fix logic for updating video count
 - Add logging for video encoding
 - Start video encoding after disconnecting arms