### PR TITLE
Update producer metadata to use shared pointers and improve metadata collection

### DIFF
--- a/include/trossen_sdk/hw/arm/arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/arm_producer.hpp
@@ -28,12 +28,6 @@ public:
     /// @brief Robot model
     std::string arm_model;
 
-    /// @brief Firmware version
-    std::string firmware_version;
-
-    /// @brief Number of joints
-    size_t num_joints;
-
     /// @brief Joint names
     std::vector<std::string> joint_names;
 

--- a/include/trossen_sdk/hw/arm/arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/arm_producer.hpp
@@ -62,7 +62,9 @@ public:
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
 
   /// @brief Get producer metadata
-  const TrossenArmProducerMetadata& metadata() const override { return metadata_; }
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<TrossenArmProducerMetadata>(metadata_);
+  }
 
 private:
   /// @brief Shared pointer to the TrossenArmDriver instance

--- a/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
@@ -37,17 +37,12 @@ public:
     /// @brief Robot model
     std::string arm_model;
 
-    /// @brief Firmware version
-    std::string firmware_version;
-
-    /// @brief Number of joints
-    size_t num_joints;
-
     /// @brief Joint names
     std::vector<std::string> joint_names;
 
     /// @brief Gripper type
     std::string gripper_type;
+
   };
 
   explicit MockJointStateProducer(Config cfg);

--- a/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
@@ -33,7 +33,6 @@ public:
   };
 
   struct MockJointStateProducerMetadata : public PolledProducer::ProducerMetadata {
-
     /// @brief Robot model
     std::string arm_model;
 

--- a/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
@@ -58,7 +58,9 @@ public:
   Diagnostics diagnostics() const { return diag_; }
   const Config& config() const { return cfg_; }
 
-  const MockJointStateProducerMetadata& metadata() const override { return metadata_; }
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<MockJointStateProducerMetadata>(metadata_);
+  }
 
 private:
   Config cfg_;

--- a/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
@@ -28,26 +28,11 @@ public:
     /// @brief Robot name
     std::string robot_name;
 
-    /// @brief Leader arm model
-    std::string leader_arm_model;
-
-    /// @brief Leader firmware version
-    std::string leader_firmware_version;
-
-    /// @brief Follower arm model
-    std::string follower_arm_model;
-
-    /// @brief Follower firmware version
-    std::string follower_firmware_version;
-
     /// @brief Action feature names
     std::vector<std::string> action_feature_names;
     
     /// @brief Observation feature names
     std::vector<std::string> observation_feature_names;
-
-    /// @brief Gripper type
-    std::string gripper_type;
 
     /// @brief Action feature data type
     std::string action_dtype;

--- a/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
@@ -79,7 +79,9 @@ public:
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
 
   /// @brief Get producer metadata
-  const TeleopTrossenArmProducerMetadata& metadata() const override { return metadata_; };
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<TeleopTrossenArmProducerMetadata>(metadata_);
+  }
 
 private:
   /// @brief Shared pointer to the TrossenArmDriver instance leader arm

--- a/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
@@ -48,9 +48,6 @@ public:
     /// @brief Observation feature data type
     std::string observation_dtype;
 
-    /// @brief Is Mock
-    bool is_mock{true};
-
   };
 
   explicit TeleopMockJointStateProducer(Config cfg);

--- a/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
@@ -36,32 +36,20 @@ public:
     /// @brief Robot name
     std::string robot_name;
 
-    /// @brief Leader arm model
-    std::string leader_arm_model;
-
-    /// @brief Leader firmware version
-    std::string leader_firmware_version;
-
-    /// @brief Follower arm model
-    std::string follower_arm_model;
-
-    /// @brief Follower firmware version
-    std::string follower_firmware_version;
-
     /// @brief Action feature names
     std::vector<std::string> action_feature_names;
     
     /// @brief Observation feature names
     std::vector<std::string> observation_feature_names;
 
-    /// @brief Gripper type
-    std::string gripper_type;
-
     /// @brief Action feature data type
     std::string action_dtype;
 
     /// @brief Observation feature data type
     std::string observation_dtype;
+
+    /// @brief Is Mock
+    bool is_mock{true};
 
   };
 

--- a/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
@@ -73,7 +73,9 @@ public:
   Diagnostics diagnostics() const { return diag_; }
   const Config& config() const { return cfg_; }
 
-  const TeleopMockJointStateProducerMetadata& metadata() const override { return metadata_; }
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<TeleopMockJointStateProducerMetadata>(metadata_);
+  }
 
 private:
   Config cfg_;

--- a/include/trossen_sdk/hw/camera/mock_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_producer.hpp
@@ -51,18 +51,17 @@ public:
 
   struct MockCameraProducerMetadata : public PolledProducer::ProducerMetadata {
 
-    /// @brief Camera name
-    std::string camera_name;
-
     /// @brief Image width
     int width;
 
     /// @brief Image height
     int height;
 
+    // TODO (shantanuparab-tr): Can be made enum
     /// @brief Image encoding
     std::string codec;
 
+    // TODO (shantanuparab-tr): Can be made enum
     /// @brief Pixel format
     std::string pix_fmt;
 
@@ -80,7 +79,7 @@ public:
 
   };
 
-  explicit MockCameraProducer(Config cfg);
+
   ~MockCameraProducer() override = default;
 
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;

--- a/include/trossen_sdk/hw/camera/mock_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_producer.hpp
@@ -79,6 +79,12 @@ public:
 
   };
 
+  /**
+   * @brief Construct a MockCameraProducer
+   *
+   * @param cfg Configuration parameters
+   */
+  explicit MockCameraProducer(Config cfg);
 
   ~MockCameraProducer() override = default;
 

--- a/include/trossen_sdk/hw/camera/mock_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_producer.hpp
@@ -51,6 +51,9 @@ public:
 
   struct MockCameraProducerMetadata : public PolledProducer::ProducerMetadata {
 
+    /// @brief Camera name
+    std::string camera_name;
+
     /// @brief Image width
     int width;
 
@@ -58,13 +61,23 @@ public:
     int height;
 
     /// @brief Image encoding
-    std::string encoding;
+    std::string codec;
+
+    /// @brief Pixel format
+    std::string pix_fmt;
+
+    /// @brief Channels
+    int channels;
+
+    /// @brief Does the camera have an audio stream?
+    bool has_audio{false};
 
     /// @brief Target frames per second
     int fps;
 
     /// @brief Is this a depth camera?
     bool is_depth_map{false};
+
   };
 
   explicit MockCameraProducer(Config cfg);

--- a/include/trossen_sdk/hw/camera/mock_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_producer.hpp
@@ -50,6 +50,7 @@ public:
   };
 
   struct MockCameraProducerMetadata : public PolledProducer::ProducerMetadata {
+
     /// @brief Image width
     int width;
 
@@ -61,7 +62,9 @@ public:
 
     /// @brief Target frames per second
     int fps;
-    
+
+    /// @brief Is this a depth camera?
+    bool is_depth_map{false};
   };
 
   explicit MockCameraProducer(Config cfg);
@@ -70,7 +73,9 @@ public:
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
 
   /// @brief Get producer metadata
-  const MockCameraProducerMetadata& metadata() const override { return metadata_; }
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<MockCameraProducerMetadata>(metadata_);
+  }
 
   struct JitterStats {
     double mean_ms{0};

--- a/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
@@ -71,8 +71,9 @@ public:
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
 
   /// @brief Get producer metadata
-  const MockSyncedCameraProducerMetadata& metadata() const override { return metadata_; }
-
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<MockSyncedCameraProducerMetadata>(metadata_);
+  }
   struct JitterStats {
     double mean_ms{0};
     double p50_ms{0};

--- a/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
@@ -43,26 +43,34 @@ public:
   };
 
   struct MockSyncedCameraProducerMetadata : public PolledProducer::ProducerMetadata {
+
     /// @brief Camera name
     std::string camera_name;
 
-    /// @brief Color image width
-    int color_width;
+    /// @brief Image width
+    int width;
 
-    /// @brief Color image height
-    int color_height;
+    /// @brief Image height
+    int height;
 
-    /// @brief Color image encoding
-    std::string color_encoding;
+    /// @brief Image encoding
+    std::string codec;
 
-    /// @brief Depth image width
-    int depth_width;
+    /// @brief Pixel format
+    std::string pix_fmt;
 
-    /// @brief Depth image height
-    int depth_height;
+    /// @brief Channels
+    int channels;
 
-    /// @brief Depth image encoding
-    std::string depth_encoding;
+    /// @brief Does the camera have an audio stream?
+    bool has_audio{false};
+
+    /// @brief Target frames per second
+    int fps;
+
+    /// @brief Is this a depth camera?
+    bool is_depth_map{false};
+
   };
 
   explicit MockSyncedCameraProducer(Config cfg);

--- a/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
@@ -35,7 +35,7 @@ public:
   enum class Pattern { Gradient, Noise }; // Reuse simple patterns for color
 
   struct Config {
-    std::string camera_name{"camera0"};
+    std::string stream_id{"camera0"};
     CameraStreamsConfig streams; // Contains frame_rate, resolutions, depth format, etc.
     Pattern pattern{Pattern::Gradient};
     uint64_t seed{0};

--- a/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
@@ -44,9 +44,6 @@ public:
 
   struct MockSyncedCameraProducerMetadata : public PolledProducer::ProducerMetadata {
 
-    /// @brief Camera name
-    std::string camera_name;
-
     /// @brief Image width
     int width;
 

--- a/include/trossen_sdk/hw/camera/opencv_producer.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_producer.hpp
@@ -94,7 +94,9 @@ public:
   void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
 
   /// @brief Get producer metadata
-  const OpenCvCameraProducerMetadata& metadata() const override { return metadata_; }
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<OpenCvCameraProducerMetadata>(metadata_);
+  }
 
 protected:
   /**

--- a/include/trossen_sdk/hw/camera/opencv_producer.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_producer.hpp
@@ -57,7 +57,7 @@ public:
 
     /// @brief Camera name
     std::string camera_name;
-
+    
     /// @brief Image width
     int width;
 
@@ -65,10 +65,23 @@ public:
     int height;
 
     /// @brief Image encoding
-    std::string encoding;
+    std::string codec;
+
+    /// @brief Pixel format
+    std::string pix_fmt;
+
+    /// @brief Channels
+    int channels;
+
+    /// @brief Does the camera have an audio stream?
+    bool has_audio{false};
 
     /// @brief Target frames per second
     int fps;
+
+    /// @brief Is this a depth camera?
+    bool is_depth_map{false};
+
   };
 
   /**

--- a/include/trossen_sdk/hw/camera/opencv_producer.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_producer.hpp
@@ -55,15 +55,13 @@ public:
 
   struct OpenCvCameraProducerMetadata : public PolledProducer::ProducerMetadata {
 
-    /// @brief Camera name
-    std::string camera_name;
-    
     /// @brief Image width
     int width;
 
     /// @brief Image height
     int height;
 
+    //TODO (shantanuparab-tr): Can be made enum
     /// @brief Image encoding
     std::string codec;
 

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -68,6 +68,9 @@ public:
     /// @brief Description of the producer's function
     std::string description;
 
+    /// @brief Is this a mock producer?
+    bool is_mock;
+
     virtual ~ProducerMetadata() = default;
 
   };

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -55,6 +55,10 @@ public:
 
   /// @brief Metadata for producers
   struct ProducerMetadata {
+
+    /// @brief Type of the producer
+    std::string type;
+
     /// @brief Unique identifier for the producer
     std::string id;
 
@@ -63,14 +67,19 @@ public:
 
     /// @brief Description of the producer's function
     std::string description;
+
+    virtual ~ProducerMetadata() = default;
+
   };
+
+  
 
   /**
    * @brief Get producer metadata
    *
    * @return const reference to ProducerMetadata
    */
-  virtual const PolledProducer::ProducerMetadata& metadata() const {return metadata_; };
+  virtual std::shared_ptr<ProducerMetadata> metadata() const = 0;
 
 protected:
   /// @brief Whether we've opened the device

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -68,9 +68,7 @@ public:
     /// @brief Description of the producer's function
     std::string description;
 
-    /// @brief Is this a mock producer?
-    bool is_mock;
-
+    /// @brief Virtual destructor
     virtual ~ProducerMetadata() = default;
 
   };

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -350,6 +350,10 @@ private:
   Config cfg_;
   // Metadata for this backend
   std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> metadata_;
