### PR TITLE
Fix: Add FPS-based timestamping for LeRobot backend

### DIFF
--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
     lerobot_cfg->overwrite_existing = false;
     lerobot_cfg->encode_videos = true;
     lerobot_cfg->type = "lerobot";
-    lerobot_cfg->fps = 30.0f;
+    lerobot_cfg->fps = cfg.camera_fps;
     lerobot_cfg->robot_name = "bimanual_widowxai";
     session_cfg.backend_config = std::move(lerobot_cfg);
     

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -54,7 +54,7 @@ struct Config {
   int camera_fps = 30;
 
   // Arm settings
-  float joint_rate_hz = 200.0f;
+  float joint_rate_hz = 30.0f;
   std::string leader_ip = "192.168.1.2";
   std::string follower_ip = "192.168.1.4";
 
@@ -74,7 +74,7 @@ void print_usage(const char* prog_name) {
             << "  --camera-width <pixels>  Camera width (default: 1920)\n"
             << "  --camera-height <pixels> Camera height (default: 1080)\n"
             << "  --camera-fps <fps>       Camera frame rate (default: 30)\n"
-            << "  --joint-rate <hz>        Joint state capture rate (default: 200)\n"
+            << "  --joint-rate <hz>        Joint state capture rate (default: 30)\n"
             << "  --leader-ip <ip>         Leader arm IP (default: 192.168.1.2)\n"
             << "  --follower-ip <ip>       Follower arm IP (default: 192.168.1.4)\n"
             << "  --backend <type>         Dataset backend type (default: mcap)\n"
@@ -244,7 +244,10 @@ int main(int argc, char** argv) {
     lerobot_cfg->overwrite_existing = false;
     lerobot_cfg->encode_videos = true;
     lerobot_cfg->type = "lerobot";
+    lerobot_cfg->fps = 30.0f;
+    lerobot_cfg->robot_name = "bimanual_widowxai";
     session_cfg.backend_config = std::move(lerobot_cfg);
+    
   } else {
     std::cerr << "Unsupported backend type: " << cfg.backend_type << "\n";
     return 1;

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -103,6 +103,9 @@ public:
     // Robot name
     std::string robot_name{"trossen_ai_generic"};
 
+    // Frames per second for timestamping
+    float fps{30.0f};
+
   };
 
   /**

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -816,7 +816,7 @@ void LeRobotBackend::writeJointState(const data::RecordBase& base) {
 
   // Append timestamp
   check_status(
-      ts_builder.Append(static_cast<float>(js.ts.monotonic.to_ns()) / 1e9f),
+      ts_builder.Append(static_cast<float>(frame_id) / cfg_.fps),
       "Failed to append timestamp");
 
   // Observation list


### PR DESCRIPTION
### TL;DR

### What changed?

- Added explicit FPS configuration (30.0) to the LeRobot backend config
- Modified the timestamp calculation in `writeJointState()` to use frame_id/fps instead of monotonic time

### How to test?

1. Run the WidowX AI LeRobot example with default settings

### Why make this change?

Using frame_id/fps for timestamps provides more consistent timing that aligns better with the video frames. 