### PR TITLE
Add image statistics computation 

### DIFF
--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -241,7 +241,7 @@ int main(int argc, char** argv) {
     lerobot_cfg->output_dir = cfg.output_dir;
     lerobot_cfg->task_name = "trossen_ai_solo_demo";
     lerobot_cfg->repository_id = "TrossenRoboticsCommunity";
-    lerobot_cfg->dataset_name = "trossen_ai_solo_dataset";
+    lerobot_cfg->dataset_id = "trossen_ai_solo_dataset";
     lerobot_cfg->overwrite_existing = false;
     lerobot_cfg->encode_videos = true;
     lerobot_cfg->type = "lerobot";

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -239,6 +239,7 @@ public:
    * @return Vector of OpenCV Mat objects representing the sampled images
    */
   std::vector<cv::Mat> sample_images(
+    const std::vector<std::filesystem::path> &image_paths) const;
       const std::vector<std::filesystem::path> &image_paths) const;
 
   /**
@@ -248,8 +249,10 @@ public:
    * @param max_threshold Maximum threshold for downsampling (default is 300)
    * @return Downsampled OpenCV Mat object
    */
-  cv::Mat auto_downsample(const cv::Mat &img, int target_size = 150,
-                          int max_threshold = 300) const;
+  cv::Mat auto_downsample(
+    const cv::Mat &img,
+    int target_size = 150,
+    int max_threshold = 300) const;
 
   /**
    * @brief Sample indices for selecting images from a dataset
@@ -259,8 +262,11 @@ public:
    * @param power Power factor for sampling distribution (default is 0.75)
    * @return Vector of sampled indices
    */
-  std::vector<int> sample_indices(int dataset_len, int min_samples = 100,
-                                  int max_samples = 10000, float power = 0.75f) const;
+  std::vector<int> sample_indices(
+    int dataset_len,
+    int min_samples = 100,
+    int max_samples = 10000,
+    float power = 0.75f) const;
 
 
 

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -267,9 +267,6 @@ public:
     int max_samples = 10000,
     float power = 0.75f) const;
 
-
-
-
   /// @brief Image encoding statistics
   struct ImageEncodeStats {
 

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -240,7 +240,6 @@ public:
    */
   std::vector<cv::Mat> sample_images(
     const std::vector<std::filesystem::path> &image_paths) const;
-      const std::vector<std::filesystem::path> &image_paths) const;
 
   /**
    * @brief Automatically downsample an image to a target size

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -225,6 +225,46 @@ public:
    * @return JSON object containing the computed statistics
    */
   nlohmann::json computeFlatStats(const std::shared_ptr<arrow::Array> &array) const;
