### PR TITLE
Add producer metadata to support dataset introspection

### DIFF
--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -17,7 +17,6 @@
 
 #include <chrono>
 #include <filesystem>
-#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/include/trossen_sdk/hw/arm/arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/arm_producer.hpp
@@ -24,6 +24,23 @@ public:
     bool use_device_time{true};
   };
 
+  struct TrossenArmProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// @brief Robot model
+    std::string arm_model;
+
+    /// @brief Firmware version
+    std::string firmware_version;
+
+    /// @brief Number of joints
+    size_t num_joints;
+
+    /// @brief Joint names
+    std::vector<std::string> joint_names;
+
+    /// @brief Gripper type
+    std::string gripper_type;
+  };
+
   /**
    * @brief Construct a TrossenArmProducer
    *
@@ -44,6 +61,9 @@ public:
    */
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
 
+  /// @brief Get producer metadata
+  const TrossenArmProducerMetadata& metadata() const override { return metadata_; }
+
 private:
   /// @brief Shared pointer to the TrossenArmDriver instance
   std::shared_ptr<trossen_arm::TrossenArmDriver> driver_;
@@ -56,6 +76,8 @@ private:
 
   /// @brief Reusable robot output to avoid reallocation each poll
   trossen_arm::RobotOutput robot_output_;
+
+  TrossenArmProducerMetadata metadata_;
 };
 
 } // namespace trossen::hw::arm

--- a/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
@@ -32,6 +32,24 @@ public:
     double max_period_ms{0.0}; // max observed poll interval
   };
 
+  struct MockJointStateProducerMetadata : public PolledProducer::ProducerMetadata {
+
+    /// @brief Robot model
+    std::string arm_model;
+
+    /// @brief Firmware version
+    std::string firmware_version;
+
+    /// @brief Number of joints
+    size_t num_joints;
+
+    /// @brief Joint names
+    std::vector<std::string> joint_names;
+
+    /// @brief Gripper type
+    std::string gripper_type;
+  };
+
   explicit MockJointStateProducer(Config cfg);
   ~MockJointStateProducer() override = default;
 
@@ -40,11 +58,14 @@ public:
   Diagnostics diagnostics() const { return diag_; }
   const Config& config() const { return cfg_; }
 
+  const MockJointStateProducerMetadata& metadata() const override { return metadata_; }
+
 private:
   Config cfg_;
   Diagnostics diag_{};
   bool started_{false};
   std::chrono::steady_clock::time_point last_tick_{};
+  MockJointStateProducerMetadata metadata_;
 };
 
 } // namespace trossen::hw::arm

--- a/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
@@ -54,7 +54,6 @@ public:
 
     /// @brief Observation feature data type
     std::string observation_dtype;
-
   };
 
   /**

--- a/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
@@ -24,6 +24,39 @@ public:
     bool use_device_time{true};
   };
 
+  struct TeleopTrossenArmProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// @brief Robot name
+    std::string robot_name;
+
+    /// @brief Leader arm model
+    std::string leader_arm_model;
+
+    /// @brief Leader firmware version
+    std::string leader_firmware_version;
+
+    /// @brief Follower arm model
+    std::string follower_arm_model;
+
+    /// @brief Follower firmware version
+    std::string follower_firmware_version;
+
+    /// @brief Action feature names
+    std::vector<std::string> action_feature_names;
+    
+    /// @brief Observation feature names
+    std::vector<std::string> observation_feature_names;
+
+    /// @brief Gripper type
+    std::string gripper_type;
+
+    /// @brief Action feature data type
+    std::string action_dtype;
+
+    /// @brief Observation feature data type
+    std::string observation_dtype;
+
+  };
+
   /**
    * @brief Construct a TeleopTrossenArmProducer
    *
@@ -46,6 +79,9 @@ public:
    */
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
 
