### PR TITLE
Add Video Encoding for LeRobot

### DIFF
--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -240,7 +240,7 @@ int main(int argc, char** argv) {
     lerobot_cfg->output_dir = cfg.output_dir;
     lerobot_cfg->task_name = "trossen_ai_solo_demo";
     lerobot_cfg->repository_id = "TrossenRoboticsCommunity";
-    lerobot_cfg->dataset_name = "trossen_ai_solo_dataset";
+    lerobot_cfg->dataset_id = "trossen_ai_solo_dataset";
     lerobot_cfg->overwrite_existing = false;
     lerobot_cfg->encode_videos = true;
     lerobot_cfg->type = "lerobot";
@@ -300,7 +300,7 @@ int main(int argc, char** argv) {
     cam_cfg.width = cfg.camera_width;
     cam_cfg.height = cfg.camera_height;
     cam_cfg.fps = cfg.camera_fps;
-    cam_cfg.stream_id = "camera/image";
+    cam_cfg.stream_id = "camera_main";
     cam_cfg.encoding = "bgr8";
     cam_cfg.pattern = trossen::hw::camera::MockCameraProducer::Pattern::Gradient;
     cam_cfg.warmup_frames = 3;

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -289,7 +289,7 @@ int main(int argc, char** argv) {
     lerobot_cfg->output_dir = cfg.output_dir;
     lerobot_cfg->task_name = "trossen_ai_solo_demo";
     lerobot_cfg->repository_id = "TrossenRoboticsCommunity";
-    lerobot_cfg->dataset_name = "trossen_ai_bimanual_dataset";
+    lerobot_cfg->dataset_id = "trossen_ai_bimanual_dataset";
     lerobot_cfg->overwrite_existing = false;
     lerobot_cfg->encode_videos = true;
     lerobot_cfg->type = "lerobot";

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -193,6 +193,9 @@ public:
    */
   void addMetadata(const Metadata& md);
 
+  /**
+   * @brief Convert recorded images to videos using FFmpeg
+   */
   void convert_to_videos() const;
 
   /// @brief Image encoding statistics

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -357,6 +357,7 @@ private:
   std::shared_ptr<arrow::io::FileOutputStream> outfile_;
   std::unique_ptr<parquet::arrow::FileWriter> writer_;
 
+  // Hash map to store the frame indices for each source
   //Hash map to store the frame indices for each source
   std::unordered_map<std::string, uint64_t> source_frame_indices_;
 };

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -90,8 +90,8 @@ public:
     // Repository ID
     std::string repository_id{"default_repo"};
 
-    // Dataset name
-    std::string dataset_name{"default_dataset"};
+    // Dataset ID
+    std::string dataset_id{"default_dataset"};
 
     // Root path
     std::string root_path{get_default_root_path().string()};
@@ -192,6 +192,8 @@ public:
    * @param md Metadata to add
    */
   void addMetadata(const Metadata& md);
+
+  void convert_to_videos() const;
 
   /// @brief Image encoding statistics
   struct ImageEncodeStats {
@@ -354,6 +356,9 @@ private:
   std::shared_ptr<arrow::Schema> schema_;
   std::shared_ptr<arrow::io::FileOutputStream> outfile_;
   std::unique_ptr<parquet::arrow::FileWriter> writer_;
+
+  //Hash map to store the frame indices for each source
+  std::unordered_map<std::string, uint64_t> source_frame_indices_;
 };
 
 } // namespace trossen::io::backends

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -361,7 +361,6 @@ private:
   std::unique_ptr<parquet::arrow::FileWriter> writer_;
 
   // Hash map to store the frame indices for each source
-  //Hash map to store the frame indices for each source
   std::unordered_map<std::string, uint64_t> source_frame_indices_;
 };
 

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -278,7 +278,6 @@ void LeRobotBackend::convert_to_videos() const {
       const auto &task = tasks[idx];
       try {
         // Gather all image files
-        // Gather all JPG files
         std::vector<fs::path> image_paths;
         image_paths.reserve(512);
         for (const auto &file : fs::directory_iterator(task.episode_dir)) {
@@ -388,7 +387,6 @@ void LeRobotBackend::close() {
   convert_to_videos();
 
   // Clear frame indices map
-  //  Clear frame indices map
   source_frame_indices_.clear();
 
   opened_ = false;

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -31,7 +31,7 @@ LeRobotBackend::LeRobotBackend(Config cfg, Metadata md)
   // URI is absolute path to output directory. Set to absolute path and check write access.
   // Validate output directory path
   try {
-    uri_ = (fs::path(cfg_.root_path) / cfg_.repository_id / cfg_.dataset_name).string();
+    uri_ = (fs::path(cfg_.root_path) / cfg_.repository_id / cfg_.dataset_id).string();
   } catch (const std::exception& e) {
     throw std::runtime_error("Failed to resolve absolute path of output directory: " + std::string(e.what()));
   }
@@ -190,6 +190,7 @@ bool LeRobotBackend::open() {
 
 void LeRobotBackend::write(const data::RecordBase& record) {
   std::lock_guard<std::mutex> lock(write_mutex_);
+
   // Decide type by RTTI (simple approach for now)
   if (auto js = dynamic_cast<const data::TeleopJointStateRecord*>(&record)) {
     writeJointState(*js);
@@ -212,6 +213,129 @@ void LeRobotBackend::writeBatch(std::span<const data::RecordBase* const> records
       writeImage(*img);
     }
   }
+}
+
+void LeRobotBackend::convert_to_videos() const {
+  std::cout << "Encoding images to videos..." << std::endl;
+
+  const int fps = static_cast<int>(std::round(30.0)); // Use recorded fps if available
+  const int episode_chunk = 0;
+  const size_t max_concurrent_encoders = std::max<size_t>(2, std::thread::hardware_concurrency() / 2);
+
+  const std::string images_path = images_root_.string();
+  std::cout << "Images path: " << images_path << std::endl;
+  const fs::path base_path = fs::path(this->config().root_path) / this->config().repository_id / this->config().dataset_id;
+
+  std::atomic<int> video_count{0};
+  std::mutex log_mutex;
+
+  auto start_time = std::chrono::steady_clock::now();
+
+  // Collect all (camera, episode) directories first — reduces directory I/O inside threads
+  struct EpisodeTask {
+    fs::path episode_dir;
+    fs::path output_path;
+    std::string episode_name;
+  };
+
+  std::vector<EpisodeTask> tasks;
+  for (const auto &cam_dir : fs::directory_iterator(images_path)) {
+    if (!cam_dir.is_directory()) continue;
+
+    const std::string video_key = "observation.images." + cam_dir.path().filename().string();
+    std::ostringstream oss;
+    oss << "videos/chunk_" << std::setw(6) << std::setfill('0') << episode_chunk
+        << "/" << video_key;
+    const fs::path videos_cam_dir = base_path / oss.str();
+    fs::create_directories(videos_cam_dir);
+
+    for (const auto &episode_dir : fs::directory_iterator(cam_dir.path())) {
+      if (!episode_dir.is_directory()) continue;
+
+      const std::string episode_name = episode_dir.path().filename().string();
+      const fs::path output_video_path = videos_cam_dir / (episode_name + ".mp4");
+
+      if (fs::exists(output_video_path)) {
+        std::cout << "Skipping existing video: " << output_video_path.string() << std::endl;
+        video_count++;
+        continue;
+      }
+      tasks.push_back({episode_dir.path(), output_video_path, episode_name});
+    }
+  }
+
+  // Thread pool setup
+  std::atomic<size_t> next_task{0};
+  std::vector<std::thread> workers;
+  workers.reserve(max_concurrent_encoders);
+
+  auto encode_task = [&](int worker_id) {
+    while (true) {
+      size_t idx = next_task.fetch_add(1);
+      if (idx >= tasks.size()) break;
+
+      const auto &task = tasks[idx];
+      try {
+        // Gather all JPG files
+        std::vector<fs::path> image_paths;
+        image_paths.reserve(512);
+        for (const auto &file : fs::directory_iterator(task.episode_dir)) {
+          if (!file.is_regular_file()) continue;
+          std::string ext = file.path().extension().string();
+          std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+          if (ext == ".jpg" || ext == ".jpeg" || ext == ".png") image_paths.push_back(file.path());
+        }
+
+        if (image_paths.empty()) {
+          std::lock_guard<std::mutex> lk(log_mutex);
+          std::cout << "No images found in episode folder: " << task.episode_name << std::endl;
+          continue;
+        }
+
+        // Ensure sorted order by filename (just in case)
+        std::sort(image_paths.begin(), image_paths.end());
+
+        const fs::path input_pattern = task.episode_dir / "image_%06d.jpg";
+        std::ostringstream ffmpeg_cmd;
+        ffmpeg_cmd
+            << "ffmpeg -y -loglevel error -framerate " << fps
+            << " -i " << input_pattern.string()
+            << " -c:v libsvtav1 -crf 30 -g 30 -preset 6 -pix_fmt yuv420p "
+            << task.output_path.string();
+
+        auto t0 = std::chrono::steady_clock::now();
+        int ret = std::system(ffmpeg_cmd.str().c_str());
+        auto t1 = std::chrono::steady_clock::now();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+
+        std::lock_guard<std::mutex> lk(log_mutex);
+        if (ret == 0) {
+          std::cout << "[Worker " << worker_id << "] Encoded " << task.output_path.string() << " in " << ms << " ms" << std::endl;
+          video_count++;
+        } else {
+          std::cout << "[Worker " << worker_id << "] FFmpeg failed for " << task.output_path.string() << " (code " << ret << ")" << std::endl;
+        }
+
+      } catch (const std::exception &e) {
+        std::lock_guard<std::mutex> lk(log_mutex);
+        std::cout << "[Worker " << worker_id << "] Exception for " << task.episode_name << ": " << e.what() << std::endl;
+      }
+    }
+  };
+
+  // Spawn worker threads
+  for (size_t i = 0; i < max_concurrent_encoders; ++i) {
+    workers.emplace_back(encode_task, static_cast<int>(i));
+  }
+
+  for (auto &t : workers) {
+    if (t.joinable()) t.join();
+  }
+
+  
+  auto end_time = std::chrono::steady_clock::now();
+  auto secs = std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
+  std::cout << "Encoded videos in " << secs << " seconds using " << max_concurrent_encoders << " threads" << std::endl;
 }
 
 void LeRobotBackend::flush() {
@@ -257,12 +381,24 @@ void LeRobotBackend::close() {
     if (t.joinable()) t.join();
   }
   image_workers_.clear();
+
+  // Encode any remaining images to videos
+  convert_to_videos();
+
+  //  Clear frame indices map
+  source_frame_indices_.clear();
+
   opened_ = false;
 }
 
 void LeRobotBackend::writeJointState(const data::RecordBase& base) {
 
   const auto& js = static_cast<const data::TeleopJointStateRecord&>(base);
+
+  if (source_frame_indices_.find(js.id) == source_frame_indices_.end()) {
+    source_frame_indices_[js.id] = js.seq;
+  }
+  int frame_id = js.seq - source_frame_indices_[js.id];
 
   // Create builders for one frame
   arrow::FloatBuilder ts_builder;
@@ -299,9 +435,9 @@ void LeRobotBackend::writeJointState(const data::RecordBase& base) {
     check_status(act_val->Append(v), "Failed to append action value");
 
   // Scalar columns
-  check_status(epi_idx_builder.Append(10), "Failed to append episode index");
-  check_status(frame_idx_builder.Append(js.seq), "Failed to append frame index");
-  check_status(index_builder.Append(0), "Failed to append global index");
+  check_status(epi_idx_builder.Append(0), "Failed to append episode index");
+  check_status(frame_idx_builder.Append(frame_id), "Failed to append frame index");
+  check_status(index_builder.Append(js.seq), "Failed to append global index");
   check_status(task_idx_builder.Append(0), "Failed to append task index");
 
   std::shared_ptr<arrow::Array> ts_arr, obs_arr, act_arr, epi_arr, frame_arr, idx_arr, task_arr;
@@ -342,11 +478,18 @@ void LeRobotBackend::writeJointState(const data::RecordBase& base) {
 void LeRobotBackend::writeImage(const data::RecordBase& base) {
   const auto& img = static_cast<const data::ImageRecord&>(base);
 
+  
   // exit early if nothing to write
   if (img.image.empty()) {
     return;
   }
 
+  if(source_frame_indices_.find(img.id) == source_frame_indices_.end()){
+    source_frame_indices_[img.id] = img.seq;
+    std::cout << "Initialized frame index for image id '" << img.id << "' to " << img.seq << std::endl;
+  }
+  int frame_index = img.seq - source_frame_indices_[img.id];
+  
   // Directory per camera id (cached)
   // TODO: this could be moved to a pre-processing step?
   auto it = image_dir_cache_.find(img.id);
@@ -360,7 +503,9 @@ void LeRobotBackend::writeImage(const data::RecordBase& base) {
   }
   const fs::path& camera_dir = it->second;
 
-  fs::path file_path = camera_dir / (std::to_string(img.ts.monotonic.to_ns()) + ".png");
+  fs::path file_path = camera_dir / (std::string("image_") + 
+                     (std::ostringstream() << std::setw(6) << std::setfill('0') << frame_index).str() +
+                     ".jpg");
 
   // Enqueue job (clone image to ensure safety if producer overwrites buffer later)
   //

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -218,6 +218,7 @@ void LeRobotBackend::writeBatch(std::span<const data::RecordBase* const> records
 void LeRobotBackend::convert_to_videos() const {
   std::cout << "Encoding images to videos..." << std::endl;
 
+  // TODO (shantanuparab-tr): Use recorded fps from metadata if available
   const int fps = static_cast<int>(std::round(30.0)); // Use recorded fps if available
   const int episode_chunk = 0;
   const size_t max_concurrent_encoders = std::max<size_t>(2, std::thread::hardware_concurrency() / 2);
@@ -397,6 +398,18 @@ void LeRobotBackend::writeJointState(const data::RecordBase& base) {
 
   const auto& js = static_cast<const data::TeleopJointStateRecord&>(base);
 
+
+  // Frame indexing strategy for multi-source data streams:
+  //
+  // PROBLEM: Each data source (camera, sensor, etc.) produces frames with global sequence IDs,
+  // but we need local frame indices that reset to 0 at the start of each recording episode.
+  //
+  // SOLUTION: Track the starting sequence ID for each source, then calculate:
+  // frame_index = current_sequence_id - starting_sequence_id_for_this_source
+  //
+  // ASSUMPTION: The first sequence ID we observe from a source marks the beginning
+  // of a new episode for that source.
+
   if (source_frame_indices_.find(js.id) == source_frame_indices_.end()) {
     source_frame_indices_[js.id] = js.seq;
   }
@@ -486,6 +499,17 @@ void LeRobotBackend::writeImage(const data::RecordBase& base) {
     return;
   }
 
+  // Frame indexing strategy for multi-source data streams:
+  //
+  // PROBLEM: Each data source (camera, sensor, etc.) produces frames with global sequence IDs,
+  // but we need local frame indices that reset to 0 at the start of each recording episode.
+  //
+  // SOLUTION: Track the starting sequence ID for each source, then calculate:
+  // frame_index = current_sequence_id - starting_sequence_id_for_this_source
+  //
+  // ASSUMPTION: The first sequence ID we observe from a source marks the beginning
+  // of a new episode for that source.
+  
   if(source_frame_indices_.find(img.id) == source_frame_indices_.end()){
     source_frame_indices_[img.id] = img.seq;
     std::cout << "Initialized frame index for image id '" << img.id << "' to " << img.seq << std::endl;

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -276,6 +276,7 @@ void LeRobotBackend::convert_to_videos() const {
 
       const auto &task = tasks[idx];
       try {
+        // Gather all image files
         // Gather all JPG files
         std::vector<fs::path> image_paths;
         image_paths.reserve(512);
@@ -385,6 +386,7 @@ void LeRobotBackend::close() {
   // Encode any remaining images to videos
   convert_to_videos();
 
+  // Clear frame indices map
   //  Clear frame indices map
   source_frame_indices_.clear();
 

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -385,7 +385,10 @@ std::shared_ptr<io::Backend> SessionManager::create_backend(
       // Copy backend config template and customize for this episode
     auto* lerobot_cfg = static_cast<io::backends::LeRobotBackend::Config*>(config_.backend_config.get());
     lerobot_cfg->output_dir = output_path;
-    lerobot_cfg->dataset_name = config_.dataset_id;
+    if (!lerobot_cfg) {
+      throw std::runtime_error("SessionManager::create_backend: backend_config is not LeRobotBackend::Config");
+    }
+    lerobot_cfg->dataset_id = config_.dataset_id;
     lerobot_cfg->episode_index = episode_index;
 
     auto metadata = io::backends::LeRobotBackend::Metadata{};


### PR DESCRIPTION
# Add video encoding and frame id computation

This PR adds video encoding functionality to the LeRobotBackend, converting captured images to videos after recording. It also implements proper frame index computation by tracking source-specific frame indices.

Key changes:
- Renamed `dataset_name` to `dataset_id` for consistency
- Added `convert_to_videos()` method to encode images to MP4 videos using ffmpeg
- Implemented frame index tracking per source stream
- Updated image file naming to use sequential frame indices
- Changed camera stream ID in examples from "camera/image" to "camera_main" (Creates Nested Directories)

The video encoding uses libsvtav1 codec with optimized settings and runs in a thread pool for performance.