### PR TITLE
Update episode information in metadata and fix metadata file handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,20 +21,59 @@ add_library(trossen_sdk
   src/runtime/session_manager.cpp
 )
 
+# Add architecture-specific CMAKE_PREFIX_PATH
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} /usr/lib/x86_64-linux-gnu/cmake)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} /usr/lib/aarch64-linux-gnu/cmake)
+endif()
+
+find_package(Protobuf REQUIRED)
+message(STATUS "Found Protobuf: ${Protobuf_VERSION}")
+
 find_package(Arrow REQUIRED)
 find_package(Parquet REQUIRED)
 
 include(FetchContent)
+
+set(FOXGLOVE_VERSION "0.16.1")
+# Detect platform for Foxglove SDK download
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+  set(FOXGLOVE_ARCH "x86_64-unknown-linux-gnu")
+  set(FOXGLOVE_HASH "d8afbb8f99b75d7ad0f1b2885d35cacead28e6f2e36bd4d1a30e17413ebab896")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+  set(FOXGLOVE_ARCH "aarch64-unknown-linux-gnu")
+  set(FOXGLOVE_HASH "20dd412fa8be481e6ed84d88879f368e1a55a146e9a98f936a05931742e1dea5")
+else()
+  message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
 FetchContent_Declare(
-  mcap_builder
-  GIT_REPOSITORY https://github.com/TrossenRobotics/mcap_builder.git
-  GIT_TAG 31b70b3ea3121ef44f7a2f9e94b0c8e8325525fe
+  foxglove
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+  URL "https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv${FOXGLOVE_VERSION}/foxglove-v${FOXGLOVE_VERSION}-cpp-${FOXGLOVE_ARCH}.zip"
+  URL_HASH SHA256=${FOXGLOVE_HASH}
 )
-message(STATUS "Fetching MCAP (mcap_builder)...")
-FetchContent_MakeAvailable(mcap_builder)
-# mcap_builder provides an imported target named "mcap"
-target_link_libraries(trossen_sdk PUBLIC mcap)
-target_compile_definitions(trossen_sdk PUBLIC TROSSEN_WITH_MCAP=1)
+message(STATUS "Fetching Foxglove SDK v${FOXGLOVE_VERSION} for ${FOXGLOVE_ARCH}...")
+FetchContent_MakeAvailable(foxglove)
+
+# Find all Foxglove SDK source files
+file(GLOB FOXGLOVE_SOURCES CONFIGURE_DEPENDS
+  "${foxglove_SOURCE_DIR}/src/*.cpp"
+  "${foxglove_SOURCE_DIR}/src/server/*.cpp"
+)
+
+# Add Foxglove SDK source files
+target_sources(trossen_sdk PRIVATE ${FOXGLOVE_SOURCES})
+
+# Add Foxglove SDK include directories
+target_include_directories(trossen_sdk PUBLIC
+  ${foxglove_SOURCE_DIR}/include
+  ${foxglove_SOURCE_DIR}/include/foxglove
+)
+
+# Link against foxglove library
+target_link_libraries(trossen_sdk PRIVATE ${foxglove_SOURCE_DIR}/lib/libfoxglove.a)
 
 # Required OpenCV dependency for camera producer
 # On Ubuntu/Debian, OpenCV 4.x is typically installed as opencv4
@@ -54,30 +93,7 @@ message(STATUS "Found OpenCV: ${OpenCV_VERSION}")
 target_include_directories(trossen_sdk PUBLIC ${OpenCV_INCLUDE_DIRS})
 target_link_libraries(trossen_sdk PUBLIC ${OpenCV_LIBS} Arrow::arrow_shared Parquet::parquet_shared)
 