+  /// @brief Get producer metadata
+  const TeleopTrossenArmProducerMetadata& metadata() const override { return metadata_; };
+
 private:
   /// @brief Shared pointer to the TrossenArmDriver instance leader arm
   std::shared_ptr<trossen_arm::TrossenArmDriver> leader_driver_;
@@ -64,6 +100,9 @@ private:
 
   /// @brief Reusable robot output to avoid reallocation each poll for follower arm
   trossen_arm::RobotOutput follower_robot_output_;
+  
+  /// @brief Metadata for producer
+  TeleopTrossenArmProducerMetadata metadata_;
 };
 
 } // namespace trossen::hw::arm

--- a/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
@@ -32,6 +32,39 @@ public:
     double max_period_ms{0.0}; // max observed poll interval
   };
 
+  struct TeleopMockJointStateProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// @brief Robot name
+    std::string robot_name;
+
+    /// @brief Leader arm model
+    std::string leader_arm_model;
+
+    /// @brief Leader firmware version
+    std::string leader_firmware_version;
+
+    /// @brief Follower arm model
+    std::string follower_arm_model;
+
+    /// @brief Follower firmware version
+    std::string follower_firmware_version;
+
+    /// @brief Action feature names
+    std::vector<std::string> action_feature_names;
+    
+    /// @brief Observation feature names
+    std::vector<std::string> observation_feature_names;
+
+    /// @brief Gripper type
+    std::string gripper_type;
+
+    /// @brief Action feature data type
+    std::string action_dtype;
+
+    /// @brief Observation feature data type
+    std::string observation_dtype;
+
+  };
+
   explicit TeleopMockJointStateProducer(Config cfg);
   ~TeleopMockJointStateProducer() override = default;
 
@@ -40,11 +73,14 @@ public:
   Diagnostics diagnostics() const { return diag_; }
   const Config& config() const { return cfg_; }
 
+  const TeleopMockJointStateProducerMetadata& metadata() const override { return metadata_; }
+
 private:
   Config cfg_;
   Diagnostics diag_{};
   bool started_{false};
   std::chrono::steady_clock::time_point last_tick_{};
+  TeleopMockJointStateProducerMetadata metadata_;
 };
 
 } // namespace trossen::hw::arm

--- a/include/trossen_sdk/hw/camera/mock_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_producer.hpp
@@ -49,10 +49,28 @@ public:
     double drop_probability{0.0}; ///< Simulated drop probability [0,1)
   };
 
+  struct MockCameraProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// @brief Image width
+    int width;
+
+    /// @brief Image height
+    int height;
+
+    /// @brief Image encoding
+    std::string encoding;
+
+    /// @brief Target frames per second
+    int fps;
+    
+  };
+
   explicit MockCameraProducer(Config cfg);
   ~MockCameraProducer() override = default;
 
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  /// @brief Get producer metadata
+  const MockCameraProducerMetadata& metadata() const override { return metadata_; }
 
   struct JitterStats {
     double mean_ms{0};
@@ -81,6 +99,8 @@ private:
   // Jitter measurement: store recent inter-frame intervals (ns)
   std::vector<uint64_t> intervals_ns_;
   static constexpr size_t kMaxIntervals = 50000; // cap to avoid unbounded growth
+
+  MockCameraProducerMetadata metadata_;
 };
 
 } // namespace trossen::hw::camera

--- a/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
@@ -42,10 +42,36 @@ public:
     double noise_stddev{20.0};
   };
 