+
+  // Store camera names from metadata for easy access
+  std::vector<std::string> camera_names_;
+  
   std::atomic<bool> image_worker_running_{false};
 
   // Basic stats
@@ -375,6 +379,7 @@ private:
   std::mutex write_mutex_;
   std::mutex open_mutex_;
   bool opened_{false};
+
   std::unordered_map<std::string, std::filesystem::path> image_dir_cache_;
 
 

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -11,7 +11,6 @@
 #include <condition_variable>
 #include <deque>
 #include <filesystem>
-#include <fstream>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
@@ -22,6 +21,7 @@
 #include <parquet/arrow/writer.h>
 #include "trossen_sdk/io/backend.hpp"
 #include "trossen_sdk/io/backends/lerobot/lerobot_constants.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
 
 namespace trossen::io::backends {
 
@@ -102,59 +102,12 @@ public:
 
   };
 
-  struct Metadata {
-    // TODO (shantanuparab-tr): Add meaningful metadata fields with the Metadata PR
-
-    // Name of the robot
-    std::string robot_name;
-
-    // Name of the task
-    std::string task_name;
-
-    // Version information (LeRobot)
-    std::string codebase_version;
-
-    // Trossen SDK subversion
-    std::string trossen_subversion;
-
-    // Number of cameras
-    int num_cameras;
-
-    // Number of action features
-    int num_action_features;
-
-    // Number of observation features
-    int num_observation_features;
-
-    // Camera Width
-    int camera_width;
-
-    // Camera Height
-    int camera_height;
-
-    // Is depth camera
-    bool is_depth_camera;
-
-    // Frame rate
-    int fps;
-
-    // Camera names
-    std::vector<std::string> camera_names;
-
-    // Action feature names
-    std::vector<std::string> action_feature_names;
-
-    // Observation feature names
-    std::vector<std::string> observation_feature_names;
-
-  };
-
   /**
    * @brief Construct a LeRobotBackend
    *
    * @param cfg Configuration parameters
    */
-  explicit LeRobotBackend(Config cfg, Metadata md);
+  explicit LeRobotBackend(Config cfg,std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> metadata);
 
   /**
    * @brief Open a LeRobot V2 logging destination
@@ -192,7 +145,7 @@ public:
    *
    * @param md Metadata to add
    */
-  void addMetadata(const Metadata& md);
+  void writeMetadata();
 
   /**
    * @brief Convert recorded images to videos using FFmpeg
@@ -209,14 +162,14 @@ public:
    *
    * @param stats JSON object containing the statistics
    */
-  void printStatsTable(const nlohmann::json& stats) const;
+  void printStatsTable(const nlohmann::ordered_json& stats) const;
 
   /**
    * @brief Compute statistics for a ListArray
    * @param list_array Shared pointer to the ListArray
    * @return JSON object containing the computed statistics
    */
-  nlohmann::json computeListStats(
+  nlohmann::ordered_json computeListStats(
       const std::shared_ptr<arrow::ListArray> &list_array) const;
 
   /**
@@ -224,14 +177,14 @@ public:
    * @param array Shared pointer to the flat array
    * @return JSON object containing the computed statistics
    */
-  nlohmann::json computeFlatStats(const std::shared_ptr<arrow::Array> &array) const;
+  nlohmann::ordered_json computeFlatStats(const std::shared_ptr<arrow::Array> &array) const;
 
   /**
    * @brief Compute statistics for a set of images
    * @param images Vector of OpenCV Mat objects representing the images
    * @return FeatureStats object containing the computed statistics
    */
-  nlohmann::json compute_image_stats(const std::vector<cv::Mat> &images) const;
+  nlohmann::ordered_json compute_image_stats(const std::vector<cv::Mat> &images) const;
 
   /**
    * @brief Sample a set of images from a list of image paths
@@ -376,7 +329,7 @@ private:
    */
   void imageWorkerLoop();
 
-  /// @brief Image encoding job
+
   struct ImageJob {
     /// @brief Full file path to write
     std::filesystem::path file_path;
@@ -396,7 +349,7 @@ private:
   // Config for this backend
   Config cfg_;
   // Metadata for this backend
-  Metadata md_;
+  std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> metadata_;
   std::atomic<bool> image_worker_running_{false};
 
   // Basic stats

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -332,7 +332,7 @@ private:
    */
   void imageWorkerLoop();
 
-
+  /// @brief Image encoding job
   struct ImageJob {
     /// @brief Full file path to write
     std::filesystem::path file_path;

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -100,6 +100,9 @@ public:
     // Episode index (for organizing output)
     uint32_t episode_index{0};
 
+    // Robot name
+    std::string robot_name{"trossen_ai_generic"};
+
   };
 
   /**

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -265,7 +265,7 @@ private:
   std::shared_ptr<io::Backend> create_backend(
     const std::string& output_path,
     uint32_t episode_index,
-    const std::vector<hw::PolledProducer::ProducerMetadata>& producer_metadatas
+    const std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>>& producer_metadatas
   );
 
   /**

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -1,6 +1,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <fstream>
 #include <sstream>
 #include "opencv2/imgcodecs.hpp"
 #include <opencv2/opencv.hpp>
@@ -105,11 +106,11 @@ bool LeRobotBackend::open() {
   //info.json, stats.json, tasks.json, episode_stats.json
 
   std::ofstream info_file(meta_root_ / JSON_INFO);
-  std::ofstream episode_file(meta_root_ / JSONL_EPISODES);
-  std::ofstream tasks_file(meta_root_ / JSONL_TASKS);
-  std::ofstream episode_stats_file(meta_root_ / JSONL_EPISODE_STATS);
+      // std::ofstream episode_file(meta_root_ / JSONL_EPISODES);
+      // std::ofstream tasks_file(meta_root_ / JSONL_TASKS);
+      // std::ofstream episode_stats_file(meta_root_ / JSONL_EPISODE_STATS);
 
-  if (!info_file || !episode_file || !tasks_file || !episode_stats_file) {
+  if (!info_file /*|| !episode_file || !tasks_file || !episode_stats_file*/) {
     std::cerr << "Failed to create metadata files\n";
     return false;
   }
@@ -599,43 +600,73 @@ void LeRobotBackend::computeStatistics() const {
     }
   }
 
-  // // Compute image statistics for each camera
-  // for (const auto &camera_info : md_.camera_names) {
-  //   std::string image_key = "observation.images." + camera_info;
-  //   // Get image paths for the current episode and camera
-  //   std::string image_folder_path = images_root_.string();
+  // Compute image statistics for each camera
+  for (const auto &camera_info : camera_names_) {
 
-  //   std::ostringstream episode_folder_ss;
-  //   episode_folder_ss << "episode_" << std::setfill('0') << std::setw(6)
-  //                     << cfg_.episode_index;
-  //   std::string episode_folder_name = episode_folder_ss.str();
+    std::string image_key = "observation.images." + camera_info;
+    // Get image paths for the current episode and camera
+    std::string image_folder_path = images_root_.string();
 
-  //   // Construct the full path to the episode's image directory for the current
-  //   // camera
-  //   std::filesystem::path episode_image_dir =
-  //       std::filesystem::path(image_folder_path) / camera_info/ episode_folder_name;
-  //   if (!std::filesystem::exists(episode_image_dir)) {
-  //     std::cout << "Image directory does not exist: "
-  //               << episode_image_dir.string() << std::endl;
-  //     continue;
-  //   }
+    std::ostringstream episode_folder_ss;
+    episode_folder_ss << "episode_" << std::setfill('0') << std::setw(6)
+                      << cfg_.episode_index;
+    std::string episode_folder_name = episode_folder_ss.str();
 
-  //   // Collect all image file paths in the directory
-  //   std::vector<std::filesystem::path> paths;
-  //   for (const auto &entry :
-  //        std::filesystem::directory_iterator(episode_image_dir)) {
-  //     if (entry.is_regular_file()) {
-  //       std::string ext = entry.path().extension().string();
-  //       std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-  //       if (ext == ".jpg" || ext == ".png") {
-  //         paths.push_back(entry.path());
-  //       }
-  //     }
-  //   }
-  //   // Sample and process images to compute statistics
-  //   auto images = sample_images(paths);
-  //   stats[image_key]  = compute_image_stats(images);
-  // }
+    // Construct the full path to the episode's image directory for the current
+    // camera
+    std::filesystem::path episode_image_dir =
+        std::filesystem::path(image_folder_path) / camera_info/ episode_folder_name;
+    if (!std::filesystem::exists(episode_image_dir)) {
+      std::cout << "Image directory does not exist: "
+                << episode_image_dir.string() << std::endl;
+      continue;
+    }
+
+    // Collect all image file paths in the directory
+    std::vector<std::filesystem::path> paths;
+    for (const auto &entry :
+         std::filesystem::directory_iterator(episode_image_dir)) {
+      if (entry.is_regular_file()) {
+        std::string ext = entry.path().extension().string();
+        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+        if (ext == ".jpg" || ext == ".png") {
+          paths.push_back(entry.path());
+        }
+      }
+    }
+    // Sample and process images to compute statistics
+    auto images = sample_images(paths);
+    stats[image_key]  = compute_image_stats(images);
+  }
+
+  // // Write to info.json
+  std::ofstream episode_stats_file(meta_root_ / JSONL_EPISODE_STATS, std::ios::app);
+
+  if (!episode_stats_file.is_open()) {
+    std::cerr << "Failed to open episode stats file for writing." << std::endl;
+    return;
+  }
+  episode_stats_file << stats.dump() << "\n";
+  episode_stats_file.close();
+  std::cout << "Metadata written to info.json successfully." << std::endl;
+
+
+  nlohmann::ordered_json episode_metadata;
+  episode_metadata["episode_index"] = cfg_.episode_index;
+  episode_metadata["tasks"] = {cfg_.task_name};
+  episode_metadata["length"] = table->num_rows();
+
+  std::ofstream episodes_file(meta_root_ / JSONL_EPISODES, std::ios::app);
+
+  if (!episodes_file.is_open()) {
+    std::cerr << "Failed to open episode stats file for writing." << std::endl;
+    return;
+  }
+  episodes_file << episode_metadata.dump() << "\n";
+  episodes_file.close();
+  std::cout << "Metadata written to info.json successfully." << std::endl;
+
+
   // TODO (shantanuparab-tr): Add this to metadata file
   printStatsTable(stats);
   