-# Protobuf schemas for MCAP backend
-# Try modern CMake config first, then fall back to FindProtobuf module
-find_package(Protobuf CONFIG QUIET)
-if(NOT Protobuf_FOUND)
-  # Fall back to the Find module (older method)
-  find_package(Protobuf QUIET)
-  if(NOT Protobuf_FOUND)
-    # Last resort: use pkg-config
-    find_package(PkgConfig QUIET)
-    if(PkgConfig_FOUND)
-      pkg_check_modules(Protobuf REQUIRED protobuf)
-      # Set standard variables for compatibility
-      set(Protobuf_LIBRARIES ${Protobuf_LINK_LIBRARIES})
-      set(Protobuf_INCLUDE_DIRS ${Protobuf_INCLUDE_DIRS})
-      # Find protoc compiler
-      find_program(Protobuf_PROTOC_EXECUTABLE protoc REQUIRED)
-    else()
-      message(FATAL_ERROR "Protobuf not found. Please install libprotobuf-dev and protobuf-compiler")
-    endif()
-  endif()
-endif()
-message(STATUS "Found Protobuf: ${Protobuf_VERSION}")
-
-# List proto files
+# List proto files for MCAP backend
 set(TROSSEN_PROTO_PATH ${CMAKE_CURRENT_SOURCE_DIR}/include/trossen_sdk/io/backends/mcap/proto)
 set(PROTOBUF_IMPORT_DIRS ${TROSSEN_PROTO_PATH})
 set(TROSSEN_PROTO_FILES
@@ -129,4 +145,3 @@ option(BUILD_BENCHMARKS "Build the benchmarking tree" OFF)
 if(BUILD_BENCHMARKS)
   add_subdirectory(benchmarks)
 endif()
-

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -226,6 +226,11 @@ public:
     int max_samples = 10000,
     float power = 0.75f) const;
 