+  struct MockSyncedCameraProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// @brief Camera name
+    std::string camera_name;
+
+    /// @brief Color image width
+    int color_width;
+
+    /// @brief Color image height
+    int color_height;
+
+    /// @brief Color image encoding
+    std::string color_encoding;
+
+    /// @brief Depth image width
+    int depth_width;
+
+    /// @brief Depth image height
+    int depth_height;
+
+    /// @brief Depth image encoding
+    std::string depth_encoding;
+  };
+
   explicit MockSyncedCameraProducer(Config cfg);
   ~MockSyncedCameraProducer() override = default;
 
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  /// @brief Get producer metadata
+  const MockSyncedCameraProducerMetadata& metadata() const override { return metadata_; }
 
   struct JitterStats {
     double mean_ms{0};
@@ -76,6 +102,8 @@ private:
   std::normal_distribution<float> norm_{0.f, 1.f};
 
   Config cfg_;
+
+  MockSyncedCameraProducerMetadata metadata_;
 };
 
 } // namespace trossen::hw::camera

--- a/include/trossen_sdk/hw/camera/opencv_producer.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_producer.hpp
@@ -53,6 +53,24 @@ public:
     bool enforce_requested_fps = true;
 };
 
+  struct OpenCvCameraProducerMetadata : public PolledProducer::ProducerMetadata {
+
+    /// @brief Camera name
+    std::string camera_name;
+
+    /// @brief Image width
+    int width;
+
+    /// @brief Image height
+    int height;
+
+    /// @brief Image encoding
+    std::string encoding;
+
+    /// @brief Target frames per second
+    int fps;
+  };
+
   /**
    * @brief Construct an OpenCvCameraProducer
    *
@@ -74,6 +92,10 @@ public:
 
   /// Poll for a single frame; emits 0 or 1 records.
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  /// @brief Get producer metadata
+  const OpenCvCameraProducerMetadata& metadata() const override { return metadata_; }
+
 protected:
   /**
    * @brief Open the device if not already opened
@@ -87,6 +109,11 @@ protected:
 
   /// @brief Capture handle
   cv::VideoCapture cap_;
+
+private:
+  /// @brief Metadata
+  OpenCvCameraProducerMetadata metadata_;
+  
 };
 
 } // namespace trossen::hw::camera

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -29,8 +29,6 @@ struct ProducerStats {
   uint64_t warmup_discarded{0};
 };
 
-
-
 /**
  * @brief PolledProducer: scheduler calls poll() periodically; implementation may emit 0 or more records.
  */
@@ -130,9 +128,6 @@ public:
    * @return const reference to ProducerStats
    */
   const ProducerStats& stats() const {return stats_; };
-
-  
-
 protected:
   /// @brief Whether we've opened the device
   bool opened_{false};

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -29,6 +29,8 @@ struct ProducerStats {
   uint64_t warmup_discarded{0};
 };
 
+
+
 /**
  * @brief PolledProducer: scheduler calls poll() periodically; implementation may emit 0 or more records.
  */
@@ -52,6 +54,26 @@ public:
    * @return const reference to ProducerStats
    */
   const ProducerStats& stats() const {return stats_; };
+
+  /// @brief Metadata for producers
+  struct ProducerMetadata {
+    /// @brief Unique identifier for the producer
+    std::string id;
+
+    /// @brief Human-readable name for the producer
+    std::string name;
+
+    /// @brief Description of the producer's function
+    std::string description;
+  };
+
+  /**
+   * @brief Get producer metadata
+   *
+   * @return const reference to ProducerMetadata
+   */
+  virtual const PolledProducer::ProducerMetadata& metadata() const {return metadata_; };
+
 protected:
   /// @brief Whether we've opened the device
   bool opened_{false};
@@ -76,6 +98,9 @@ protected:
 
   /// @brief Monotonic sequence number for emitted records
   uint64_t seq_{0};
+
+  /// @brief Producer metadata
+  PolledProducer::ProducerMetadata metadata_{};
 };
 
 // PushProducer: owns its own internal thread(s); start registers emit callback.
@@ -105,6 +130,9 @@ public:
    * @return const reference to ProducerStats
    */
   const ProducerStats& stats() const {return stats_; };
+
+  
+
 protected:
   /// @brief Whether we've opened the device
   bool opened_{false};