@@ -675,9 +706,6 @@ void LeRobotBackend::printStatsTable(const nlohmann::json& stats) const {
   }
   std::cout << "=================================================================\n";
 }
-}
-
-
 
 void LeRobotBackend::flush() {
   // TODO (shantanuparab-tr): flush parquet writer if needed
@@ -787,7 +815,7 @@ void LeRobotBackend::writeJointState(const data::RecordBase& base) {
     check_status(act_val->Append(v), "Failed to append action value");
 
   // Scalar columns
-  check_status(epi_idx_builder.Append(0), "Failed to append episode index");
+  check_status(epi_idx_builder.Append(cfg_.episode_index), "Failed to append episode index");
   check_status(frame_idx_builder.Append(frame_id), "Failed to append frame index");
   check_status(index_builder.Append(js.seq), "Failed to append global index");
   check_status(task_idx_builder.Append(0), "Failed to append task index");
@@ -1019,6 +1047,7 @@ void LeRobotBackend::writeMetadata() {
           features["observation.state"] = observation_state;
         }      
     } else if (metadata->type == "camera"){
+        camera_names_.push_back(metadata->id);
         if(metadata->is_mock){
           const auto &camera_metadata = dynamic_cast<const hw::camera::MockCameraProducer::MockCameraProducerMetadata&>(*metadata);
           nlohmann::ordered_json camera_feature;

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -7,6 +7,14 @@
 #include <parquet/arrow/reader.h>
 #include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/io/backends/lerobot/lerobot_backend.hpp"
+#include "trossen_sdk/hw/arm/arm_producer.hpp"
+#include "trossen_sdk/hw/arm/mock_joint_producer.hpp"
+#include "trossen_sdk/hw/arm/teleop_arm_producer.hpp"
+#include "trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp"
+#include "trossen_sdk/hw/camera/opencv_producer.hpp"
+#include "trossen_sdk/hw/camera/mock_producer.hpp"
+
+
 
 // For PNG writing we stub out with raw dump placeholder (future: integrate stb_image_write or libpng)
 namespace trossen::io::backends {
@@ -15,8 +23,8 @@ namespace trossen::io::backends {
 
 namespace fs = std::filesystem;
 
-LeRobotBackend::LeRobotBackend(Config cfg, Metadata md)
-  : io::Backend(cfg.output_dir), cfg_(std::move(cfg)), md_(std::move(md)) {
+LeRobotBackend::LeRobotBackend(Config cfg, std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> metadata)
+  : io::Backend(cfg.output_dir), cfg_(std::move(cfg)), metadata_(std::move(metadata)) {
 
   // Validate encoder threads
   if (cfg_.encoder_threads <= 0) {
@@ -106,8 +114,6 @@ bool LeRobotBackend::open() {
     return false;
   }
 
-  addMetadata(md_);
-
   // Create data directory
   data_root_ = root_ / "data" / "chunk_000000";
   try {
@@ -170,6 +176,9 @@ bool LeRobotBackend::open() {
   }
 
   writer_ = std::move(result).ValueUnsafe();  // store unique_ptr<FileWriter>
+
+
+  writeMetadata();
 
   opened_ = true;
   return true;
@@ -384,8 +393,9 @@ void LeRobotBackend::convert_to_videos() const {
     return images;
   }
 
-  nlohmann::json LeRobotBackend::compute_image_stats (const std::vector<cv::Mat> &images) const{
-    nlohmann::json stats_json;
+  nlohmann::ordered_json LeRobotBackend::compute_image_stats (
+    const std::vector<cv::Mat> &images) const{
+    nlohmann::ordered_json stats_json;
     if (images.empty()) {
       std::cout << "No images provided." << std::endl;
       stats_json["min"] = {};
@@ -417,7 +427,7 @@ void LeRobotBackend::convert_to_videos() const {
 
     // Helper lambda to convert a vector to a nested JSON array
     auto to_nested = [](const std::vector<float> &vec) {
-    nlohmann::json result = nlohmann::json::array();
+    nlohmann::ordered_json result = nlohmann::ordered_json::array();
     for (float v : vec) {
       result.push_back({{v}});
     }
@@ -449,7 +459,7 @@ void LeRobotBackend::convert_to_videos() const {
   }
 
 
-nlohmann::json LeRobotBackend::computeFlatStats(
+nlohmann::ordered_json LeRobotBackend::computeFlatStats(
     const std::shared_ptr<arrow::Array> &array) const {
     double sum = 0.0, sum_sq = 0.0;
     double min_val = std::numeric_limits<double>::max();
@@ -500,7 +510,7 @@ nlohmann::json LeRobotBackend::computeFlatStats(
             {"count", {count}}};
 }
 
-nlohmann::json LeRobotBackend::computeListStats(
+nlohmann::ordered_json LeRobotBackend::computeListStats(
     const std::shared_ptr<arrow::ListArray> &list_array) const {
     // Get the values array from the ListArray
     auto values =
@@ -572,7 +582,7 @@ void LeRobotBackend::computeStatistics() const {
   }
 
 
-  nlohmann::json stats;
+  nlohmann::ordered_json stats;
   // Compute statistics for each column in the table
   for (const auto &field : table->schema()->fields()) {
     auto column = table->GetColumnByName(field->name());
@@ -589,43 +599,43 @@ void LeRobotBackend::computeStatistics() const {
     }
   }
 
-  // Compute image statistics for each camera
-  for (const auto &camera_info : md_.camera_names) {
-    std::string image_key = "observation.images." + camera_info;
-    // Get image paths for the current episode and camera
-    std::string image_folder_path = images_root_.string();
+  // // Compute image statistics for each camera
+  // for (const auto &camera_info : md_.camera_names) {
+  //   std::string image_key = "observation.images." + camera_info;
+  //   // Get image paths for the current episode and camera
+  //   std::string image_folder_path = images_root_.string();
 
-    std::ostringstream episode_folder_ss;
-    episode_folder_ss << "episode_" << std::setfill('0') << std::setw(6)
-                      << cfg_.episode_index;
-    std::string episode_folder_name = episode_folder_ss.str();
+  //   std::ostringstream episode_folder_ss;
+  //   episode_folder_ss << "episode_" << std::setfill('0') << std::setw(6)
+  //                     << cfg_.episode_index;
+  //   std::string episode_folder_name = episode_folder_ss.str();
 
-    // Construct the full path to the episode's image directory for the current
-    // camera
-    std::filesystem::path episode_image_dir =
-        std::filesystem::path(image_folder_path) / camera_info/ episode_folder_name;
-    if (!std::filesystem::exists(episode_image_dir)) {
-      std::cout << "Image directory does not exist: "
-                << episode_image_dir.string() << std::endl;
-      continue;
-    }
+  //   // Construct the full path to the episode's image directory for the current
+  //   // camera
+  //   std::filesystem::path episode_image_dir =
+  //       std::filesystem::path(image_folder_path) / camera_info/ episode_folder_name;
+  //   if (!std::filesystem::exists(episode_image_dir)) {
+  //     std::cout << "Image directory does not exist: "
+  //               << episode_image_dir.string() << std::endl;
+  //     continue;
+  //   }
 
-    // Collect all image file paths in the directory
-    std::vector<std::filesystem::path> paths;
-    for (const auto &entry :
-         std::filesystem::directory_iterator(episode_image_dir)) {
-      if (entry.is_regular_file()) {
-        std::string ext = entry.path().extension().string();
-        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-        if (ext == ".jpg" || ext == ".png") {
-          paths.push_back(entry.path());
-        }
-      }
-    }
-    // Sample and process images to compute statistics
-    auto images = sample_images(paths);
-    stats[image_key]  = compute_image_stats(images);
-  }
+  //   // Collect all image file paths in the directory
+  //   std::vector<std::filesystem::path> paths;
+  //   for (const auto &entry :
+  //        std::filesystem::directory_iterator(episode_image_dir)) {
+  //     if (entry.is_regular_file()) {
+  //       std::string ext = entry.path().extension().string();
+  //       std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+  //       if (ext == ".jpg" || ext == ".png") {
+  //         paths.push_back(entry.path());
+  //       }
+  //     }
+  //   }
+  //   // Sample and process images to compute statistics
+  //   auto images = sample_images(paths);
+  //   stats[image_key]  = compute_image_stats(images);
+  // }
   // TODO (shantanuparab-tr): Add this to metadata file
   printStatsTable(stats);
   
@@ -962,98 +972,135 @@ void LeRobotBackend::imageWorkerLoop() {
 }
 
 
-void LeRobotBackend::addMetadata(const Metadata& md) {
+void LeRobotBackend::writeMetadata() {
   
   // TODO(shantanuparab-tr): [TDS-15]: Extract features from the robot's
   // observation space and action space
   // TODO(shantanuparab-tr): [TDS-16]: Get feature specifications from a
   // configuration file or constant definitions
   //  Action
-  nlohmann::json info_;
 
-  nlohmann::json action;
-  action["dtype"] = "float32";
-  action["shape"] = {static_cast<int>(md.num_action_features)};
-  action["names"] = md.action_feature_names;
+  nlohmann::ordered_json info_;
+  nlohmann::ordered_json features;
 
-  nlohmann::json observation_state;
-  observation_state["dtype"] = "float32";
-  observation_state["shape"] = {
-      static_cast<int>(md.num_observation_features)};
-  observation_state["names"] = md.observation_feature_names;
+  for(const auto &metadata : metadata_ ){
 
-  nlohmann::json timestamp_feature;
-  timestamp_feature["dtype"] = "float32";
-  timestamp_feature["shape"] = {1};
-  timestamp_feature["names"] = {};
+    std::cout << "Processing Metadata Type: " << metadata->type << std::endl;
+    // Check for type if is ArmMetadata
+    if (metadata->type == "arm"){
+      std::cout << "Arm Metadata found" << std::endl;
+      std::cout << "Type: " << metadata->type << std::endl;
+      std::cout << "No support is available for Arm Metadata" << std::endl;
+    } else if (metadata->type == "mock_teleop_arm"){
+      // Type cast
+      const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopMockJointStateProducer::TeleopMockJointStateProducerMetadata&>(*metadata);
+      
+      nlohmann::ordered_json action;
+      std::cout << "Action Dtype: " << teleop_arm_metadata.action_dtype << std::endl;
+      action["dtype"] = teleop_arm_metadata.action_dtype;
+      action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
+      action["names"] = teleop_arm_metadata.action_feature_names;
 
-  nlohmann::json frame_index_feature;
-  frame_index_feature["dtype"] = "int64";
-  frame_index_feature["shape"] = {1};
-  frame_index_feature["names"] = {};
+      nlohmann::ordered_json observation_state;
+      std::cout << "Observation Dtype: " << teleop_arm_metadata.observation_dtype << std::endl;
+      observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
+      observation_state["shape"] = {
+          static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
+      observation_state["names"] = teleop_arm_metadata.observation_feature_names;
 
-  nlohmann::json episode_index_feature;
-  episode_index_feature["dtype"] = "int64";
-  episode_index_feature["shape"] = {1};
-  episode_index_feature["names"] = {};
-
-  nlohmann::json index_feature;
-  index_feature["dtype"] = "int64";
-  index_feature["shape"] = {1};
-  index_feature["names"] = {};
-
-  nlohmann::json task_index_feature;
-  task_index_feature["dtype"] = "int64";
-  task_index_feature["shape"] = {1};
-  task_index_feature["names"] = {};
-
-  nlohmann::json features;
-  features["action"] = action;
-  features["observation.state"] = observation_state;
-  features["timestamp"] = timestamp_feature;
-  features["frame_index"] = frame_index_feature;
-  features["episode_index"] = episode_index_feature;
-  features["index"] = index_feature;
-  features["task_index"] = task_index_feature;
-
-  // Assuming robot.get_camera_features() returns a list of camera identifiers
-  for (const auto &cam_info : md.camera_names) {
-    // Add camera features
-    // TODO(shantanuparab-tr): [TDS-16]: Get camera specifications from a
-    // configuration file or constant definitions
-
-    nlohmann::json camera_feature;
-    camera_feature["dtype"] = "video";
-    camera_feature["shape"] = {md.camera_height, md.camera_width, 3};
-    camera_feature["names"] = {"height", "width", "channels"};
-    camera_feature["info"] = {
-        {"video.fps", md.fps},           {"video.height", md.camera_height},
-        {"video.width", md.camera_width},       {"video.channels", 3},
-        {"video.codec", "av1"},                {"video.pix_fmt", "yuv420p"},
-        {"video.is_depth_map", (md.is_depth_camera)}, {"has_audio", false}};
-    features["observation.images." + cam_info] = camera_feature;
+      features["action"] = action;
+      features["observation.state"] = observation_state;
+      
+    } else if (metadata->type == "camera"){
+      const auto &camera_metadata = dynamic_cast<const hw::camera::MockCameraProducer::MockCameraProducerMetadata&>(*metadata);
+      nlohmann::ordered_json camera_feature;
+      camera_feature["dtype"] = "video";
+      camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
+      camera_feature["names"] = {"height", "width", "channels"};
+      camera_feature["info"] = {
+          {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
+          {"video.width", camera_metadata.width},       {"video.channels", 3},
+          {"video.codec", "av1"},                {"video.pix_fmt", "yuv420p"},
+          {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", false}};
+      features["observation.images." + camera_metadata.id] = camera_feature;
+    }
   }
+
+
+  
+
+  // nlohmann::ordered_json timestamp_feature;
+  // timestamp_feature["dtype"] = "float32";
+  // timestamp_feature["shape"] = {1};
+  // timestamp_feature["names"] = {};
+
+  // nlohmann::ordered_json frame_index_feature;
+  // frame_index_feature["dtype"] = "int64";
+  // frame_index_feature["shape"] = {1};
+  // frame_index_feature["names"] = {};
+
+  // nlohmann::ordered_json episode_index_feature;
+  // episode_index_feature["dtype"] = "int64";
+  // episode_index_feature["shape"] = {1};
+  // episode_index_feature["names"] = {};
+
+  // nlohmann::ordered_json index_feature;
+  // index_feature["dtype"] = "int64";
+  // index_feature["shape"] = {1};
+  // index_feature["names"] = {};
+
+  // nlohmann::ordered_json task_index_feature;
+  // task_index_feature["dtype"] = "int64";
+  // task_index_feature["shape"] = {1};
+  // task_index_feature["names"] = {};
+
+  // nlohmann::ordered_json features;
+  
+  // features["timestamp"] = timestamp_feature;
+  // features["frame_index"] = frame_index_feature;
+  // features["episode_index"] = episode_index_feature;
+  // features["index"] = index_feature;
+  // features["task_index"] = task_index_feature;
+
+  // // Assuming robot.get_camera_features() returns a list of camera identifiers
+  // for (const auto &cam_info : md.camera_names) {
+  //   // Add camera features
+  //   // TODO(shantanuparab-tr): [TDS-16]: Get camera specifications from a
+  //   // configuration file or constant definitions
+
+  //   nlohmann::ordered_json camera_feature;
+  //   camera_feature["dtype"] = "video";
+  //   camera_feature["shape"] = {md.camera_height, md.camera_width, 3};
+  //   camera_feature["names"] = {"height", "width", "channels"};
+  //   camera_feature["info"] = {
+  //       {"video.fps", md.fps},           {"video.height", md.camera_height},
+  //       {"video.width", md.camera_width},       {"video.channels", 3},
+  //       {"video.codec", "av1"},                {"video.pix_fmt", "yuv420p"},
+  //       {"video.is_depth_map", (md.is_depth_camera)}, {"has_audio", false}};
+  //   features["observation.images." + cam_info] = camera_feature;
+  // }
+  
 
   info_["features"] = features;
 
-  // Miscellaneous Feature
-  info_["total_episodes"] = 0;
-  info_["total_frames"] = 0;
-  // TODO(shantanuparab-tr): [TDS-25]: Update total tasks based on total number
-  // of unique tasks
-  info_["total_tasks"] = 1;
-  // TODO(shantanuparab-tr): [TDS-26] Update chunks based on total number of
-  // episodes
-  info_["total_chunks"] = 1;
-  // TODO(shantanuparab-tr): [TDS-27] Add appropriate logic to decide chunk size
-  info_["chunks_size"] = 1000;
-  // TODO(shantanuparab-tr): [TDS-28] Update fps based on robot/control
-  // configuration
-  info_["fps"] = 30;
-  info_["splits"]["train"] = "0:0";
+  // // Miscellaneous Feature
+  // info_["total_episodes"] = 0;
+  // info_["total_frames"] = 0;
+  // // TODO(shantanuparab-tr): [TDS-25]: Update total tasks based on total number
+  // // of unique tasks
+  // info_["total_tasks"] = 1;
+  // // TODO(shantanuparab-tr): [TDS-26] Update chunks based on total number of
+  // // episodes
+  // info_["total_chunks"] = 1;
+  // // TODO(shantanuparab-tr): [TDS-27] Add appropriate logic to decide chunk size
+  // info_["chunks_size"] = 1000;
+  // // TODO(shantanuparab-tr): [TDS-28] Update fps based on robot/control
+  // // configuration
+  // info_["fps"] = 30;
+  // info_["splits"]["train"] = "0:0";
 
 
-  // Write to info.json
+  // // Write to info.json
   std::ofstream info_file(meta_root_ / JSON_INFO);
 
   if (!info_file.is_open()) {

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -1046,72 +1046,69 @@ void LeRobotBackend::writeMetadata() {
 
   for(const auto &metadata : metadata_ ){
 
-   if (metadata->type == "teleop_arm"){
-        if(metadata->is_mock){
-          const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopMockJointStateProducer::TeleopMockJointStateProducerMetadata&>(*metadata);
-        
-          nlohmann::ordered_json action;
-          action["dtype"] = teleop_arm_metadata.action_dtype;
-          action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
-          action["names"] = teleop_arm_metadata.action_feature_names;
+   if (metadata->type == "mock_teleop_arm"){
+      const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopMockJointStateProducer::TeleopMockJointStateProducerMetadata&>(*metadata);
+    
+      nlohmann::ordered_json action;
+      action["dtype"] = teleop_arm_metadata.action_dtype;
+      action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
+      action["names"] = teleop_arm_metadata.action_feature_names;
 
-          nlohmann::ordered_json observation_state;
-          observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
-          observation_state["shape"] = {
-              static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
-          observation_state["names"] = teleop_arm_metadata.observation_feature_names;
-          features["action"] = action;
-          features["observation.state"] = observation_state;
+      nlohmann::ordered_json observation_state;
+      observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
+      observation_state["shape"] = {
+          static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
+      observation_state["names"] = teleop_arm_metadata.observation_feature_names;
+      features["action"] = action;
+      features["observation.state"] = observation_state;
+    } else if (metadata->type == "teleop_arm"){
+      const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopTrossenArmProducer::TeleopTrossenArmProducerMetadata&>(*metadata);
+    
+      nlohmann::ordered_json action;
+      action["dtype"] = teleop_arm_metadata.action_dtype;
+      action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
+      action["names"] = teleop_arm_metadata.action_feature_names;
 
-        } else {
-          const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopTrossenArmProducer::TeleopTrossenArmProducerMetadata&>(*metadata);
-        
-          nlohmann::ordered_json action;
-          action["dtype"] = teleop_arm_metadata.action_dtype;
-          action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
-          action["names"] = teleop_arm_metadata.action_feature_names;
-
-          nlohmann::ordered_json observation_state;
-          observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
-          observation_state["shape"] = {
-              static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
-          observation_state["names"] = teleop_arm_metadata.observation_feature_names;
-          features["action"] = action;
-          features["observation.state"] = observation_state;
-        }      
-    } else if (metadata->type == "camera"){
-        camera_names_.push_back(metadata->id);
-        if(metadata->is_mock){
-          const auto &camera_metadata = dynamic_cast<const hw::camera::MockCameraProducer::MockCameraProducerMetadata&>(*metadata);
-          nlohmann::ordered_json camera_feature;
-          camera_feature["dtype"] = "video";
-          camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
-          camera_feature["names"] = {"height", "width", "channels"};
-          camera_feature["info"] = {
-              {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
-              {"video.width", camera_metadata.width},       {"video.channels", camera_metadata.channels},
-              {"video.codec", camera_metadata.codec},                {"video.pix_fmt", camera_metadata.pix_fmt},
-              {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", camera_metadata.has_audio}};
-          features["observation.images." + camera_metadata.id] = camera_feature;
-        } else {
-          const auto &camera_metadata = dynamic_cast<const hw::camera::OpenCvCameraProducer::OpenCvCameraProducerMetadata&>(*metadata);
-          nlohmann::ordered_json camera_feature;
-          camera_feature["dtype"] = "video";
-          camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
-          camera_feature["names"] = {"height", "width", "channels"};
-          camera_feature["info"] = {
-              {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
-              {"video.width", camera_metadata.width},       {"video.channels", camera_metadata.channels},
-              {"video.codec", camera_metadata.codec},                {"video.pix_fmt", camera_metadata.pix_fmt},
-              {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", camera_metadata.has_audio}};
-          features["observation.images." + camera_metadata.id] = camera_feature;
-        }
+      nlohmann::ordered_json observation_state;
+      observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
+      observation_state["shape"] = {
+          static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
+      observation_state["names"] = teleop_arm_metadata.observation_feature_names;
+      features["action"] = action;
+      features["observation.state"] = observation_state;    
+    } else if (metadata->type == "mock_camera"){
+      camera_names_.push_back(metadata->id);
+      const auto &camera_metadata = dynamic_cast<const hw::camera::MockCameraProducer::MockCameraProducerMetadata&>(*metadata);
+      nlohmann::ordered_json camera_feature;
+      camera_feature["dtype"] = "video";
+      camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
+      camera_feature["names"] = {"height", "width", "channels"};
+      camera_feature["info"] = {
+          {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
+          {"video.width", camera_metadata.width},       {"video.channels", camera_metadata.channels},
+          {"video.codec", camera_metadata.codec},                {"video.pix_fmt", camera_metadata.pix_fmt},
+          {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", camera_metadata.has_audio}};
+      features["observation.images." + camera_metadata.id] = camera_feature;
+    } else if (metadata->type == "opencv_camera"){
+      camera_names_.push_back(metadata->id);
+      const auto &camera_metadata = dynamic_cast<const hw::camera::OpenCvCameraProducer::OpenCvCameraProducerMetadata&>(*metadata);
+      nlohmann::ordered_json camera_feature;
+      camera_feature["dtype"] = "video";
+      camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
+      camera_feature["names"] = {"height", "width", "channels"};
+      camera_feature["info"] = {
+          {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
+          {"video.width", camera_metadata.width},       {"video.channels", camera_metadata.channels},
+          {"video.codec", camera_metadata.codec},                {"video.pix_fmt", camera_metadata.pix_fmt},
+          {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", camera_metadata.has_audio}};
+      features["observation.images." + camera_metadata.id] = camera_feature;
+    } else {
+      std::cerr << "Unknown metadata type: " << metadata->type << std::endl;
     }
   }
 
-  // Common Feature these can be moved to a constants file later
+  //TODO (shantanuparab-tr): Common Feature these can be moved to a constants file later
   
-
   nlohmann::ordered_json timestamp_feature;
   timestamp_feature["dtype"] = "float32";
   timestamp_feature["shape"] = {1};

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -75,7 +75,7 @@ bool LeRobotBackend::open() {
   oss << "episode_" << std::setfill('0') << std::setw(6) << cfg_.episode_index;
 
   // Create images root directory from camera names
-  images_root_ = root_ / "images" / "chunk_000000" ;
+  images_root_ = root_ / "images" / "chunk-000" ;
   try {
     fs::create_directories(images_root_);
   } catch (const std::exception& e) {
@@ -85,7 +85,7 @@ bool LeRobotBackend::open() {
 
   // Create Video Directories
   // TODO (shantanuparab-tr): Use chunk size to create chunk folders
-  videos_root_ = root_ / "videos" / "chunk_000000" / oss.str();
+  videos_root_ = root_ / "videos" / "chunk-000";
   try {
     fs::create_directories(videos_root_);
   } catch (const std::exception& e) {
@@ -115,7 +115,7 @@ bool LeRobotBackend::open() {
   }
 
   // Create data directory
-  data_root_ = root_ / "data" / "chunk_000000";
+  data_root_ = root_ / "data" / "chunk-000";
   try {
     fs::create_directories(data_root_);
   } catch (const std::exception& e) {
@@ -240,7 +240,7 @@ void LeRobotBackend::convert_to_videos() const {
 
     const std::string video_key = "observation.images." + cam_dir.path().filename().string();
     std::ostringstream oss;
-    oss << "videos/chunk_" << std::setw(6) << std::setfill('0') << episode_chunk
+    oss << "videos/chunk-" << std::setw(3) << std::setfill('0') << episode_chunk
         << "/" << video_key;
     const fs::path videos_cam_dir = base_path / oss.str();
     fs::create_directories(videos_cam_dir);
@@ -582,7 +582,7 @@ void LeRobotBackend::computeStatistics() const {
   }
 
 
-  nlohmann::ordered_json stats;
+  nlohmann::json stats;
   // Compute statistics for each column in the table
   for (const auto &field : table->schema()->fields()) {
     auto column = table->GetColumnByName(field->name());
@@ -641,11 +641,15 @@ void LeRobotBackend::computeStatistics() const {
   // // Write to info.json
   std::ofstream episode_stats_file(meta_root_ / JSONL_EPISODE_STATS, std::ios::app);
 
+  nlohmann::ordered_json episode_stats;
+  episode_stats["episode_index"] = cfg_.episode_index;
+  episode_stats["stats"] = stats;
+
   if (!episode_stats_file.is_open()) {
     std::cerr << "Failed to open episode stats file for writing." << std::endl;
     return;
   }
-  episode_stats_file << stats.dump() << "\n";
+  episode_stats_file << episode_stats.dump() << "\n";
   episode_stats_file.close();
   std::cout << "Metadata written to info.json successfully." << std::endl;
 

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -666,9 +666,22 @@ void LeRobotBackend::computeStatistics() const {
   episodes_file.close();
   std::cout << "Metadata written to info.json successfully." << std::endl;
 
+  // TODO (shantanuparab-tr): Implement logic to check for existing task entrys
+  nlohmann::ordered_json task_metadata;
+  task_metadata["task_index"] = cfg_.episode_index;
+  task_metadata["task"] = cfg_.task_name;
+
+  std::ofstream tasks_file(meta_root_ / JSONL_TASKS, std::ios::app);
+
+  if (!tasks_file.is_open()) {
+    std::cerr << "Failed to open tasks file for writing." << std::endl;
+    return;
+  }
+  tasks_file << task_metadata.dump() << "\n";
+  
 
   // TODO (shantanuparab-tr): Add this to metadata file
-  printStatsTable(stats);
+  // printStatsTable(stats);
   
 }
 
@@ -1006,9 +1019,30 @@ void LeRobotBackend::writeMetadata() {
   // observation space and action space
   // TODO(shantanuparab-tr): [TDS-16]: Get feature specifications from a
   // configuration file or constant definitions
-  //  Action
+  
 
   nlohmann::ordered_json info_;
+
+  // Miscellaneous Feature (Initialization with placeholder values)
+
+  info_["codebase_version"] = "v2.1"; // TODO(shantanuparab-tr): [TDS-24]: Update codebase version dynamically (Uses LeRobot version for now)
+  info_["robot_type"] = cfg_.robot_name;
+
+  info_["total_episodes"] = 0;
+  info_["total_frames"] = 0;
+  // TODO(shantanuparab-tr): [TDS-25]: Update total tasks based on total number
+  // of unique tasks
+  info_["total_tasks"] = 1;
+  // TODO(shantanuparab-tr): [TDS-26] Update chunks based on total number of
+  // episodes
+  info_["total_chunks"] = 1;
+  // TODO(shantanuparab-tr): [TDS-27] Add appropriate logic to decide chunk size
+  info_["chunks_size"] = 1000;
+  // TODO(shantanuparab-tr): [TDS-28] Update fps based on robot/control
+  // configuration
+  info_["fps"] = 30;
+  info_["splits"]["train"] = "0:0";
+
   nlohmann::ordered_json features;
 
   for(const auto &metadata : metadata_ ){
@@ -1111,23 +1145,6 @@ void LeRobotBackend::writeMetadata() {
   features["task_index"] = task_index_feature;  
 
   info_["features"] = features;
-
-  // Miscellaneous Feature (Initialization with placeholder values)
-  info_["total_episodes"] = 0;
-  info_["total_frames"] = 0;
-  // TODO(shantanuparab-tr): [TDS-25]: Update total tasks based on total number
-  // of unique tasks
-  info_["total_tasks"] = 1;
-  // TODO(shantanuparab-tr): [TDS-26] Update chunks based on total number of
-  // episodes
-  info_["total_chunks"] = 1;
-  // TODO(shantanuparab-tr): [TDS-27] Add appropriate logic to decide chunk size
-  info_["chunks_size"] = 1000;
-  // TODO(shantanuparab-tr): [TDS-28] Update fps based on robot/control
-  // configuration
-  info_["fps"] = 30;
-  info_["splits"]["train"] = "0:0";
-
 
   // // Write to info.json
   std::ofstream info_file(meta_root_ / JSON_INFO);

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -688,7 +688,7 @@ void LeRobotBackend::computeStatistics() const {
   
 }
 
-void LeRobotBackend::printStatsTable(const nlohmann::json& stats) const {
+void LeRobotBackend::printStatsTable(const nlohmann::ordered_json& stats) const {
   std::cout << "\n================ Episode: " << cfg_.episode_index << " ================\n";
   for (auto it = stats.begin(); it != stats.end(); ++it) {
     const std::string& column_name = it.key();
@@ -1163,4 +1163,5 @@ void LeRobotBackend::writeMetadata() {
   info_file.close();
   std::cout << "Metadata written to info.json successfully." << std::endl;
   }
+}
 } // namespace trossen::io::backends

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -985,119 +985,119 @@ void LeRobotBackend::writeMetadata() {
 
   for(const auto &metadata : metadata_ ){
 
-    std::cout << "Processing Metadata Type: " << metadata->type << std::endl;
-    // Check for type if is ArmMetadata
-    if (metadata->type == "arm"){
-      std::cout << "Arm Metadata found" << std::endl;
-      std::cout << "Type: " << metadata->type << std::endl;
-      std::cout << "No support is available for Arm Metadata" << std::endl;
-    } else if (metadata->type == "mock_teleop_arm"){
-      // Type cast
-      const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopMockJointStateProducer::TeleopMockJointStateProducerMetadata&>(*metadata);
-      
-      nlohmann::ordered_json action;
-      std::cout << "Action Dtype: " << teleop_arm_metadata.action_dtype << std::endl;
-      action["dtype"] = teleop_arm_metadata.action_dtype;
-      action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
-      action["names"] = teleop_arm_metadata.action_feature_names;
+   if (metadata->type == "teleop_arm"){
+        if(metadata->is_mock){
+          const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopMockJointStateProducer::TeleopMockJointStateProducerMetadata&>(*metadata);
+        
+          nlohmann::ordered_json action;
+          action["dtype"] = teleop_arm_metadata.action_dtype;
+          action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
+          action["names"] = teleop_arm_metadata.action_feature_names;
 
-      nlohmann::ordered_json observation_state;
-      std::cout << "Observation Dtype: " << teleop_arm_metadata.observation_dtype << std::endl;
-      observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
-      observation_state["shape"] = {
-          static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
-      observation_state["names"] = teleop_arm_metadata.observation_feature_names;
+          nlohmann::ordered_json observation_state;
+          observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
+          observation_state["shape"] = {
+              static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
+          observation_state["names"] = teleop_arm_metadata.observation_feature_names;
+          features["action"] = action;
+          features["observation.state"] = observation_state;
 
-      features["action"] = action;
-      features["observation.state"] = observation_state;
-      
+        } else {
+          const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopTrossenArmProducer::TeleopTrossenArmProducerMetadata&>(*metadata);
+        
+          nlohmann::ordered_json action;
+          action["dtype"] = teleop_arm_metadata.action_dtype;
+          action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
+          action["names"] = teleop_arm_metadata.action_feature_names;
+
+          nlohmann::ordered_json observation_state;
+          observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
+          observation_state["shape"] = {
+              static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
+          observation_state["names"] = teleop_arm_metadata.observation_feature_names;
+          features["action"] = action;
+          features["observation.state"] = observation_state;
+        }      
     } else if (metadata->type == "camera"){
-      const auto &camera_metadata = dynamic_cast<const hw::camera::MockCameraProducer::MockCameraProducerMetadata&>(*metadata);
-      nlohmann::ordered_json camera_feature;
-      camera_feature["dtype"] = "video";
-      camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
-      camera_feature["names"] = {"height", "width", "channels"};
-      camera_feature["info"] = {
-          {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
-          {"video.width", camera_metadata.width},       {"video.channels", 3},
-          {"video.codec", "av1"},                {"video.pix_fmt", "yuv420p"},
-          {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", false}};
-      features["observation.images." + camera_metadata.id] = camera_feature;
+        if(metadata->is_mock){
+          const auto &camera_metadata = dynamic_cast<const hw::camera::MockCameraProducer::MockCameraProducerMetadata&>(*metadata);
+          nlohmann::ordered_json camera_feature;
+          camera_feature["dtype"] = "video";
+          camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
+          camera_feature["names"] = {"height", "width", "channels"};
+          camera_feature["info"] = {
+              {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
+              {"video.width", camera_metadata.width},       {"video.channels", camera_metadata.channels},
+              {"video.codec", camera_metadata.codec},                {"video.pix_fmt", camera_metadata.pix_fmt},
+              {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", camera_metadata.has_audio}};
+          features["observation.images." + camera_metadata.id] = camera_feature;
+        } else {
+          const auto &camera_metadata = dynamic_cast<const hw::camera::OpenCvCameraProducer::OpenCvCameraProducerMetadata&>(*metadata);
+          nlohmann::ordered_json camera_feature;
+          camera_feature["dtype"] = "video";
+          camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
+          camera_feature["names"] = {"height", "width", "channels"};
+          camera_feature["info"] = {
+              {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
+              {"video.width", camera_metadata.width},       {"video.channels", camera_metadata.channels},
+              {"video.codec", camera_metadata.codec},                {"video.pix_fmt", camera_metadata.pix_fmt},
+              {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", camera_metadata.has_audio}};
+          features["observation.images." + camera_metadata.id] = camera_feature;
+        }
     }
   }
 
-
+  // Common Feature these can be moved to a constants file later
   
 
-  // nlohmann::ordered_json timestamp_feature;
-  // timestamp_feature["dtype"] = "float32";
-  // timestamp_feature["shape"] = {1};
-  // timestamp_feature["names"] = {};
+  nlohmann::ordered_json timestamp_feature;
+  timestamp_feature["dtype"] = "float32";
+  timestamp_feature["shape"] = {1};
+  timestamp_feature["names"] = {};
 
-  // nlohmann::ordered_json frame_index_feature;
-  // frame_index_feature["dtype"] = "int64";
-  // frame_index_feature["shape"] = {1};
-  // frame_index_feature["names"] = {};
+  nlohmann::ordered_json frame_index_feature;
+  frame_index_feature["dtype"] = "int64";
+  frame_index_feature["shape"] = {1};
+  frame_index_feature["names"] = {};
 
-  // nlohmann::ordered_json episode_index_feature;
-  // episode_index_feature["dtype"] = "int64";
-  // episode_index_feature["shape"] = {1};
-  // episode_index_feature["names"] = {};
+  nlohmann::ordered_json episode_index_feature;
+  episode_index_feature["dtype"] = "int64";
+  episode_index_feature["shape"] = {1};
+  episode_index_feature["names"] = {};
 
-  // nlohmann::ordered_json index_feature;
-  // index_feature["dtype"] = "int64";
-  // index_feature["shape"] = {1};
-  // index_feature["names"] = {};
+  nlohmann::ordered_json index_feature;
+  index_feature["dtype"] = "int64";
+  index_feature["shape"] = {1};
+  index_feature["names"] = {};
 
-  // nlohmann::ordered_json task_index_feature;
-  // task_index_feature["dtype"] = "int64";
-  // task_index_feature["shape"] = {1};
-  // task_index_feature["names"] = {};
-
-  // nlohmann::ordered_json features;
+  nlohmann::ordered_json task_index_feature;
+  task_index_feature["dtype"] = "int64";
+  task_index_feature["shape"] = {1};
+  task_index_feature["names"] = {};
   
-  // features["timestamp"] = timestamp_feature;
-  // features["frame_index"] = frame_index_feature;
-  // features["episode_index"] = episode_index_feature;
-  // features["index"] = index_feature;
-  // features["task_index"] = task_index_feature;
-
-  // // Assuming robot.get_camera_features() returns a list of camera identifiers
-  // for (const auto &cam_info : md.camera_names) {
-  //   // Add camera features
-  //   // TODO(shantanuparab-tr): [TDS-16]: Get camera specifications from a
-  //   // configuration file or constant definitions
-
-  //   nlohmann::ordered_json camera_feature;
-  //   camera_feature["dtype"] = "video";
-  //   camera_feature["shape"] = {md.camera_height, md.camera_width, 3};
-  //   camera_feature["names"] = {"height", "width", "channels"};
-  //   camera_feature["info"] = {
-  //       {"video.fps", md.fps},           {"video.height", md.camera_height},
-  //       {"video.width", md.camera_width},       {"video.channels", 3},
-  //       {"video.codec", "av1"},                {"video.pix_fmt", "yuv420p"},
-  //       {"video.is_depth_map", (md.is_depth_camera)}, {"has_audio", false}};
-  //   features["observation.images." + cam_info] = camera_feature;
-  // }
-  
+  features["timestamp"] = timestamp_feature;
+  features["frame_index"] = frame_index_feature;
+  features["episode_index"] = episode_index_feature;
+  features["index"] = index_feature;
+  features["task_index"] = task_index_feature;  
 
   info_["features"] = features;
 
-  // // Miscellaneous Feature
-  // info_["total_episodes"] = 0;
-  // info_["total_frames"] = 0;
-  // // TODO(shantanuparab-tr): [TDS-25]: Update total tasks based on total number
-  // // of unique tasks
-  // info_["total_tasks"] = 1;
-  // // TODO(shantanuparab-tr): [TDS-26] Update chunks based on total number of
-  // // episodes
-  // info_["total_chunks"] = 1;
-  // // TODO(shantanuparab-tr): [TDS-27] Add appropriate logic to decide chunk size
-  // info_["chunks_size"] = 1000;
-  // // TODO(shantanuparab-tr): [TDS-28] Update fps based on robot/control
-  // // configuration
-  // info_["fps"] = 30;
-  // info_["splits"]["train"] = "0:0";
+  // Miscellaneous Feature (Initialization with placeholder values)
+  info_["total_episodes"] = 0;
+  info_["total_frames"] = 0;
+  // TODO(shantanuparab-tr): [TDS-25]: Update total tasks based on total number
+  // of unique tasks
+  info_["total_tasks"] = 1;
+  // TODO(shantanuparab-tr): [TDS-26] Update chunks based on total number of
+  // episodes
+  info_["total_chunks"] = 1;
+  // TODO(shantanuparab-tr): [TDS-27] Add appropriate logic to decide chunk size
+  info_["chunks_size"] = 1000;
+  // TODO(shantanuparab-tr): [TDS-28] Update fps based on robot/control
+  // configuration
+  info_["fps"] = 30;
+  info_["splits"]["train"] = "0:0";
 
 
   // // Write to info.json

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -1146,6 +1146,12 @@ void LeRobotBackend::writeMetadata() {
 
   info_["features"] = features;
 
+  info_["data_path"] = "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet";
+  info_["video_path"] = "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4";
+
+  {
+
+
   // // Write to info.json
   std::ofstream info_file(meta_root_ / JSON_INFO);
 

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -16,7 +16,6 @@
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
 
 
-
 // For PNG writing we stub out with raw dump placeholder (future: integrate stb_image_write or libpng)
 namespace trossen::io::backends {
 

--- a/src/hw/arm/arm_producer.cpp
+++ b/src/hw/arm/arm_producer.cpp
@@ -26,8 +26,6 @@ TrossenArmProducer::TrossenArmProducer(
   metadata_.arm_model = "WIDOWX_AI"; // TODO: Extract from driver/User Config
   metadata_.joint_names = {"joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7"}; // TODO: Extract from driver / User Config
   metadata_.gripper_type = "STANDARD"; // TODO: Extract from driver / User Config
-
-  metadata_.is_mock = false;
 }
 
 void TrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/arm/arm_producer.cpp
+++ b/src/hw/arm/arm_producer.cpp
@@ -19,6 +19,7 @@ TrossenArmProducer::TrossenArmProducer(
   }
 
   // Populate metadata
+  metadata_.type = "arm";
   metadata_.id = cfg_.stream_id;
   metadata_.name = "Trossen Arm Producer";
   metadata_.description = "Produces joint states from a Trossen Arm via TrossenArmDriver";

--- a/src/hw/arm/arm_producer.cpp
+++ b/src/hw/arm/arm_producer.cpp
@@ -24,10 +24,10 @@ TrossenArmProducer::TrossenArmProducer(
   metadata_.name = "Trossen Arm Producer";
   metadata_.description = "Produces joint states from a Trossen Arm via TrossenArmDriver";
   metadata_.arm_model = "WIDOWX_AI"; // TODO: Extract from driver/User Config
-  metadata_.firmware_version = "v1.9.0"; // TODO: Extract from driver / Remove
-  metadata_.num_joints = driver_ ? driver_->get_num_joints() : 0;
   metadata_.joint_names = {"joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7"}; // TODO: Extract from driver / User Config
   metadata_.gripper_type = "STANDARD"; // TODO: Extract from driver / User Config
+
+  metadata_.is_mock = false;
 }
 
 void TrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/arm/mock_joint_producer.cpp
+++ b/src/hw/arm/mock_joint_producer.cpp
@@ -15,15 +15,13 @@ MockJointStateProducer::MockJointStateProducer(Config cfg)
   : cfg_(std::move(cfg)) {
 
   // Populate metadata
-  metadata_.type = "arm";
+  metadata_.type = "mock_arm";
   metadata_.id = cfg_.id;
   metadata_.name = "Mock Joint State Producer";
   metadata_.description = "Produces synthetic joint states for testing and diagnostics";
   metadata_.arm_model = "MOCK_WIDOWX_AI"; // TODO: Extract from driver/User Config
   metadata_.joint_names = {"joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7"}; // TODO: Extract from driver / User Config
   metadata_.gripper_type = "STANDARD"; // TODO: Extract from driver / User Config
-
-  metadata_.is_mock = true;
 }
 
 void MockJointStateProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/arm/mock_joint_producer.cpp
+++ b/src/hw/arm/mock_joint_producer.cpp
@@ -15,6 +15,7 @@ MockJointStateProducer::MockJointStateProducer(Config cfg)
   : cfg_(std::move(cfg)) {
 
   // Populate metadata
+  metadata_.type = "arm";
   metadata_.id = cfg_.id;
   metadata_.name = "Mock Joint State Producer";
   metadata_.description = "Produces synthetic joint states for testing and diagnostics";

--- a/src/hw/arm/mock_joint_producer.cpp
+++ b/src/hw/arm/mock_joint_producer.cpp
@@ -19,13 +19,11 @@ MockJointStateProducer::MockJointStateProducer(Config cfg)
   metadata_.id = cfg_.id;
   metadata_.name = "Mock Joint State Producer";
   metadata_.description = "Produces synthetic joint states for testing and diagnostics";
-  metadata_.arm_model = "MOCK_ARM";
-  metadata_.firmware_version = "v0.0.1-mock";
-  metadata_.num_joints = cfg_.num_joints;
-  metadata_.joint_names.resize(cfg_.num_joints);
-  for (size_t i = 0; i < cfg_.num_joints; ++i) {
-    metadata_.joint_names[i] = "joint_" + std::to_string(i);
-  }
+  metadata_.arm_model = "MOCK_WIDOWX_AI"; // TODO: Extract from driver/User Config
+  metadata_.joint_names = {"joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7"}; // TODO: Extract from driver / User Config
+  metadata_.gripper_type = "STANDARD"; // TODO: Extract from driver / User Config
+
+  metadata_.is_mock = true;
 }
 
 void MockJointStateProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/arm/teleop_arm_producer.cpp
+++ b/src/hw/arm/teleop_arm_producer.cpp
@@ -33,8 +33,6 @@ TeleopTrossenArmProducer::TeleopTrossenArmProducer(
   metadata_.action_dtype = "float32";
   metadata_.observation_dtype = "float32";
 
-  metadata_.is_mock = false;
-
 }
 
 void TeleopTrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/arm/teleop_arm_producer.cpp
+++ b/src/hw/arm/teleop_arm_producer.cpp
@@ -21,22 +21,19 @@ TeleopTrossenArmProducer::TeleopTrossenArmProducer(
     leader_robot_output_ = leader_driver_->get_robot_output();
     follower_robot_output_ = follower_driver_->get_robot_output();
   }
-
+  // TODO (shantanuparab-tr): Extract robot info from user config or driver
   // Populate metadata
   metadata_.type = "teleop_arm";
   metadata_.id = cfg_.stream_id;
   metadata_.name = "Teleop Trossen Arm Producer";
   metadata_.description = "Produces teleoperation joint states from leader and follower Trossen Arms via TrossenArmDriver";
   metadata_.robot_name = "Trossen AI Bimanual"; // TODO: Extract from driver/User Config
-  metadata_.leader_arm_model = "WIDOWX_AI"; // TODO: Extract from driver/User Config
-  metadata_.follower_arm_model = "WIDOWX_AI"; // TODO: Extract from driver/User Config
-  metadata_.leader_firmware_version = "v1.9.0"; // TODO: Extract from driver / Remove
-  metadata_.follower_firmware_version = "v1.9.0"; // TODO: Extract from driver / Remove
   metadata_.action_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
   metadata_.observation_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
-  metadata_.gripper_type = "STANDARD"; // TODO: Extract from driver / User Config
   metadata_.action_dtype = "float32";
   metadata_.observation_dtype = "float32";
+
+  metadata_.is_mock = false;
 
 }
 

--- a/src/hw/arm/teleop_arm_producer.cpp
+++ b/src/hw/arm/teleop_arm_producer.cpp
@@ -23,6 +23,7 @@ TeleopTrossenArmProducer::TeleopTrossenArmProducer(
   }
 
   // Populate metadata
+  metadata_.type = "teleop_arm";
   metadata_.id = cfg_.stream_id;
   metadata_.name = "Teleop Trossen Arm Producer";
   metadata_.description = "Produces teleoperation joint states from leader and follower Trossen Arms via TrossenArmDriver";

--- a/src/hw/arm/teleop_mock_joint_producer.cpp
+++ b/src/hw/arm/teleop_mock_joint_producer.cpp
@@ -15,20 +15,17 @@ namespace trossen::hw::arm {
 TeleopMockJointStateProducer::TeleopMockJointStateProducer(Config cfg)
   : cfg_(std::move(cfg)) {
   // Populate metadata
-  metadata_.type = "mock_teleop_arm";
+  metadata_.type = "teleop_arm";
   metadata_.id = cfg_.id;
   metadata_.name = "Teleop Mock Joint State Producer";
   metadata_.description = "Produces synthetic teleoperation joint states for testing and diagnostics";
   metadata_.robot_name = "MOCK_TELEOP_ROBOT"; 
-  metadata_.leader_arm_model = "MOCK_LEADER_ARM";
-  metadata_.leader_firmware_version = "v0.0.1-mock";
-  metadata_.follower_arm_model = "MOCK_FOLLOWER_ARM";
-  metadata_.follower_firmware_version = "v0.0.1-mock";
   metadata_.action_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
   metadata_.observation_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
-  metadata_.gripper_type = "MOCK_GRIPPER";
   metadata_.action_dtype = "float32";
   metadata_.observation_dtype = "float32";
+
+  metadata_.is_mock = true;
 }
 
 void TeleopMockJointStateProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/arm/teleop_mock_joint_producer.cpp
+++ b/src/hw/arm/teleop_mock_joint_producer.cpp
@@ -15,7 +15,7 @@ namespace trossen::hw::arm {
 TeleopMockJointStateProducer::TeleopMockJointStateProducer(Config cfg)
   : cfg_(std::move(cfg)) {
   // Populate metadata
-  metadata_.type = "teleop_arm";
+  metadata_.type = "mock_teleop_arm";
   metadata_.id = cfg_.id;
   metadata_.name = "Teleop Mock Joint State Producer";
   metadata_.description = "Produces synthetic teleoperation joint states for testing and diagnostics";
@@ -24,8 +24,6 @@ TeleopMockJointStateProducer::TeleopMockJointStateProducer(Config cfg)
   metadata_.observation_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
   metadata_.action_dtype = "float32";
   metadata_.observation_dtype = "float32";
-
-  metadata_.is_mock = true;
 }
 
 void TeleopMockJointStateProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/arm/teleop_mock_joint_producer.cpp
+++ b/src/hw/arm/teleop_mock_joint_producer.cpp
@@ -15,6 +15,7 @@ namespace trossen::hw::arm {
 TeleopMockJointStateProducer::TeleopMockJointStateProducer(Config cfg)
   : cfg_(std::move(cfg)) {
   // Populate metadata
+  metadata_.type = "mock_teleop_arm";
   metadata_.id = cfg_.id;
   metadata_.name = "Teleop Mock Joint State Producer";
   metadata_.description = "Produces synthetic teleoperation joint states for testing and diagnostics";
@@ -23,13 +24,11 @@ TeleopMockJointStateProducer::TeleopMockJointStateProducer(Config cfg)
   metadata_.leader_firmware_version = "v0.0.1-mock";
   metadata_.follower_arm_model = "MOCK_FOLLOWER_ARM";
   metadata_.follower_firmware_version = "v0.0.1-mock";
-  metadata_.action_feature_names.resize(cfg_.num_joints);
-  metadata_.observation_feature_names.resize(cfg_.num_joints);
-  for (size_t i = 0; i < cfg_.num_joints; ++i) {
-    metadata_.action_feature_names[i] = "joint_" + std::to_string(i);
-    metadata_.observation_feature_names[i] = "joint_" + std::to_string(i);
-  }
+  metadata_.action_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
+  metadata_.observation_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
   metadata_.gripper_type = "MOCK_GRIPPER";
+  metadata_.action_dtype = "float32";
+  metadata_.observation_dtype = "float32";
 }
 
 void TeleopMockJointStateProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/camera/mock_producer.cpp
+++ b/src/hw/camera/mock_producer.cpp
@@ -20,13 +20,18 @@ MockCameraProducer::MockCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
 
   // Populate metadata
   metadata_.type = "camera";
-  metadata_.id = cfg_.stream_id;
-  metadata_.name = "Mock Camera";
+  metadata_.id = "mock_camera_" + std::to_string(cfg_.seed);
+  metadata_.name = "Mock Camera Producer";
   metadata_.description = "Produces synthetic camera frames for testing and diagnostics";
   metadata_.width = cfg_.width;
   metadata_.height = cfg_.height;
-  metadata_.encoding = cfg_.encoding;
   metadata_.fps = cfg_.fps;
+  metadata_.codec = "av1";
+  metadata_.pix_fmt = "yuv420p";
+  metadata_.channels = (cfg_.encoding == "bgr8" || cfg_.encoding == "rgb8") ? 3 : 1;
+  metadata_.camera_name = cfg_.stream_id;
+  metadata_.has_audio = false;
+  metadata_.is_mock = true;
 }
 
 void MockCameraProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/camera/mock_producer.cpp
+++ b/src/hw/camera/mock_producer.cpp
@@ -20,7 +20,7 @@ MockCameraProducer::MockCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
 
   // Populate metadata
   metadata_.type = "camera";
-  metadata_.id = "mock_camera_" + std::to_string(cfg_.seed);
+  metadata_.id = cfg_.stream_id;
   metadata_.name = "Mock Camera Producer";
   metadata_.description = "Produces synthetic camera frames for testing and diagnostics";
   metadata_.width = cfg_.width;

--- a/src/hw/camera/mock_producer.cpp
+++ b/src/hw/camera/mock_producer.cpp
@@ -19,8 +19,9 @@ MockCameraProducer::MockCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   }
 
   // Populate metadata
+  metadata_.type = "camera";
   metadata_.id = cfg_.stream_id;
-  metadata_.name = "Mock Camera Producer";
+  metadata_.name = "Mock Camera";
   metadata_.description = "Produces synthetic camera frames for testing and diagnostics";
   metadata_.width = cfg_.width;
   metadata_.height = cfg_.height;

--- a/src/hw/camera/mock_producer.cpp
+++ b/src/hw/camera/mock_producer.cpp
@@ -19,9 +19,9 @@ MockCameraProducer::MockCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   }
 
   // Populate metadata
-  metadata_.type = "camera";
+  metadata_.type = "mock_camera";
   metadata_.id = cfg_.stream_id;
-  metadata_.name = "Mock Camera Producer";
+  metadata_.name = cfg_.stream_id;
   metadata_.description = "Produces synthetic camera frames for testing and diagnostics";
   metadata_.width = cfg_.width;
   metadata_.height = cfg_.height;
@@ -29,9 +29,7 @@ MockCameraProducer::MockCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   metadata_.codec = "av1";
   metadata_.pix_fmt = "yuv420p";
   metadata_.channels = (cfg_.encoding == "bgr8" || cfg_.encoding == "rgb8") ? 3 : 1;
-  metadata_.camera_name = cfg_.stream_id;
   metadata_.has_audio = false;
-  metadata_.is_mock = true;
 }
 
 void MockCameraProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/camera/mock_synced_producer.cpp
+++ b/src/hw/camera/mock_synced_producer.cpp
@@ -22,20 +22,19 @@ MockSyncedCameraProducer::MockSyncedCameraProducer(Config cfg) : cfg_(std::move(
 
   // Populate metadata
   metadata_.type = "camera";
-  metadata_.id = cfg_.camera_name;
+  metadata_.id = "mock_camera_" + std::to_string(cfg_.seed);
   metadata_.name = "Mock Synchronized Camera Producer";
   metadata_.description = "Produces synthetic synchronized color and depth frames for testing and diagnostics";
-  metadata_.camera_name = cfg_.camera_name;
-  metadata_.color_width = cfg_.streams.color_width;
-  metadata_.color_height = cfg_.streams.color_height;
-  metadata_.color_encoding = cfg_.streams.color_encoding;
-  metadata_.depth_width = cfg_.streams.depth_width;
-  metadata_.depth_height = cfg_.streams.depth_height;
-  if (cfg_.streams.depth_format == DepthFormat::DEPTH16) {
-    metadata_.depth_encoding = "depth16";
-  } else {
-    metadata_.depth_encoding = "32FC1";
-  }
+  metadata_.width = 640;
+  metadata_.height = 480;
+  metadata_.fps = 30;
+  metadata_.codec = "av1";
+  metadata_.pix_fmt = "yuv420p";
+  metadata_.channels = 3;
+  metadata_.camera_name = "mock_synced_camera";
+  metadata_.has_audio = false;
+  metadata_.is_mock = false;
+
 }
 
 void MockSyncedCameraProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {

--- a/src/hw/camera/mock_synced_producer.cpp
+++ b/src/hw/camera/mock_synced_producer.cpp
@@ -21,9 +21,9 @@ MockSyncedCameraProducer::MockSyncedCameraProducer(Config cfg) : cfg_(std::move(
   frame_period_ns_ = cfg_.streams.frame_period_ns();
 
   // Populate metadata
-  metadata_.type = "camera";
+  metadata_.type = "mock_synced_camera";
   metadata_.id = "mock_camera_" + std::to_string(cfg_.seed);
-  metadata_.name = "Mock Synchronized Camera Producer";
+  metadata_.name = cfg_.stream_id;
   metadata_.description = "Produces synthetic synchronized color and depth frames for testing and diagnostics";
   metadata_.width = 640;
   metadata_.height = 480;
@@ -31,9 +31,7 @@ MockSyncedCameraProducer::MockSyncedCameraProducer(Config cfg) : cfg_(std::move(
   metadata_.codec = "av1";
   metadata_.pix_fmt = "yuv420p";
   metadata_.channels = 3;
-  metadata_.camera_name = "mock_synced_camera";
   metadata_.has_audio = false;
-  metadata_.is_mock = false;
 
 }
 
@@ -68,7 +66,7 @@ void MockSyncedCameraProducer::poll(const std::function<void(std::shared_ptr<dat
     rec->ts.monotonic = ts_mono;
     rec->ts.realtime = ts_real;
     rec->seq = seq;
-    rec->id = color_id(cfg_.camera_name);
+    rec->id = color_id(cfg_.stream_id);
     rec->width = static_cast<uint32_t>(color_mat.cols);
     rec->height = static_cast<uint32_t>(color_mat.rows);
     rec->channels = static_cast<uint32_t>(color_mat.channels());
@@ -95,7 +93,7 @@ void MockSyncedCameraProducer::poll(const std::function<void(std::shared_ptr<dat
     rec->ts.monotonic = ts_mono; // identical timestamps
     rec->ts.realtime = ts_real;
     rec->seq = seq;              // shared sequence
-    rec->id = depth_id(cfg_.camera_name);
+    rec->id = depth_id(cfg_.stream_id);
     rec->width = static_cast<uint32_t>(depth_mat.cols);
     rec->height = static_cast<uint32_t>(depth_mat.rows);
     rec->channels = 1; // depth is single channel

--- a/src/hw/camera/mock_synced_producer.cpp
+++ b/src/hw/camera/mock_synced_producer.cpp
@@ -21,6 +21,7 @@ MockSyncedCameraProducer::MockSyncedCameraProducer(Config cfg) : cfg_(std::move(
   frame_period_ns_ = cfg_.streams.frame_period_ns();
 
   // Populate metadata
+  metadata_.type = "camera";
   metadata_.id = cfg_.camera_name;
   metadata_.name = "Mock Synchronized Camera Producer";
   metadata_.description = "Produces synthetic synchronized color and depth frames for testing and diagnostics";

--- a/src/hw/camera/opencv_producer.cpp
+++ b/src/hw/camera/opencv_producer.cpp
@@ -10,9 +10,9 @@ namespace trossen::hw::camera {
 
 OpenCvCameraProducer::OpenCvCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   // Populate metadata
-  metadata_.type = "camera";
+  metadata_.type = "opencv_camera";
   metadata_.id = "opencv_camera_" + std::to_string(cfg_.device_index);
-  metadata_.name = "OpenCV Camera Producer";
+  metadata_.name = cfg_.stream_id;
   metadata_.description = "Produces camera frames from a physical camera device using OpenCV";
   metadata_.width = cfg_.width;
   metadata_.height = cfg_.height;
@@ -20,9 +20,7 @@ OpenCvCameraProducer::OpenCvCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   metadata_.codec = "av1";
   metadata_.pix_fmt = "yuv420p";
   metadata_.channels = (cfg_.encoding == "bgr8" || cfg_.encoding == "rgb8") ? 3 : 1;
-  metadata_.camera_name = cfg_.stream_id;
   metadata_.has_audio = false;
-  metadata_.is_mock = false;
 }
 
 OpenCvCameraProducer::~OpenCvCameraProducer() {

--- a/src/hw/camera/opencv_producer.cpp
+++ b/src/hw/camera/opencv_producer.cpp
@@ -10,6 +10,7 @@ namespace trossen::hw::camera {
 
 OpenCvCameraProducer::OpenCvCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   // Populate metadata
+  metadata_.type = "camera";
   metadata_.id = "opencv_camera_" + std::to_string(cfg_.device_index);
   metadata_.name = "OpenCV Camera Producer";
   metadata_.description = "Produces camera frames from a physical camera device using OpenCV";

--- a/src/hw/camera/opencv_producer.cpp
+++ b/src/hw/camera/opencv_producer.cpp
@@ -16,8 +16,13 @@ OpenCvCameraProducer::OpenCvCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   metadata_.description = "Produces camera frames from a physical camera device using OpenCV";
   metadata_.width = cfg_.width;
   metadata_.height = cfg_.height;
-  metadata_.encoding = cfg_.encoding;
   metadata_.fps = cfg_.fps;
+  metadata_.codec = "av1";
+  metadata_.pix_fmt = "yuv420p";
+  metadata_.channels = (cfg_.encoding == "bgr8" || cfg_.encoding == "rgb8") ? 3 : 1;
+  metadata_.camera_name = cfg_.stream_id;
+  metadata_.has_audio = false;
+  metadata_.is_mock = false;
 }
 
 OpenCvCameraProducer::~OpenCvCameraProducer() {

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -101,15 +101,18 @@ bool SessionManager::start_episode() {
   // Build episode file path
   auto path = build_episode_path(next_episode_index_);
 
-  std::vector<hw::PolledProducer::ProducerMetadata> producer_metadata;
+  std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> producer_metadata;
+
   // Fetch Metadata from producers as a vector of the base class
   for (const auto& pt : producer_tasks_) {
     // Dynamic cast to PolledProducer to access metadata()
     if (auto polled_producer = std::dynamic_pointer_cast<hw::PolledProducer>(pt.producer)) {
+      std::cout << "  Pushed Producer: " << polled_producer->metadata()->name
+                << " (ID: " << polled_producer->metadata()->id << ")\n";
       producer_metadata.push_back(polled_producer->metadata());
     }
   }
-
+  std::cout<< "Number of Producers Pushed: " << producer_metadata.size() << std::endl;
   // Create backend
   try {
     current_backend_ = create_backend(path.string(), next_episode_index_, producer_metadata);
@@ -386,7 +389,7 @@ std::filesystem::path SessionManager::build_episode_path(uint32_t index) const {
 std::shared_ptr<io::Backend> SessionManager::create_backend(
   const std::string& output_path,
   uint32_t episode_index, 
-  const std::vector<hw::PolledProducer::ProducerMetadata>& producer_metadatas) {
+  const std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>>& producer_metadatas) {
 
   
   if(config_.backend_config == nullptr) {
@@ -404,28 +407,13 @@ std::shared_ptr<io::Backend> SessionManager::create_backend(
     // Print registered producers
     std::cout << "\n╔═══════════════════════════════════════════════ Registered Producers Metadata ═══════════════════════════════════════════════╗\n";
     for(const auto& pm : producer_metadatas) {
-      std::cout << "║  [ID: " << pm.id << "] Name: " << pm.name << "\n";
-      std::cout << "║      Description: " << pm.description << "\n";
+      std::cout << "║  [ID: " << pm->id << "] Name: " << pm->name << "\n";
+      std::cout << "║      Description: " << pm->description << "\n";
       std::cout << "║ --------------------------------------------------------------------------------------------------------------------\n";
     }
     std::cout << "╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝\n";
 
-    auto metadata = io::backends::LeRobotBackend::Metadata{};
-    metadata.task_name = lerobot_cfg->task_name;
-    metadata.robot_name = "TrossenRobot"; // TODO: Make configurable
-    metadata.codebase_version = "1.0.0";   // TODO: Extract from build system
-    metadata.trossen_subversion = "rev_1234"; // TODO: Extract from VCS 
-    metadata.num_cameras = 2; // TODO: Extract from registered producers
-    metadata.num_action_features = 7; // TODO: Extract from registered producers
-    metadata.num_observation_features = 7; // TODO: Extract from registered producers
-    metadata.camera_width = 640; // TODO: Extract from camera producers
-    metadata.camera_height = 480; // TODO: Extract from camera producers
-    metadata.is_depth_camera = false; // TODO: Extract from camera producers
-    metadata.camera_names = {"camera_main"}; // TODO: Extract from camera producers
-    metadata.action_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
-    metadata.observation_feature_names = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
-
-    return std::make_shared<io::backends::LeRobotBackend>(*lerobot_cfg, metadata);
+    return std::make_shared<io::backends::LeRobotBackend>(*lerobot_cfg, producer_metadatas);
   }
   else if (config_.backend_config->type == "mcap") {
     // Copy backend config template and customize for this episode


### PR DESCRIPTION
### TL;DR

Update the producer metadata system to use shared pointers and improve metadata handling in the LeRobot backend.

### What changed?

- Changed `metadata()` method in `PolledProducer` to return `std::shared_ptr<ProducerMetadata>` instead of a const reference
- Updated all producer implementations to create and return shared pointers to their metadata
- Added a `type` field to `ProducerMetadata` to identify different producer types
- Enhanced the `LeRobotBackend` to accept and process a vector of metadata shared pointers
- Improved metadata handling in the `LeRobotBackend` by dynamically casting to specific metadata types
- Added `is_depth_map` field to `MockCameraProducerMetadata`
- Added action and observation dtype fields to teleop mock joint producer

### How to test?

1. Create a session with multiple producers (cameras, arm, etc.)
2. Start an episode and verify that metadata is correctly written to the output files
3. Check that the metadata contains the correct information for each producer type
4. Verify that the LeRobot backend correctly processes the metadata from different producer types

### Why make this change?

This change improves the metadata system by:
1. Using shared pointers for better memory management and ownership semantics
2. Adding type information to enable proper identification and processing of different producer types
3. Making the metadata system more extensible for future producer types
4. Enabling the LeRobot backend to generate more accurate and complete metadata files based on the actual producers in use