+
+  /**
+   * @brief Compute statistics for a set of images
+   * @param images Vector of OpenCV Mat objects representing the images
+   * @return FeatureStats object containing the computed statistics
+   */
+  nlohmann::json compute_image_stats(const std::vector<cv::Mat> &images) const;
+
+  /**
+   * @brief Sample a set of images from a list of image paths
+   * @param image_paths Vector of filesystem paths to the images
+   * @return Vector of OpenCV Mat objects representing the sampled images
+   */
+  std::vector<cv::Mat> sample_images(
+      const std::vector<std::filesystem::path> &image_paths) const;
+
+  /**
+   * @brief Automatically downsample an image to a target size
+   * @param img OpenCV Mat object representing the image
+   * @param target_size Target size for the downsampled image (default is 150)
+   * @param max_threshold Maximum threshold for downsampling (default is 300)
+   * @return Downsampled OpenCV Mat object
+   */
+  cv::Mat auto_downsample(const cv::Mat &img, int target_size = 150,
+                          int max_threshold = 300) const;
+
+  /**
+   * @brief Sample indices for selecting images from a dataset
+   * @param dataset_len Length of the dataset
+   * @param min_samples Minimum number of samples to select (default is 100)
+   * @param max_samples Maximum number of samples to select (default is 10000)
+   * @param power Power factor for sampling distribution (default is 0.75)
+   * @return Vector of sampled indices
+   */
+  std::vector<int> sample_indices(int dataset_len, int min_samples = 100,
+                                  int max_samples = 10000, float power = 0.75f) const;
+
+
+
+
   /// @brief Image encoding statistics
   struct ImageEncodeStats {
 

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -223,6 +223,7 @@ void LeRobotBackend::convert_to_videos() const {
   const size_t max_concurrent_encoders = std::max<size_t>(2, std::thread::hardware_concurrency() / 2);
 
   const std::string images_path = images_root_.string();
+
   std::cout << "Images path: " << images_path << std::endl;
   const fs::path base_path = fs::path(this->config().root_path) / this->config().repository_id / this->config().dataset_id;
 
@@ -337,6 +338,129 @@ void LeRobotBackend::convert_to_videos() const {
   auto secs = std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
   std::cout << "Encoded videos in " << secs << " seconds using " << max_concurrent_encoders << " threads" << std::endl;
 }
+
+
+  std::vector<int> LeRobotBackend::sample_indices(int dataset_len,
+                                                    int min_samples,
+                                                    int max_samples,
+                                                    float power) const {
+    // Calculate the number of samples based on the power law
+    // Clamp the number of samples between min_samples and max_samples
+    int num_samples = std::clamp(static_cast<int>(std::pow(dataset_len, power)),
+                                min_samples, max_samples);
+    std::vector<int> indices(num_samples);
+    float step = static_cast<float>(dataset_len - 1) / (num_samples - 1);
+    for (int i = 0; i < num_samples; ++i) indices[i] = std::round(i * step);
+    return indices;
+  }
+
+  cv::Mat LeRobotBackend::auto_downsample(const cv::Mat &img, int target_size,
+                                            int max_threshold) const{
+    int h = img.rows;
+    int w = img.cols;
+    // If the larger dimension is already below the max threshold, return the
+    // original image
+    if (std::max(w, h) < max_threshold) return img;
+    // Calculate the downsampling factor to make the larger dimension equal to
+    // target_size
+    float factor = (w > h) ? (w / static_cast<float>(target_size))
+                          : (h / static_cast<float>(target_size));
+    // Downsample the image using area interpolation for better quality
+    cv::Mat downsampled;
+    cv::resize(img, downsampled, {}, 1.0 / factor, 1.0 / factor, cv::INTER_AREA);
+    return downsampled;
+  }
+
+  std::vector<cv::Mat> LeRobotBackend::sample_images(
+      const std::vector<std::filesystem::path> &image_paths) const {
+    // Sample indices using power law distribution
+    auto indices = sample_indices(image_paths.size());
+
+    std::vector<cv::Mat> images;
+    // Load and process images at the sampled indices
+    for (int idx : indices) {
+      cv::Mat img = cv::imread(image_paths[idx].string(), cv::IMREAD_COLOR);
+      if (img.empty()) continue;
+      // Downsample the image if necessary and convert to float32
+      cv::Mat img_downsampled = auto_downsample(img);
+      cv::Mat img_float;
+      // Normalize pixel values to [0, 1]
+      img_downsampled.convertTo(img_float, CV_32F, 1.0 / 255.0);
+      // Ensure the image has 3 channels (BGR)
+      if (img_float.channels() == 3) {
+        images.push_back(img_float);
+      } else {
+        std::cout << "Unexpected channel count: " << img_float.channels() << std::endl;
+      }
+    }
+
+    return images;
+  }
+
+  nlohmann::json LeRobotBackend::compute_image_stats (
+    const std::vector<cv::Mat> &images) const{
+    nlohmann::json stats_json;
+    if (images.empty()) {
+      std::cout << "No images provided." << std::endl;
+      stats_json["min"] = {};
+      stats_json["max"] = {};
+      stats_json["mean"] = {};
+      stats_json["std"] = {};
+      stats_json["count"] = {0};
+    return stats_json;
+    }
+
+    int num_channels = images[0].channels();
+    int count = static_cast<int>(images.size());
+
+    // Create a vector for each channel
+    std::vector<std::vector<float>> channel_values(num_channels);
+
+    for (const auto &img : images) {
+    std::vector<cv::Mat> channels;
+    cv::split(img, channels);
+
+    for (int c = 0; c < num_channels; ++c) {
+      // Flatten and push pixels into channel_values[c]
+      channel_values[c].insert(
+        channel_values[c].end(),
+        reinterpret_cast<float *>(const_cast<uchar *>(channels[c].datastart)),
+        reinterpret_cast<float *>(const_cast<uchar *>(channels[c].dataend)));
+    }
+    }
+
+    // Helper lambda to convert a vector to a nested JSON array
+    auto to_nested = [](const std::vector<float> &vec) {
+    nlohmann::json result = nlohmann::json::array();
+    for (float v : vec) {
+      result.push_back({{v}});
+    }
+    return result;
+    };
+
+    std::vector<float> min_vals, max_vals, mean_vals, std_vals;
+    for (int c = 0; c < num_channels; ++c) {
+    cv::Mat channel_mat(channel_values[c]);
+    cv::Scalar mean, stddev;
+    cv::meanStdDev(channel_mat, mean, stddev);
+
+    double min_val, max_val;
+    cv::minMaxLoc(channel_mat, &min_val, &max_val);
+
+    min_vals.push_back(static_cast<float>(min_val));
+    max_vals.push_back(static_cast<float>(max_val));
+    mean_vals.push_back(static_cast<float>(mean[0]));
+    std_vals.push_back(static_cast<float>(stddev[0]));
+    }
+
+    stats_json["min"] = to_nested(min_vals);
+    stats_json["max"] = to_nested(max_vals);
+    stats_json["mean"] = to_nested(mean_vals);
+    stats_json["std"] = to_nested(std_vals);
+    stats_json["count"] = {count};
+
+    return stats_json;
+  }
 
 
 nlohmann::json LeRobotBackend::computeFlatStats(
@@ -480,6 +604,44 @@ void LeRobotBackend::computeStatistics() const {
       stats[field->name()] = computeFlatStats(array);
     }
   }
+
+  // Compute image statistics for each camera
+  for (const auto &camera_info : md_.camera_names) {
+    std::string image_key = "observation.images." + camera_info;
+    // Get image paths for the current episode and camera
+    std::string image_folder_path = images_root_.string();
+
+    std::ostringstream episode_folder_ss;
+    episode_folder_ss << "episode_" << std::setfill('0') << std::setw(6)
+                      << cfg_.episode_index;
+    std::string episode_folder_name = episode_folder_ss.str();
+
+    // Construct the full path to the episode's image directory for the current
+    // camera
+    std::filesystem::path episode_image_dir =
+        std::filesystem::path(image_folder_path) / camera_info/ episode_folder_name;
+    if (!std::filesystem::exists(episode_image_dir)) {
+      std::cout << "Image directory does not exist: "
+                << episode_image_dir.string() << std::endl;
+      continue;
+    }
+
+    // Collect all image file paths in the directory
+    std::vector<std::filesystem::path> paths;
+    for (const auto &entry :
+         std::filesystem::directory_iterator(episode_image_dir)) {
+      if (entry.is_regular_file()) {
+        std::string ext = entry.path().extension().string();
+        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+        if (ext == ".jpg" || ext == ".png") {
+          paths.push_back(entry.path());
+        }
+      }
+    }
+    // Sample and process images to compute statistics
+    auto images = sample_images(paths);
+    stats[image_key]  = compute_image_stats(images);
+  }
   // TODO (shantanuparab-tr): Add this to metadata file
   printStatsTable(stats);
   
@@ -519,6 +681,8 @@ void LeRobotBackend::printStatsTable(const nlohmann::json& stats) const {
   }
   std::cout << "=================================================================\n";
 }
+
+
 
 void LeRobotBackend::flush() {
   // TODO (shantanuparab-tr): flush parquet writer if needed

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -341,10 +341,7 @@ void LeRobotBackend::convert_to_videos() const {
 }
 
 
-  std::vector<int> LeRobotBackend::sample_indices(int dataset_len,
-                                                    int min_samples,
-                                                    int max_samples,
-                                                    float power) const {
+  std::vector<int> LeRobotBackend::sample_indices(int dataset_len, int min_samples, int max_samples, float power) const {
     // Calculate the number of samples based on the power law
     // Clamp the number of samples between min_samples and max_samples
     int num_samples = std::clamp(static_cast<int>(std::pow(dataset_len, power)),
@@ -355,8 +352,7 @@ void LeRobotBackend::convert_to_videos() const {
     return indices;
   }
 
-  cv::Mat LeRobotBackend::auto_downsample(const cv::Mat &img, int target_size,
-                                            int max_threshold) const{
+  cv::Mat LeRobotBackend::auto_downsample(const cv::Mat &img, int target_size, int max_threshold) const{
     int h = img.rows;
     int w = img.cols;
     // If the larger dimension is already below the max threshold, return the
@@ -402,8 +398,7 @@ void LeRobotBackend::convert_to_videos() const {
     return images;
   }
 
-  nlohmann::json LeRobotBackend::compute_image_stats (
-    const std::vector<cv::Mat> &images) const{
+  nlohmann::json LeRobotBackend::compute_image_stats (const std::vector<cv::Mat> &images) const{
     nlohmann::json stats_json;
     if (images.empty()) {
       std::cout << "No images provided." << std::endl;
@@ -412,7 +407,7 @@ void LeRobotBackend::convert_to_videos() const {
       stats_json["mean"] = {};
       stats_json["std"] = {};
       stats_json["count"] = {0};
-    return stats_json;
+      return stats_json;
     }
 
     int num_channels = images[0].channels();
@@ -422,16 +417,16 @@ void LeRobotBackend::convert_to_videos() const {
     std::vector<std::vector<float>> channel_values(num_channels);
 
     for (const auto &img : images) {
-    std::vector<cv::Mat> channels;
-    cv::split(img, channels);
+      std::vector<cv::Mat> channels;
+      cv::split(img, channels);
 
-    for (int c = 0; c < num_channels; ++c) {
-      // Flatten and push pixels into channel_values[c]
-      channel_values[c].insert(
-        channel_values[c].end(),
-        reinterpret_cast<float *>(const_cast<uchar *>(channels[c].datastart)),
-        reinterpret_cast<float *>(const_cast<uchar *>(channels[c].dataend)));
-    }
+      for (int c = 0; c < num_channels; ++c) {
+        // Flatten and push pixels into channel_values[c]
+        channel_values[c].insert(
+          channel_values[c].end(),
+          reinterpret_cast<float *>(const_cast<uchar *>(channels[c].datastart)),
+          reinterpret_cast<float *>(const_cast<uchar *>(channels[c].dataend)));
+      }
     }
 
     // Helper lambda to convert a vector to a nested JSON array
@@ -445,17 +440,17 @@ void LeRobotBackend::convert_to_videos() const {
 
     std::vector<float> min_vals, max_vals, mean_vals, std_vals;
     for (int c = 0; c < num_channels; ++c) {
-    cv::Mat channel_mat(channel_values[c]);
-    cv::Scalar mean, stddev;
-    cv::meanStdDev(channel_mat, mean, stddev);
+      cv::Mat channel_mat(channel_values[c]);
+      cv::Scalar mean, stddev;
+      cv::meanStdDev(channel_mat, mean, stddev);
 
-    double min_val, max_val;
-    cv::minMaxLoc(channel_mat, &min_val, &max_val);
+      double min_val, max_val;
+      cv::minMaxLoc(channel_mat, &min_val, &max_val);
 
-    min_vals.push_back(static_cast<float>(min_val));
-    max_vals.push_back(static_cast<float>(max_val));
-    mean_vals.push_back(static_cast<float>(mean[0]));
-    std_vals.push_back(static_cast<float>(stddev[0]));
+      min_vals.push_back(static_cast<float>(min_val));
+      max_vals.push_back(static_cast<float>(max_val));
+      mean_vals.push_back(static_cast<float>(mean[0]));
+      std_vals.push_back(static_cast<float>(stddev[0]));
     }
 
     stats_json["min"] = to_nested(min_vals);

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -373,6 +373,10 @@ void LeRobotBackend::convert_to_videos() const {
 
   std::vector<cv::Mat> LeRobotBackend::sample_images(
       const std::vector<std::filesystem::path> &image_paths) const {
+    if (image_paths.empty()) {
+      return {};
+    }
+    
     // Sample indices using power law distribution
     auto indices = sample_indices(image_paths.size());
 

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <sstream>
 #include "opencv2/imgcodecs.hpp"
+#include <opencv2/opencv.hpp>
 #include <parquet/arrow/reader.h>
 #include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/io/backends/lerobot/lerobot_backend.hpp"
@@ -685,6 +686,7 @@ void LeRobotBackend::printStatsTable(const nlohmann::json& stats) const {
   }
   std::cout << "=================================================================\n";
 }
+}
 
 
 
@@ -1088,7 +1090,5 @@ void LeRobotBackend::addMetadata(const Metadata& md) {
   info_file << info_.dump(4);
   info_file.close();
   std::cout << "Metadata written to info.json successfully." << std::endl;
-
-}
-
+  }
 } // namespace trossen::io::backends

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -402,7 +402,7 @@ std::shared_ptr<io::Backend> SessionManager::create_backend(
     metadata.camera_width = 640; // TODO: Extract from camera producers
     metadata.camera_height = 480; // TODO: Extract from camera producers
     metadata.is_depth_camera = false; // TODO: Extract from camera producers
-    metadata.camera_names = {"front_camera", "rear_camera"}; // TODO: Extract from camera producers
+    metadata.camera_names = {"camera_main"}; // TODO: Extract from camera producers
     metadata.action_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
     metadata.observation_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
 


### PR DESCRIPTION
### TL;DR

Added image statistics computation to the LeRobot backend and fixed dataset parameter naming.

### What changed?

- Fixed parameter naming by changing `dataset_name` to `dataset_id` in the WidowX AI LeRobot example
- Added new methods to the LeRobotBackend class for image statistics computation:
  - `compute_image_stats`: Calculates min, max, mean, and standard deviation for image data
  - `sample_images`: Samples a subset of images from a dataset
  - `auto_downsample`: Automatically resizes images to a target size
  - `sample_indices`: Generates indices for sampling using a power law distribution
- Enhanced the `computeStatistics` method to include image statistics for each camera
- Updated the `printStatsTable` method to handle different types of statistics data, including nested arrays for image stats
- Updated the default camera name in `SessionManager` from multiple cameras to just `camera_main`

### How to test?

1. Run the WidowX AI LeRobot example to verify the backend correctly computes and displays image statistics
2. Check that the statistics table properly shows image data metrics (min, max, mean, std) for each color channel
3. Verify that the dataset is correctly identified using the `dataset_id` parameter

### Why make this change?

This change enhances the data analysis capabilities of the LeRobot backend by adding support for computing image statistics. These statistics are valuable for understanding the distribution of pixel values across the dataset, which is important for training computer vision models. The parameter naming fix ensures consistency in the API, and the updated camera name reflects the actual hardware configuration.