@@ -129,6 +157,7 @@ protected:
 
   /// @brief Monotonic sequence number for emitted records
   uint64_t seq_{0};
+
 };
 
 } // namespace trossen::hw

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -259,6 +259,7 @@ private:
    * @brief Create backend instance for the given episode
    * @param output_path Path to output file
    * @param episode_index Episode index for metadata
+   * @param producer_metadatas Metadata from registered producers
    * @return Shared pointer to backend instance
    */
   std::shared_ptr<io::Backend> create_backend(

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -263,7 +263,9 @@ private:
    */
   std::shared_ptr<io::Backend> create_backend(
     const std::string& output_path,
-    uint32_t episode_index);
+    uint32_t episode_index,
+    const std::vector<hw::PolledProducer::ProducerMetadata>& producer_metadatas
+  );
 
   /**
    * @brief Background monitoring loop for auto-stop

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -54,18 +54,6 @@ LeRobotBackend::LeRobotBackend(Config cfg, Metadata md)
   }
   test_file.close();
   fs::remove(test_path);
-
-
-  // Print off configuration
-  std::cout << "LeRobotBackend configuration:\n"
-            << "  Output dir: " << uri_ << "\n"
-            << "  Encoder threads: " << cfg_.encoder_threads << "\n"
-            << "  Max image queue: " << (cfg_.max_image_queue == 0 ? "unbounded" : std::to_string(cfg_.max_image_queue)) << "\n"
-            << "  Drop policy: "
-            << (cfg_.drop_policy == DropPolicy::DropNewest ? "DropNewest" :
-                (cfg_.drop_policy == DropPolicy::DropOldest ? "DropOldest" : "Block"))
-            << "\n"
-            << "  PNG compression level: " << cfg_.png_compression_level << "\n";
 }
 
 bool LeRobotBackend::open() {
@@ -182,7 +170,6 @@ bool LeRobotBackend::open() {
   }
 
   writer_ = std::move(result).ValueUnsafe();  // store unique_ptr<FileWriter>
-  std::cerr << "Opened Parquet writer successfully." << std::endl;
 
   opened_ = true;
   return true;
@@ -216,7 +203,6 @@ void LeRobotBackend::writeBatch(std::span<const data::RecordBase* const> records
 }
 
 void LeRobotBackend::convert_to_videos() const {
-  std::cout << "Encoding images to videos..." << std::endl;
 
   // TODO (shantanuparab-tr): Use recorded fps from metadata if available
   const int fps = static_cast<int>(std::round(30.0)); // Use recorded fps if available
@@ -225,7 +211,6 @@ void LeRobotBackend::convert_to_videos() const {
 
   const std::string images_path = images_root_.string();
 
-  std::cout << "Images path: " << images_path << std::endl;
   const fs::path base_path = fs::path(this->config().root_path) / this->config().repository_id / this->config().dataset_id;
 
   std::atomic<int> video_count{0};
@@ -306,13 +291,15 @@ void LeRobotBackend::convert_to_videos() const {
             << task.output_path.string();
 
         auto t0 = std::chrono::steady_clock::now();
+        std::cout<<"\n════════════════════════ [Worker " << worker_id << "] Encoding video ════════════════════════"<< std::endl;
         int ret = std::system(ffmpeg_cmd.str().c_str());
+        std::cout<<"══════════════════════════════════════════════════════════════════════════════════\n"<< std::endl;
+
         auto t1 = std::chrono::steady_clock::now();
         auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
 
         std::lock_guard<std::mutex> lk(log_mutex);
         if (ret == 0) {
-          std::cout << "[Worker " << worker_id << "] Encoded " << task.output_path.string() << " in " << ms << " ms" << std::endl;
           video_count++;
         } else {
           std::cout << "[Worker " << worker_id << "] FFmpeg failed for " << task.output_path.string() << " (code " << ret << ")" << std::endl;
@@ -337,7 +324,6 @@ void LeRobotBackend::convert_to_videos() const {
   
   auto end_time = std::chrono::steady_clock::now();
   auto secs = std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
-  std::cout << "Encoded videos in " << secs << " seconds using " << max_concurrent_encoders << " threads" << std::endl;
 }
 
 
@@ -560,8 +546,6 @@ nlohmann::json LeRobotBackend::computeListStats(
 
 void LeRobotBackend::computeStatistics() const {
 
-  std::cout << "Computing dataset statistics..." << std::endl;
-
   std::ostringstream oss;
   oss << "episode_" << std::setfill('0') << std::setw(6) << cfg_.episode_index << ".parquet";
   fs::path episode_path = data_root_ / oss.str();
@@ -700,8 +684,6 @@ void LeRobotBackend::close() {
       if (!st.ok()) {
         std::cerr << "[Parquet] Warning: Failed to close writer cleanly: "
                   << st.ToString() << std::endl;
-      } else {
-        std::cerr << "[Parquet] Writer closed successfully." << std::endl;
       }
       writer_.reset();
     }
@@ -712,8 +694,6 @@ void LeRobotBackend::close() {
       if (!st.ok()) {
         std::cerr << "[Parquet] Warning: Failed to close file stream: "
                   << st.ToString() << std::endl;
-      } else {
-        std::cerr << "[Parquet] File stream closed successfully." << std::endl;
       }
       outfile_.reset();
     }
@@ -859,7 +839,6 @@ void LeRobotBackend::writeImage(const data::RecordBase& base) {
   
   if(source_frame_indices_.find(img.id) == source_frame_indices_.end()){
     source_frame_indices_[img.id] = img.seq;
-    std::cout << "Initialized frame index for image id '" << img.id << "' to " << img.seq << std::endl;
   }
   int frame_index = img.seq - source_frame_indices_[img.id];
   
@@ -1076,8 +1055,7 @@ void LeRobotBackend::addMetadata(const Metadata& md) {
 
   // Write to info.json
   std::ofstream info_file(meta_root_ / JSON_INFO);
-  std::cout << "Writing metadata to info.json at: "
-            << (meta_root_ / JSON_INFO).string() << std::endl;
+
   if (!info_file.is_open()) {
     std::cerr << "Failed to open info.json for writing metadata." << std::endl;
     return;

--- a/src/hw/arm/arm_producer.cpp
+++ b/src/hw/arm/arm_producer.cpp
@@ -17,6 +17,16 @@ TrossenArmProducer::TrossenArmProducer(
     // Initial read to populate robot_output state
     robot_output_ = driver_->get_robot_output();
   }
+
+  // Populate metadata
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "Trossen Arm Producer";
+  metadata_.description = "Produces joint states from a Trossen Arm via TrossenArmDriver";
+  metadata_.arm_model = "WIDOWX_AI"; // TODO: Extract from driver/User Config
+  metadata_.firmware_version = "v1.9.0"; // TODO: Extract from driver / Remove
+  metadata_.num_joints = driver_ ? driver_->get_num_joints() : 0;
+  metadata_.joint_names = {"joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7"}; // TODO: Extract from driver / User Config
+  metadata_.gripper_type = "STANDARD"; // TODO: Extract from driver / User Config
 }
 
 void TrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/arm/mock_joint_producer.cpp
+++ b/src/hw/arm/mock_joint_producer.cpp
@@ -12,7 +12,20 @@
 namespace trossen::hw::arm {
 
 MockJointStateProducer::MockJointStateProducer(Config cfg)
-  : cfg_(std::move(cfg)) {}
+  : cfg_(std::move(cfg)) {
+
+  // Populate metadata
+  metadata_.id = cfg_.id;
+  metadata_.name = "Mock Joint State Producer";
+  metadata_.description = "Produces synthetic joint states for testing and diagnostics";
+  metadata_.arm_model = "MOCK_ARM";
+  metadata_.firmware_version = "v0.0.1-mock";
+  metadata_.num_joints = cfg_.num_joints;
+  metadata_.joint_names.resize(cfg_.num_joints);
+  for (size_t i = 0; i < cfg_.num_joints; ++i) {
+    metadata_.joint_names[i] = "joint_" + std::to_string(i);
+  }
+}
 
 void MockJointStateProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {
   using clock = std::chrono::steady_clock;

--- a/src/hw/arm/teleop_arm_producer.cpp
+++ b/src/hw/arm/teleop_arm_producer.cpp
@@ -1,6 +1,7 @@
 #include "trossen_sdk/hw/arm/teleop_arm_producer.hpp"
 
 #include <algorithm>
+#include <iostream>
 
 namespace trossen::hw::arm {
 
@@ -12,7 +13,7 @@ TeleopTrossenArmProducer::TeleopTrossenArmProducer(
     follower_driver_(std::move(follower_driver)),
     cfg_(std::move(cfg))
 {
-  if (leader_driver_) {
+  if (leader_driver_ && follower_driver_) {
     // Preallocate buffers based on number of joints
     act_d_.resize(leader_driver_->get_num_joints());
     obs_d_.resize(follower_driver_->get_num_joints());
@@ -20,6 +21,22 @@ TeleopTrossenArmProducer::TeleopTrossenArmProducer(
     leader_robot_output_ = leader_driver_->get_robot_output();
     follower_robot_output_ = follower_driver_->get_robot_output();
   }
+
+  // Populate metadata
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "Teleop Trossen Arm Producer";
+  metadata_.description = "Produces teleoperation joint states from leader and follower Trossen Arms via TrossenArmDriver";
+  metadata_.robot_name = "Trossen AI Bimanual"; // TODO: Extract from driver/User Config
+  metadata_.leader_arm_model = "WIDOWX_AI"; // TODO: Extract from driver/User Config
+  metadata_.follower_arm_model = "WIDOWX_AI"; // TODO: Extract from driver/User Config
+  metadata_.leader_firmware_version = "v1.9.0"; // TODO: Extract from driver / Remove
+  metadata_.follower_firmware_version = "v1.9.0"; // TODO: Extract from driver / Remove
+  metadata_.action_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
+  metadata_.observation_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
+  metadata_.gripper_type = "STANDARD"; // TODO: Extract from driver / User Config
+  metadata_.action_dtype = "float32";
+  metadata_.observation_dtype = "float32";
+
 }
 
 void TeleopTrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/arm/teleop_mock_joint_producer.cpp
+++ b/src/hw/arm/teleop_mock_joint_producer.cpp
@@ -8,11 +8,29 @@
 
 #include "trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp"
 #include "trossen_sdk/data/timestamp.hpp"
+#include <iostream>
 
 namespace trossen::hw::arm {
 
 TeleopMockJointStateProducer::TeleopMockJointStateProducer(Config cfg)
-  : cfg_(std::move(cfg)) {}
+  : cfg_(std::move(cfg)) {
+  // Populate metadata
+  metadata_.id = cfg_.id;
+  metadata_.name = "Teleop Mock Joint State Producer";
+  metadata_.description = "Produces synthetic teleoperation joint states for testing and diagnostics";
+  metadata_.robot_name = "MOCK_TELEOP_ROBOT"; 
+  metadata_.leader_arm_model = "MOCK_LEADER_ARM";
+  metadata_.leader_firmware_version = "v0.0.1-mock";
+  metadata_.follower_arm_model = "MOCK_FOLLOWER_ARM";
+  metadata_.follower_firmware_version = "v0.0.1-mock";
+  metadata_.action_feature_names.resize(cfg_.num_joints);
+  metadata_.observation_feature_names.resize(cfg_.num_joints);
+  for (size_t i = 0; i < cfg_.num_joints; ++i) {
+    metadata_.action_feature_names[i] = "joint_" + std::to_string(i);
+    metadata_.observation_feature_names[i] = "joint_" + std::to_string(i);
+  }
+  metadata_.gripper_type = "MOCK_GRIPPER";
+}
 
 void TeleopMockJointStateProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {
   using clock = std::chrono::steady_clock;

--- a/src/hw/camera/mock_producer.cpp
+++ b/src/hw/camera/mock_producer.cpp
@@ -17,6 +17,15 @@ MockCameraProducer::MockCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   if (cfg_.fps > 0) {
     frame_period_ns_ = static_cast<uint64_t>(1e9 / static_cast<double>(cfg_.fps));
   }
+
+  // Populate metadata
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "Mock Camera Producer";
+  metadata_.description = "Produces synthetic camera frames for testing and diagnostics";
+  metadata_.width = cfg_.width;
+  metadata_.height = cfg_.height;
+  metadata_.encoding = cfg_.encoding;
+  metadata_.fps = cfg_.fps;
 }
 
 void MockCameraProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/camera/mock_synced_producer.cpp
+++ b/src/hw/camera/mock_synced_producer.cpp
@@ -19,6 +19,22 @@ MockSyncedCameraProducer::MockSyncedCameraProducer(Config cfg) : cfg_(std::move(
   if (cfg_.seed) rng_.seed(static_cast<uint32_t>(cfg_.seed));
   warmup_remaining_ = cfg_.streams.warmup_frames;
   frame_period_ns_ = cfg_.streams.frame_period_ns();
+
+  // Populate metadata
+  metadata_.id = cfg_.camera_name;
+  metadata_.name = "Mock Synchronized Camera Producer";
+  metadata_.description = "Produces synthetic synchronized color and depth frames for testing and diagnostics";
+  metadata_.camera_name = cfg_.camera_name;
+  metadata_.color_width = cfg_.streams.color_width;
+  metadata_.color_height = cfg_.streams.color_height;
+  metadata_.color_encoding = cfg_.streams.color_encoding;
+  metadata_.depth_width = cfg_.streams.depth_width;
+  metadata_.depth_height = cfg_.streams.depth_height;
+  if (cfg_.streams.depth_format == DepthFormat::DEPTH16) {
+    metadata_.depth_encoding = "depth16";
+  } else {
+    metadata_.depth_encoding = "32FC1";
+  }
 }
 
 void MockSyncedCameraProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/camera/opencv_producer.cpp
+++ b/src/hw/camera/opencv_producer.cpp
@@ -8,7 +8,16 @@
 
 namespace trossen::hw::camera {
 
-OpenCvCameraProducer::OpenCvCameraProducer(Config cfg) : cfg_(std::move(cfg)) {}
+OpenCvCameraProducer::OpenCvCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
+  // Populate metadata
+  metadata_.id = "opencv_camera_" + std::to_string(cfg_.device_index);
+  metadata_.name = "OpenCV Camera Producer";
+  metadata_.description = "Produces camera frames from a physical camera device using OpenCV";
+  metadata_.width = cfg_.width;
+  metadata_.height = cfg_.height;
+  metadata_.encoding = cfg_.encoding;
+  metadata_.fps = cfg_.fps;
+}
 
 OpenCvCameraProducer::~OpenCvCameraProducer() {
   if (opened_) {

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -438,8 +438,6 @@ std::shared_ptr<io::Backend> SessionManager::create_backend(
   }
 }
 
-
-
 void SessionManager::monitor_duration() {
   while (monitoring_active_ && episode_active_) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -101,9 +101,18 @@ bool SessionManager::start_episode() {
   // Build episode file path
   auto path = build_episode_path(next_episode_index_);
 
+  std::vector<hw::PolledProducer::ProducerMetadata> producer_metadata;
+  // Fetch Metadata from producers as a vector of the base class
+  for (const auto& pt : producer_tasks_) {
+    // Dynamic cast to PolledProducer to access metadata()
+    if (auto polled_producer = std::dynamic_pointer_cast<hw::PolledProducer>(pt.producer)) {
+      producer_metadata.push_back(polled_producer->metadata());
+    }
+  }
+
   // Create backend
   try {
-    current_backend_ = create_backend(path.string(), next_episode_index_);
+    current_backend_ = create_backend(path.string(), next_episode_index_, producer_metadata);
   } catch (const std::exception& e) {
     std::cerr << "Backend creation failed: " << e.what() << std::endl;
     return false;
@@ -376,7 +385,8 @@ std::filesystem::path SessionManager::build_episode_path(uint32_t index) const {
 
 std::shared_ptr<io::Backend> SessionManager::create_backend(
   const std::string& output_path,
-  uint32_t episode_index) {
+  uint32_t episode_index, 
+  const std::vector<hw::PolledProducer::ProducerMetadata>& producer_metadatas) {
 
   
   if(config_.backend_config == nullptr) {
@@ -390,6 +400,15 @@ std::shared_ptr<io::Backend> SessionManager::create_backend(
     }
     lerobot_cfg->dataset_id = config_.dataset_id;
     lerobot_cfg->episode_index = episode_index;
+    // TODO (shantanuparab-tr): Use the producer metadata to populate backend metadata
+    // Print registered producers
+    std::cout << "\n╔═══════════════════════════════════════════════ Registered Producers Metadata ═══════════════════════════════════════════════╗\n";
+    for(const auto& pm : producer_metadatas) {
+      std::cout << "║  [ID: " << pm.id << "] Name: " << pm.name << "\n";
+      std::cout << "║      Description: " << pm.description << "\n";
+      std::cout << "║ --------------------------------------------------------------------------------------------------------------------\n";
+    }
+    std::cout << "╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝\n";
 
     auto metadata = io::backends::LeRobotBackend::Metadata{};
     metadata.task_name = lerobot_cfg->task_name;
@@ -418,6 +437,8 @@ std::shared_ptr<io::Backend> SessionManager::create_backend(
     throw std::runtime_error("SessionManager::create_backend: Unsupported backend type: " + config_.backend_config->type);
   }
 }
+
+
 
 void SessionManager::monitor_duration() {
   while (monitoring_active_ && episode_active_) {


### PR DESCRIPTION
### TL;DR

Added metadata support to all producers in the Trossen SDK, enabling better introspection and documentation of data sources.

### What changed?

- Added a `ProducerMetadata` base struct to the `PolledProducer` class with common fields like id, name, and description
- Implemented producer-specific metadata structs for each producer type with relevant fields:
  - Arm producers: arm model, firmware version, joint names, etc.
  - Camera producers: resolution, encoding, fps, etc.
  - Teleop producers: leader/follower information, action/observation features
- Populated metadata in each producer's constructor
- Modified `SessionManager` to collect metadata from producers and pass it to the backend
- Cleaned up verbose logging in the LeRobot backend for a cleaner output experience
- Removed an unused header (`<iomanip>`) from widowxai_lerobot.cpp

### How to test?

1. Run any example that uses producers (e.g., widowxai_lerobot.cpp)
2. Verify that producer metadata is displayed in the console output under "Registered Producers Metadata"
3. Check that the metadata is correctly populated for each producer type
4. Verify that the backend still functions correctly with the added metadata

### Why make this change?

This change improves the system's introspection capabilities by providing structured metadata about each data producer. This is valuable for:

1. Documentation: Better understanding of data sources and their capabilities
2. Debugging: More context about producers when troubleshooting
3. Data analysis: Metadata can be stored alongside recorded data for better interpretation
4. User experience: Cleaner console output with more relevant information

The metadata system provides a standardized way to expose producer-specific information while maintaining a common interface, making the SDK more robust and user-friendly.