+  /**
+   * @brief Update episode information in metadata
+   */
+  void updateEpisodeInfo(int episode_frame_length) const;
+
   /// @brief Image encoding statistics
   struct ImageEncodeStats {
 

--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -15,12 +15,17 @@
 #include <unordered_map>
 #include <vector>
 
-#include <mcap/writer.hpp>
+#include "foxglove/foxglove.hpp"
+#include "foxglove/mcap.hpp"
+#include "foxglove/channel.hpp"
+#include "foxglove/schemas.hpp"
 
 #include "trossen_sdk/io/backend.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_schemas.hpp"
 
 namespace trossen::io::backends {
+
+const size_t MCAP_INITIAL_ENCODED_BUFFER_SIZE = 1024 * 1024; // 1 MB
 
 /**
  * McapBackend writes records into an MCAP file.
@@ -111,21 +116,6 @@ public:
   Stats stats() const { return stats_; }
 
 private:
-  /// @brief Information about a registered MCAP channel
-  struct ChannelInfo {
-    /// @brief MCAP channel ID and associated info
-    mcap::ChannelId id{0};
-
-    /// @brief Stream ID (e.g., camera name or joint state topic)
-    std::string topic;
-
-    /// @brief Data encoding (e.g., "rgb8", "protobuf", etc.)
-    std::string encoding{"protobuf"};
-
-    /// @brief Associated schema ID
-    mcap::SchemaId schema_id{0};
-  };
-
   /**
    * @brief Ensure an image channel exists for the given camera name
    *
@@ -167,24 +157,14 @@ private:
    */
   void register_schemas_once();
 
-  /// @brief Image schema ID
-  mcap::SchemaId schema_image_{0};
+  /// @brief Foxglove context
+  foxglove::Context context_;
 
-  /// @brief Joint state schema ID
-  mcap::SchemaId schema_joint_{0};
+  /// @brief Foxglove MCAP writer instance
+  std::optional<foxglove::McapWriter> writer_;
 
-  // TODO(lukeschmitt-tr): camera calibration, robot description support
-  /// @brief Camera calibration schema ID
-  // mcap::SchemaId schema_cam_calib_{0};
-
-  /// @brief Robot description schema ID
-  // mcap::SchemaId schema_robot_description_{0};
-
-  /// @brief MCAP writer instance
-  mcap::McapWriter writer_;
-
-  /// @brief MCAP writer options
-  mcap::McapWriterOptions opts_{"trossen"};
+  /// @brief Protobuf schema for images
+  std::string schema_data_;
 
   /// @brief Output file path
   std::filesystem::path path_;
@@ -196,7 +176,7 @@ private:
   std::mutex writer_mutex_;
 
   /// @brief Map of image channels by camera name
-  std::unordered_map<std::string, ChannelInfo> image_channels_;
+  std::unordered_map<std::string, foxglove::RawChannel> image_channels_;
 
   /// @brief Helper to identify depth topics
   static bool is_depth_topic(const std::string& topic);
@@ -204,8 +184,8 @@ private:
   /// @brief Helper to identify depth encodings
   static bool is_depth_encoding(const std::string& enc);
 
-  /// @brief Joint state channel info
-  ChannelInfo joint_channel_{};
+  /// @brief Joint state channel
+  std::optional<foxglove::RawChannel> joint_channel_;
 
   /// @brief Statistics about written records
   Stats stats_{};

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -1012,7 +1012,6 @@ void LeRobotBackend::updateEpisodeInfo(int episode_frame_length) const{
       info_file.close();
     }
   }
-  std::cout << info_json.dump(4) << std::endl;
   // Update episode count
   info_json["total_episodes"] = info_json.value("total_episodes", 0) + 1;
 

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -101,19 +101,6 @@ bool LeRobotBackend::open() {
     std::cerr << "Failed to create metadata directories: " << e.what() << "\n";
     return false;
   }
-  // Create metadata files as needed (not implemented yet)
-  //info.json, stats.json, tasks.json, episode_stats.json
-
-  std::ofstream info_file(meta_root_ / JSON_INFO);
-      // std::ofstream episode_file(meta_root_ / JSONL_EPISODES);
-      // std::ofstream tasks_file(meta_root_ / JSONL_TASKS);
-      // std::ofstream episode_stats_file(meta_root_ / JSONL_EPISODE_STATS);
-
-  if (!info_file /*|| !episode_file || !tasks_file || !episode_stats_file*/) {
-    std::cerr << "Failed to create metadata files\n";
-    return false;
-  }
-
   // Create data directory
   data_root_ = root_ / "data" / "chunk-000";
   try {
@@ -650,7 +637,6 @@ void LeRobotBackend::computeStatistics() const {
   }
   episode_stats_file << episode_stats.dump() << "\n";
   episode_stats_file.close();
-  std::cout << "Metadata written to info.json successfully." << std::endl;
 
 
   nlohmann::ordered_json episode_metadata;
@@ -666,7 +652,6 @@ void LeRobotBackend::computeStatistics() const {
   }
   episodes_file << episode_metadata.dump() << "\n";
   episodes_file.close();
-  std::cout << "Metadata written to info.json successfully." << std::endl;
 
   // TODO (shantanuparab-tr): Implement logic to check for existing task entrys
   nlohmann::ordered_json task_metadata;
@@ -681,9 +666,10 @@ void LeRobotBackend::computeStatistics() const {
   }
   tasks_file << task_metadata.dump() << "\n";
   
+  // Get total number of rows in the table (frames recorded)
+  int64_t episode_frame_length = table->num_rows();
 
-  // TODO (shantanuparab-tr): Add this to metadata file
-  // printStatsTable(stats);
+  updateEpisodeInfo(episode_frame_length);
   
 }
 
@@ -1015,14 +1001,58 @@ void LeRobotBackend::imageWorkerLoop() {
 }
 
 
+void LeRobotBackend::updateEpisodeInfo(int episode_frame_length) const{
+  // Load the existing info.json
+  fs::path info_path = meta_root_ / JSON_INFO;
+  nlohmann::ordered_json info_json;
+  if (fs::exists(info_path)) {
+    std::ifstream info_file(info_path);
+    if (info_file.is_open()) {
+      info_file >> info_json;
+      info_file.close();
+    }
+  }
+  std::cout << info_json.dump(4) << std::endl;
+  // Update episode count
+  info_json["total_episodes"] = info_json.value("total_episodes", 0) + 1;
+
+  // update total videos
+  info_json["total_videos"] = info_json.value("total_videos", 0) + camera_names_.size();
+
+  // Update splits (simple logic: all episodes go to train)
+  std::string train_split = info_json["splits"].value("train", "0:0");
+  size_t colon_pos = train_split.find(':');
+  int train_start = std::stoi(train_split.substr(0, colon_pos));;
+  int train_end = std::stoi(train_split.substr(colon_pos + 1));;
+  train_end += 1; // add one episode to train
+  info_json["splits"]["train"] = std::to_string(train_start) + ":" + std::to_string(train_end);
+
+  // Update total frames
+  info_json["total_frames"] = info_json.value("total_frames", 0) + episode_frame_length ;
+
+  // Write back to info.json
+  std::ofstream info_file(info_path);
+  if (info_file.is_open()) {
+    info_file << info_json.dump(4);
+    info_file.close();
+  }
+}
+
 void LeRobotBackend::writeMetadata() {
   
   // TODO(shantanuparab-tr): [TDS-15]: Extract features from the robot's
   // observation space and action space
   // TODO(shantanuparab-tr): [TDS-16]: Get feature specifications from a
   // configuration file or constant definitions
-  
 
+
+  // Check if info.json already exists
+  fs::path info_path = meta_root_ / JSON_INFO;
+  if (fs::exists(info_path)) {
+    std::cout << "Info file already exists at " << info_path
+              << ". Skipping metadata write." << std::endl;
+    return;
+  }
   nlohmann::ordered_json info_;
 
   // Miscellaneous Feature (Initialization with placeholder values)
@@ -1032,6 +1062,7 @@ void LeRobotBackend::writeMetadata() {
 
   info_["total_episodes"] = 0;
   info_["total_frames"] = 0;
+  info_["total_videos"] = 0;
   // TODO(shantanuparab-tr): [TDS-25]: Update total tasks based on total number
   // of unique tasks
   info_["total_tasks"] = 1;

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -2,17 +2,14 @@
 #include <unordered_set>
 #include <iostream>
 
-#include "mcap/types.hpp"
-#include "opencv2/imgcodecs.hpp"
-
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/descriptor.pb.h"
+#include "opencv2/imgcodecs.hpp"
 
 #include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_backend.hpp"
 #include "trossen_sdk/version.hpp"
 #include "JointState.pb.h"
-#include "RawImage.pb.h"
 
 
 namespace trossen::io::backends {
@@ -31,40 +28,53 @@ bool McapBackend::open() {
 
   // Parse configs
   path_ = cfg_.output_path;
-  opts_.chunkSize = cfg_.chunk_size_bytes;
+
+  // Create Foxglove context
+  context_ = foxglove::Context::create();
+
+  // Store path as string
+  std::string path_str = path_.string();
+
+  // Configure MCAP writer options
+  foxglove::McapWriterOptions opts;
+  opts.context = context_;
+  opts.path = path_str;
+  opts.profile = "trossen";
+  opts.chunk_size = cfg_.chunk_size_bytes;
+
   if (cfg_.compression == "zstd") {
-    opts_.compression = mcap::Compression::Zstd;
+    opts.compression = foxglove::McapCompression::Zstd;
   } else if (cfg_.compression == "lz4") {
-    opts_.compression = mcap::Compression::Lz4;
+    opts.compression = foxglove::McapCompression::Lz4;
   } else if (cfg_.compression.empty()) {
-    opts_.compression = mcap::Compression::None;
+    opts.compression = foxglove::McapCompression::None;
   } else {
     std::cerr << "Unknown compression option: " << cfg_.compression << " (falling back to none)\n";
-    opts_.compression = mcap::Compression::None;
+    opts.compression = foxglove::McapCompression::None;
   }
 
   // Open mcap writer
-  auto status = writer_.open(path_.string(), opts_);
-  if (!status.ok()) {
-    std::cerr << "Failed to open MCAP file: " << status.message << "\n";
+  auto writer_result = foxglove::McapWriter::create(opts);
+  if (!writer_result.has_value()) {
+    std::cerr << "Failed to open MCAP file: " << foxglove::strerror(writer_result.error()) << "\n";
     return false;
   }
+  writer_ = std::move(writer_result.value());
   opened_ = true;
 
   register_schemas_once();
 
   // Write MCAP file-level metadata
-  mcap::Metadata metadata;
-  metadata.name = "trossen_sdk_recording";
-  metadata.metadata["tool_version"] = trossen::core::version();
-  metadata.metadata["dataset_id"] = cfg_.dataset_id;
-  metadata.metadata["episode_index"] = std::to_string(cfg_.episode_index);
+  std::map<std::string, std::string> metadata;
+  metadata["tool_version"] = trossen::core::version();
+  metadata["dataset_id"] = cfg_.dataset_id;
+  metadata["episode_index"] = std::to_string(cfg_.episode_index);
   auto now = trossen::data::now_real();
-  metadata.metadata["recording_start_time"] = std::to_string(now.to_ns());
+  metadata["recording_start_time"] = std::to_string(now.to_ns());
 
-  auto st = writer_.write(metadata);
-  if (!st.ok()) {
-    std::cerr << "Failed to write metadata: " << st.message << "\n";
+  auto st = writer_->writeMetadata("trossen_sdk_recording", metadata.begin(), metadata.end());
+  if (st != foxglove::FoxgloveError::Ok) {
+    std::cerr << "Failed to write metadata: " << foxglove::strerror(st) << "\n";
   }
 
   return true;
@@ -75,7 +85,19 @@ void McapBackend::close() {
   if (!opened_) {
     return;
   }
-  writer_.close();
+  // Close channels
+  if (joint_channel_) {
+    joint_channel_->close();
+  }
+  for (auto& [name, channel] : image_channels_) {
+    channel.close();
+  }
+  if (writer_) {
+    auto st = writer_->close();
+    if (st != foxglove::FoxgloveError::Ok) {
+      std::cerr << "Failed to close MCAP writer: " << foxglove::strerror(st) << "\n";
+    }
+  }
   opened_ = false;
 }
 
@@ -84,7 +106,6 @@ void McapBackend::flush() {
   if (!opened_) {
     return;
   }
-  writer_.closeLastChunk();
 }
 
 void McapBackend::write(const data::RecordBase& record) {
@@ -121,20 +142,33 @@ void McapBackend::writeBatch(std::span<const data::RecordBase* const> records) {
 
 void McapBackend::ensure_jointstate_channel() {
   // Check if the channel already exists
-  if (joint_channel_.id != 0) {
+  if (joint_channel_.has_value()) {
     return;
   }
 
-  // Create a new channel
-  mcap::Channel ch;
-  ch.topic = mcapdefs::joint_state_topic(cfg_.robot_name);
-  ch.messageEncoding = "protobuf";
-  ch.schemaId = schema_joint_;
-  writer_.addChannel(ch);
-  joint_channel_.id = ch.id;
-  joint_channel_.topic = ch.topic;
-  joint_channel_.encoding = ch.messageEncoding;
-  joint_channel_.schema_id = ch.schemaId;
+  // Create schema
+  foxglove::Schema schema;
+  schema.name = "trossen_sdk.msg.JointState";
+  schema.encoding = "protobuf";
+  schema.data = reinterpret_cast<const std::byte*>(schema_data_.data());
+  schema.data_len = schema_data_.size();
+
+  // Create channel
+  auto channel_result = foxglove::RawChannel::create(
+    mcapdefs::joint_state_topic(cfg_.robot_name),
+    "protobuf",
+    schema,
+    context_,
+    std::nullopt
+  );
+
+  if (!channel_result.has_value()) {
+    std::cerr << "Failed to create joint state channel: "
+              << foxglove::strerror(channel_result.error()) << "\n";
+    return;
+  }
+
+  joint_channel_ = std::move(channel_result.value());
 }
 
 void McapBackend::ensure_image_channel(const std::string& camera_name) {
@@ -149,21 +183,29 @@ void McapBackend::ensure_image_channel_with_metadata(
   if (it != image_channels_.end()) {
     return; // already exists
   }
-  mcap::Channel ch;
-  ch.topic = mcapdefs::image_topic(camera_name);
-  ch.messageEncoding = "protobuf";
-  ch.schemaId = schema_image_;
-  // Insert metadata (MCAP Channel supports key/value map)
-  for (const auto& kv : metadata) {
-    ch.metadata[kv.first] = kv.second;
+
+  // Use Foxglove SDK's built-in RawImage schema
+  foxglove::Schema schema = foxglove::schemas::RawImage::schema();
+
+  // Convert metadata to std::map
+  std::map<std::string, std::string> channel_metadata(metadata.begin(), metadata.end());
+
+  // Create channel
+  auto channel_result = foxglove::RawChannel::create(
+    mcapdefs::image_topic(camera_name),
+    "protobuf",
+    schema,
+    context_,
+    channel_metadata
+  );
+
+  if (!channel_result.has_value()) {
+    std::cerr << "Failed to create image channel: "
+              << foxglove::strerror(channel_result.error()) << "\n";
+    return;
   }
-  writer_.addChannel(ch);
-  ChannelInfo info;
-  info.id = ch.id;
-  info.topic = ch.topic;
-  info.encoding = ch.messageEncoding;
-  info.schema_id = ch.schemaId;
-  image_channels_.emplace(camera_name, info);
+
+  image_channels_.emplace(camera_name, std::move(channel_result.value()));
 }
 
 void McapBackend::write_jointstate_record(const data::JointStateRecord& js) {
@@ -190,18 +232,16 @@ void McapBackend::write_jointstate_record(const data::JointStateRecord& js) {
   for (auto v : js.efforts) out.add_efforts(v);
   std::string payload;
   out.SerializeToString(&payload);
-  mcap::Message msg;
-  msg.channelId = joint_channel_.id;
-  msg.sequence = js.seq;
-  msg.publishTime = js.ts.realtime.to_ns();
-  msg.logTime = js.ts.realtime.to_ns();
-  msg.data = reinterpret_cast<const std::byte*>(payload.data());
-  msg.dataSize = payload.size();
-  auto st = writer_.write(msg);
-  if (!st.ok()) {
-    std::cerr << "Failed to write joint state: " << st.message << "\n";
-  }
-  else {
+
+  auto st = joint_channel_->log(
+    reinterpret_cast<const std::byte*>(payload.data()),
+    payload.size(),
+    js.ts.realtime.to_ns()
+  );
+
+  if (st != foxglove::FoxgloveError::Ok) {
+    std::cerr << "Failed to write joint state: " << foxglove::strerror(st) << "\n";
+  } else {
     ++stats_.joint_states_written;
   }
 }
@@ -225,31 +265,45 @@ void McapBackend::write_image_record(const data::ImageRecord& img) {
   } else {
     ensure_image_channel(img.id);
   }
-  foxglove::RawImage imsg;
-  auto* ts = imsg.mutable_timestamp();
-  ts->set_seconds(img.ts.realtime.sec);
-  ts->set_nanos(img.ts.realtime.nsec);
-  imsg.set_frame_id(img.id);
-  imsg.set_width(img.width);
-  imsg.set_height(img.height);
-  imsg.set_encoding(img.encoding);
-  // Step: use OpenCV stride (bytes per row) if available
-  imsg.set_step(static_cast<uint32_t>(img.image.step));
-  imsg.set_data(
-    reinterpret_cast<const char*>(img.image.data),
-    img.image.total() * img.image.elemSize());
-  std::string payload;
-  imsg.SerializeToString(&payload);
-  mcap::Message msg;
-  msg.channelId = image_channels_.at(img.id).id;
-  msg.sequence = img.seq;
-  msg.logTime = img.ts.realtime.to_ns();
-  msg.publishTime = msg.logTime;
-  msg.data = reinterpret_cast<const std::byte*>(payload.data());
-  msg.dataSize = payload.size();
-  auto st = writer_.write(msg);
-  if (!st.ok()) {
-    std::cerr << "Failed to write image: " << st.message << "\n";
+  foxglove::schemas::RawImage imsg;
+  imsg.timestamp = foxglove::schemas::Timestamp{
+    .sec = static_cast<uint32_t>(img.ts.realtime.sec),
+    .nsec = static_cast<uint32_t>(img.ts.realtime.nsec)
+  };
+  imsg.frame_id = img.id;
+  imsg.width = img.width;
+  imsg.height = img.height;
+  imsg.encoding = img.encoding;
+  imsg.step = static_cast<uint32_t>(img.image.step);
+  // Copy image data to std::vector<std::byte>
+  const std::byte* data_ptr = reinterpret_cast<const std::byte*>(img.image.data);
+  size_t data_size = img.image.total() * img.image.elemSize();
+  imsg.data.assign(data_ptr, data_ptr + data_size);
+
+  // Encode to buffer
+  std::vector<uint8_t> payload(MCAP_INITIAL_ENCODED_BUFFER_SIZE);
+  size_t encoded_len = 0;
+  auto encode_result = imsg.encode(payload.data(), payload.size(), &encoded_len);
+
+  if (encode_result == foxglove::FoxgloveError::BufferTooShort) {
+    // Resize and try again
+    payload.resize(encoded_len);
+    encode_result = imsg.encode(payload.data(), payload.size(), &encoded_len);
+  }
+
+  if (encode_result != foxglove::FoxgloveError::Ok) {
+    std::cerr << "Failed to encode image: " << foxglove::strerror(encode_result) << "\n";
+    return;
+  }
+
+  auto st = image_channels_.at(img.id).log(
+    reinterpret_cast<const std::byte*>(payload.data()),
+    encoded_len,
+    img.ts.realtime.to_ns()
+  );
+
+  if (st != foxglove::FoxgloveError::Ok) {
+    std::cerr << "Failed to write image: " << foxglove::strerror(st) << "\n";
   } else {
     if (depth) {
       ++stats_.depth_images_written;
@@ -266,8 +320,6 @@ void McapBackend::register_schemas_once() {
 
   const char* roots[] = {
     "trossen_sdk/io/backends/mcap/proto/JointState.proto",
-    "trossen_sdk/io/backends/mcap/proto/Rawimage.proto",
-    "trossen_sdk/io/backends/mcap/proto/Timestamp.proto"
   };
 
   std::unordered_set<std::string> visited;
@@ -297,18 +349,7 @@ void McapBackend::register_schemas_once() {
 
   std::string blob;
   set.SerializeToString(&blob);
-
-  // Register schemas we care about and store IDs
-  auto addSchema = [&](const std::string& name) -> mcap::SchemaId {
-    mcap::Schema s;
-    s.name = name;
-    s.encoding = "protobuf";
-    s.data.assign(reinterpret_cast<const std::byte*>(blob.data()), reinterpret_cast<const std::byte*>(blob.data() + blob.size()));
-    writer_.addSchema(s);
-    return s.id;
-  };
-  schema_joint_   = addSchema("trossen_sdk.msg.JointState");
-  schema_image_   = addSchema("foxglove.RawImage");
+  schema_data_ = blob;
 }
 
 bool McapBackend::is_depth_topic(const std::string& topic) {


### PR DESCRIPTION
### TL;DR

Added episode information tracking and metadata management for the LeRobot backend.

### What changed?

- Added a new `updateEpisodeInfo` method to update episode metadata after recording
- Modified the metadata initialization process to only create info.json if it doesn't exist
- Updated `computeStatistics` to track episode frame length and update episode information
- Improved metadata handling to track total episodes, videos, and frames
- Removed redundant console output messages
- Fixed the metadata file structure to properly update with new episode data

### How to test?

1. Record an episode using the LeRobot backend
2. Verify that the metadata files are created correctly in the metadata directory
3. Record multiple episodes and check that the episode count, video count, and frame count are incremented properly
4. Verify that the train split in info.json is updated correctly with each new episode.