### PR TITLE
Add repository ID parameter and improve default output paths

### DIFF
--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -31,6 +31,7 @@
 #include "trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp"
 #include "trossen_sdk/hw/camera/opencv_producer.hpp"
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
 
 using namespace std::chrono_literals;
 using namespace trossen::demo;
@@ -43,7 +44,8 @@ struct Config {
   int duration_s = 10;
   int episodes = 3;
   std::string dataset_id = "";  // empty = auto-generate
-  std::string output_dir = "output/episodes";
+  std::string output_dir = trossen::io::backends::get_default_root_path().string();
+  std::string repository_id = "TrossenRoboticsCommunity"; //Valid only for LeRobot backend
   bool use_mock = false;
   bool show_help = false;
 
@@ -69,6 +71,7 @@ void print_usage(const char* prog_name) {
             << "  --episodes <count>       Number of episodes to record (default: 3)\n"
             << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
             << "  --output-dir <path>      Output directory for episodes (default: output/episodes)\n"
+            << "  --repository-id <string> Repository identifier (default: TrossenRoboticsCommunity, only for LeRobot backend)\n"
             << "  --mock                   Use mock producers instead of real hardware\n"
             << "  --camera-index <num>     Camera device index (default: 2, i.e., /dev/video2)\n"
             << "  --camera-width <pixels>  Camera width (default: 1920)\n"
@@ -100,6 +103,8 @@ Config parse_args(int argc, char** argv) {
       cfg.dataset_id = argv[++i];
     } else if (arg == "--output-dir" && i + 1 < argc) {
       cfg.output_dir = argv[++i];
+    } else if (arg == "--repository-id" && i + 1 < argc) {
+      cfg.repository_id = argv[++i];
     } else if (arg == "--mock") {
       cfg.use_mock = true;
     } else if (arg == "--camera-index" && i + 1 < argc) {
@@ -144,6 +149,7 @@ int main(int argc, char** argv) {
     "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
     "Output directory:     " + cfg.output_dir,
+    "Repository ID:       " + cfg.repository_id,
     "Backend:              " + cfg.backend_type
   };
 
@@ -227,6 +233,7 @@ int main(int argc, char** argv) {
   session_cfg.dataset_id = cfg.dataset_id;
   session_cfg.max_duration = std::chrono::seconds(cfg.duration_s);
   session_cfg.max_episodes = cfg.episodes;
+  session_cfg.repository_id = cfg.repository_id;
 
   if(cfg.backend_type == "mcap") {
     auto mcap_cfg = std::make_unique<trossen::io::backends::McapBackend::Config>();
@@ -239,8 +246,8 @@ int main(int argc, char** argv) {
     auto lerobot_cfg = std::make_unique<trossen::io::backends::LeRobotBackend::Config>();
     lerobot_cfg->output_dir = cfg.output_dir;
     lerobot_cfg->task_name = "trossen_ai_solo_demo";
-    lerobot_cfg->repository_id = "TrossenRoboticsCommunity";
-    lerobot_cfg->dataset_id = "trossen_ai_solo_dataset";
+    lerobot_cfg->repository_id = cfg.repository_id;
+    lerobot_cfg->dataset_id = cfg.dataset_id;
     lerobot_cfg->overwrite_existing = false;
     lerobot_cfg->encode_videos = true;
     lerobot_cfg->type = "lerobot";

--- a/include/trossen_sdk/io/backend_utils.hpp
+++ b/include/trossen_sdk/io/backend_utils.hpp
@@ -1,0 +1,23 @@
+// Copyright 2025 Trossen Robotics
+#ifndef INCLUDE_TROSSEN_SDK_IO_BACKEND_UTILS_HPP_
+#define INCLUDE_TROSSEN_SDK_IO_BACKEND_UTILS_HPP_
+#include <filesystem>
+
+namespace trossen::io::backends {
+
+
+/// @brief Default root path for dataset storage
+/// Safely get the default root path for dataset storage
+inline std::filesystem::path get_default_root_path() {
+    const char* home = std::getenv("HOME");
+    if (home) {
+        return std::filesystem::path(home) / ".cache" / "trossen_sdk";
+    } else {
+        // Fallback to current directory if HOME is not set
+        return std::filesystem::path(".") / ".cache" / "trossen_sdk";
+    }
+}
+
+}  // namespace trossen::io::backends
+
+#endif  // INCLUDE_TROSSEN_SDK_IO_BACKEND_UTILS_HPP_

--- a/include/trossen_sdk/io/backend_utils.hpp
+++ b/include/trossen_sdk/io/backend_utils.hpp
@@ -1,4 +1,3 @@
-// Copyright 2025 Trossen Robotics
 #ifndef INCLUDE_TROSSEN_SDK_IO_BACKEND_UTILS_HPP_
 #define INCLUDE_TROSSEN_SDK_IO_BACKEND_UTILS_HPP_
 #include <filesystem>

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -21,6 +21,7 @@
 #include <parquet/arrow/writer.h>
 #include "trossen_sdk/io/backend.hpp"
 #include "trossen_sdk/io/backends/lerobot/lerobot_constants.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/hw/producer_base.hpp"
 
 namespace trossen::io::backends {
@@ -95,7 +96,7 @@ public:
     std::string dataset_id{"default_dataset"};
 
     // Root path
-    std::string root_path{get_default_root_path().string()};
+    std::string root_path{trossen::io::backends::get_default_root_path().string()};
 
     // Episode index (for organizing output)
     uint32_t episode_index{0};
@@ -230,6 +231,14 @@ public:
    * @brief Update episode information in metadata
    */
   void updateEpisodeInfo(int episode_frame_length) const;
+
+
+  /**
+   * @brief Scan directory for existing episode files and return next index
+   * @param base_path Directory to scan
+   * @return Next episode index (max_found + 1, or 0 if none found)
+   */
+  static uint32_t scan_existing_episodes(const std::filesystem::path& base_path);
 
   /// @brief Image encoding statistics
   struct ImageEncodeStats {

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_constants.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_constants.hpp
@@ -1,21 +1,8 @@
 // Copyright 2025 Trossen Robotics
 #ifndef INCLUDE_LEROBOT_CONSTANTS_HPP_
 #define INCLUDE_LEROBOT_CONSTANTS_HPP_
-#include <filesystem>
 
 namespace trossen::io::backends {
-
-/// @brief Default root path for dataset storage
-/// @brief Safely get the default root path for dataset storage
-inline std::filesystem::path get_default_root_path() {
-    const char* home = std::getenv("HOME");
-    if (home) {
-        return std::filesystem::path(home) / ".cache" / "trossen_dataset_collection_sdk";
-    } else {
-        // Fallback to current directory if HOME is not set
-        return std::filesystem::path(".") / ".cache" / "trossen_dataset_collection_sdk";
-    }
-}
 
 /// @brief Format string for leader robot configuration file path
 const char LEADER_ROBOT_CONFIG_FORMAT[] = "config/{}_leader.json";

--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <regex>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -114,6 +115,14 @@ public:
    * @return Stats structure with counts
    */
   Stats stats() const { return stats_; }
+
+
+  /**
+   * @brief Scan directory for existing episode files and return next index
+   * @param base_path Directory to scan
+   * @return Next episode index (max_found + 1, or 0 if none found)
+   */
+  static uint32_t scan_existing_episodes(const std::filesystem::path& base_path);
 
 private:
   /**

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -47,6 +47,9 @@ struct SessionConfig {
   /// Optional: maximum number of episodes (nullopt = unlimited)
   std::optional<uint32_t> max_episodes = std::nullopt;
 
+  /// Repository identifier (used by LeRobot backend)
+  std::string repository_id = "";
+
   /// Backend configuration template (output_path will be overwritten per episode)
   std::unique_ptr<trossen::io::Backend::Config> backend_config;
 };

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -48,6 +48,7 @@ struct SessionConfig {
   std::optional<uint32_t> max_episodes = std::nullopt;
 
   /// Repository identifier (used by LeRobot backend)
+  // TODO (shantanuparab-tr): Make this generic or remove it after making backend-agnostic
   std::string repository_id = "";
 
   /// Backend configuration template (output_path will be overwritten per episode)

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -1163,9 +1163,6 @@ uint32_t LeRobotBackend::scan_existing_episodes(const std::filesystem::path& bas
   }
 
   // Pattern: episode_NNNNNN.parquet (6-digit zero-padded) Regex to match episode files
-  //
-  // TODO(lukeschmitt-tr): This is specific to MCAP files; consider making more generic - backend
-  // could provide pattern?
   std::regex episode_pattern(R"(episode_(\d{6})\.parquet)");
 
   uint32_t max_index = 0;

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -3,13 +3,12 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
+#include <regex>
 #include "opencv2/imgcodecs.hpp"
 #include <opencv2/opencv.hpp>
 #include <parquet/arrow/reader.h>
 #include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/io/backends/lerobot/lerobot_backend.hpp"
-#include "trossen_sdk/hw/arm/arm_producer.hpp"
-#include "trossen_sdk/hw/arm/mock_joint_producer.hpp"
 #include "trossen_sdk/hw/arm/teleop_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp"
 #include "trossen_sdk/hw/camera/opencv_producer.hpp"
@@ -39,7 +38,7 @@ LeRobotBackend::LeRobotBackend(Config cfg, std::vector<std::shared_ptr<hw::Polle
   // URI is absolute path to output directory. Set to absolute path and check write access.
   // Validate output directory path
   try {
-    uri_ = (fs::path(cfg_.root_path) / cfg_.repository_id / cfg_.dataset_id).string();
+    uri_ = (fs::path(cfg_.output_dir) / cfg_.repository_id / cfg_.dataset_id).string();
   } catch (const std::exception& e) {
     throw std::runtime_error("Failed to resolve absolute path of output directory: " + std::string(e.what()));
   }
@@ -70,6 +69,10 @@ bool LeRobotBackend::open() {
     return true; // idempotent
   }
   root_ = fs::path(uri_);
+  std::cout << "=====================================================================" << std::endl;
+  std::cout << "Opening LeRobotBackend at: " << root_ << "\n";
+  std::cout << "=====================================================================" << std::endl;
+
 
   std::ostringstream oss;
   oss << "episode_" << std::setfill('0') << std::setw(6) << cfg_.episode_index;
@@ -1140,7 +1143,66 @@ void LeRobotBackend::writeMetadata() {
   }
   info_file << info_.dump(4);
   info_file.close();
-  std::cout << "Metadata written to info.json successfully." << std::endl;
+  }
 
+
+
+uint32_t LeRobotBackend::scan_existing_episodes(const std::filesystem::path& base_path) {
+
+  std::cout << "Scanning existing episodes in: " << base_path << std::endl;
+  
+  // If directory doesn't exist, return 0
+  if (!std::filesystem::exists(base_path)) {
+    return 0;
+  }
+
+  // If not a directory, return 0
+  if (!std::filesystem::is_directory(base_path)) {
+    std::cerr << "Warning: base_path exists but is not a directory: " << base_path << std::endl;
+    return 0;
+  }
+
+  // Pattern: episode_NNNNNN.parquet (6-digit zero-padded) Regex to match episode files
+  //
+  // TODO(lukeschmitt-tr): This is specific to MCAP files; consider making more generic - backend
+  // could provide pattern?
+  std::regex episode_pattern(R"(episode_(\d{6})\.parquet)");
+
+  uint32_t max_index = 0;
+  bool found_any = false;
+
+  try {
+    // Iterate through directory entries
+    for (const auto& entry : std::filesystem::directory_iterator(base_path)) {
+      // Skip if not a regular file
+      if (!entry.is_regular_file()) {
+        continue;
+      }
+
+      // Get filename only (not full path)
+      std::string filename = entry.path().filename().string();
+
+      // Try to match against episode pattern
+      std::smatch match;
+      if (std::regex_match(filename, match, episode_pattern)) {
+        // Extract the numeric index from capture group 1
+        std::string index_str = match[1].str();
+        uint32_t index = static_cast<uint32_t>(std::stoul(index_str));
+
+        // Track maximum index found
+        if (!found_any || index > max_index) {
+          max_index = index;
+          found_any = true;
+        }
+      }
+      // Silently ignore non-episode files (as per design doc)
+    }
+  } catch (const std::filesystem::filesystem_error& e) {
+    std::cerr << "Filesystem error while scanning episodes: " << e.what() << std::endl;
+    return 0;
+  }
+
+  // Return max_index + 1, or 0 if no episodes found
+  return found_any ? (max_index + 1) : 0;
 }
 } // namespace trossen::io::backends

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -52,13 +52,13 @@ bool McapBackend::open() {
     std::cerr << "Unknown compression option: " << cfg_.compression << " (falling back to none)\n";
     opts.compression = foxglove::McapCompression::None;
   }
-  // Check it the output path parent directory exists
+  // Check if the output path parent directory exists
   auto parent_path = path_.parent_path();
   if (!std::filesystem::exists(parent_path)) {
     try {
       std::filesystem::create_directories(parent_path);
     } catch (const std::exception& e) {
-      std::cerr << "Failed to create parent directories for MCAP file: " << e.what() << "\n";
+      std::cerr << "Failed to create parent directories for MCAP file at " << parent_path << ": " << e.what() << "\n";
       return false;
     }
   }

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -52,6 +52,16 @@ bool McapBackend::open() {
     std::cerr << "Unknown compression option: " << cfg_.compression << " (falling back to none)\n";
     opts.compression = foxglove::McapCompression::None;
   }
+  // Check it the output path parent directory exists
+  auto parent_path = path_.parent_path();
+  if (!std::filesystem::exists(parent_path)) {
+    try {
+      std::filesystem::create_directories(parent_path);
+    } catch (const std::exception& e) {
+      std::cerr << "Failed to create parent directories for MCAP file: " << e.what() << "\n";
+      return false;
+    }
+  }
 
   // Open mcap writer
   auto writer_result = foxglove::McapWriter::create(opts);
@@ -363,11 +373,12 @@ bool McapBackend::is_depth_encoding(const std::string& enc) {
 
 
 uint32_t McapBackend::scan_existing_episodes(const std::filesystem::path& base_path) {
+  std::cout << "Scanning existing episodes in: " << base_path << std::endl;
   // If directory doesn't exist, return 0
   if (!std::filesystem::exists(base_path)) {
     return 0;
   }
-
+  
   // If not a directory, return 0
   if (!std::filesystem::is_directory(base_path)) {
     std::cerr << "Warning: base_path exists but is not a directory: " << base_path << std::endl;

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -386,9 +386,6 @@ uint32_t McapBackend::scan_existing_episodes(const std::filesystem::path& base_p
   }
 
   // Pattern: episode_NNNNNN.mcap (6-digit zero-padded) Regex to match episode files
-  //
-  // TODO(lukeschmitt-tr): This is specific to MCAP files; consider making more generic - backend
-  // could provide pattern?
   std::regex episode_pattern(R"(episode_(\d{6})\.mcap)");
 
   uint32_t max_index = 0;

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -361,4 +361,61 @@ bool McapBackend::is_depth_encoding(const std::string& enc) {
   return enc == "depth16" || enc == "32FC1" || enc == "16UC1"; // allow alias
 }
 
+
+uint32_t McapBackend::scan_existing_episodes(const std::filesystem::path& base_path) {
+  // If directory doesn't exist, return 0
+  if (!std::filesystem::exists(base_path)) {
+    return 0;
+  }
+
+  // If not a directory, return 0
+  if (!std::filesystem::is_directory(base_path)) {
+    std::cerr << "Warning: base_path exists but is not a directory: " << base_path << std::endl;
+    return 0;
+  }
+
+  // Pattern: episode_NNNNNN.mcap (6-digit zero-padded) Regex to match episode files
+  //
+  // TODO(lukeschmitt-tr): This is specific to MCAP files; consider making more generic - backend
+  // could provide pattern?
+  std::regex episode_pattern(R"(episode_(\d{6})\.mcap)");
+
+  uint32_t max_index = 0;
+  bool found_any = false;
+
+  try {
+    // Iterate through directory entries
+    for (const auto& entry : std::filesystem::directory_iterator(base_path)) {
+      // Skip if not a regular file
+      if (!entry.is_regular_file()) {
+        continue;
+      }
+
+      // Get filename only (not full path)
+      std::string filename = entry.path().filename().string();
+
+      // Try to match against episode pattern
+      std::smatch match;
+      if (std::regex_match(filename, match, episode_pattern)) {
+        // Extract the numeric index from capture group 1
+        std::string index_str = match[1].str();
+        uint32_t index = static_cast<uint32_t>(std::stoul(index_str));
+
+        // Track maximum index found
+        if (!found_any || index > max_index) {
+          max_index = index;
+          found_any = true;
+        }
+      }
+      // Silently ignore non-episode files (as per design doc)
+    }
+  } catch (const std::filesystem::filesystem_error& e) {
+    std::cerr << "Filesystem error while scanning episodes: " << e.what() << std::endl;
+    return 0;
+  }
+
+  // Return max_index + 1, or 0 if no episodes found
+  return found_any ? (max_index + 1) : 0;
+}
+
 } // namespace trossen::io::backends

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -40,7 +40,8 @@ SessionManager::SessionManager(SessionConfig&& config)
 
   // Scan directory for existing episodes and resume from next index
   if(config_.backend_config->type == "mcap") {
-    next_episode_index_ = io::backends::McapBackend::scan_existing_episodes(config_.base_path);
+    std::filesystem::path data_directory_path = config_.base_path / config_.dataset_id;
+    next_episode_index_ = io::backends::McapBackend::scan_existing_episodes(data_directory_path);
   } else if (config_.backend_config->type == "lerobot") {
     std::filesystem::path data_directory_path = config_.base_path / config_.repository_id / config_.dataset_id / "data" / "chunk-000";
     next_episode_index_ = io::backends::LeRobotBackend::scan_existing_episodes(data_directory_path);
@@ -103,7 +104,7 @@ bool SessionManager::start_episode() {
     std::cerr << "Max episodes (" << config_.max_episodes.value() << ") reached." << std::endl;
     return false;
   }
-
+  
   // Build episode file path
   auto path = build_episode_path(next_episode_index_);
 
@@ -331,10 +332,13 @@ std::filesystem::path SessionManager::build_episode_path(uint32_t index) const {
       return config_.base_path;
   } else if (config_.backend_config->type == "mcap") {
       oss << "episode_" << std::setfill('0') << std::setw(6) << index << ".mcap";
+      return config_.base_path / config_.dataset_id / oss.str();
+
   } else {
     throw std::runtime_error("SessionManager::build_episode_path: Unsupported backend type: " + config_.backend_config->type);
   }
-  return config_.base_path / oss.str();
+  // return empty path as fallback (should not reach here)
+  return std::filesystem::path();
 }
 
 std::shared_ptr<io::Backend> SessionManager::create_backend(

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
-#include <regex>
 #include <sstream>
 
 namespace trossen::runtime {
@@ -40,7 +39,14 @@ SessionManager::SessionManager(SessionConfig&& config)
   }
 
   // Scan directory for existing episodes and resume from next index
-  next_episode_index_ = scan_existing_episodes(config_.base_path);
+  if(config_.backend_config->type == "mcap") {
+    next_episode_index_ = io::backends::McapBackend::scan_existing_episodes(config_.base_path);
+  } else if (config_.backend_config->type == "lerobot") {
+    std::filesystem::path data_directory_path = config_.base_path / config_.repository_id / config_.dataset_id / "data" / "chunk-000";
+    next_episode_index_ = io::backends::LeRobotBackend::scan_existing_episodes(data_directory_path);
+  } else {
+    throw std::invalid_argument("Unsupported backend type: " + config_.backend_config->type);
+  }
   if (next_episode_index_ > 0) {
     std::cout << "Found " << next_episode_index_ << " existing episode(s). "
               << "Next episode index: " << next_episode_index_ << std::endl;
@@ -313,61 +319,7 @@ SessionManager::Stats SessionManager::stats() const {
   return s;
 }
 
-uint32_t SessionManager::scan_existing_episodes(const std::filesystem::path& base_path) {
-  // If directory doesn't exist, return 0
-  if (!std::filesystem::exists(base_path)) {
-    return 0;
-  }
 
-  // If not a directory, return 0
-  if (!std::filesystem::is_directory(base_path)) {
-    std::cerr << "Warning: base_path exists but is not a directory: " << base_path << std::endl;
-    return 0;
-  }
-
-  // Pattern: episode_NNNNNN.mcap (6-digit zero-padded) Regex to match episode files
-  //
-  // TODO(lukeschmitt-tr): This is specific to MCAP files; consider making more generic - backend
-  // could provide pattern?
-  std::regex episode_pattern(R"(episode_(\d{6})\.mcap)");
-
-  uint32_t max_index = 0;
-  bool found_any = false;
-
-  try {
-    // Iterate through directory entries
-    for (const auto& entry : std::filesystem::directory_iterator(base_path)) {
-      // Skip if not a regular file
-      if (!entry.is_regular_file()) {
-        continue;
-      }
-
-      // Get filename only (not full path)
-      std::string filename = entry.path().filename().string();
-
-      // Try to match against episode pattern
-      std::smatch match;
-      if (std::regex_match(filename, match, episode_pattern)) {
-        // Extract the numeric index from capture group 1
-        std::string index_str = match[1].str();
-        uint32_t index = static_cast<uint32_t>(std::stoul(index_str));
-
-        // Track maximum index found
-        if (!found_any || index > max_index) {
-          max_index = index;
-          found_any = true;
-        }
-      }
-      // Silently ignore non-episode files (as per design doc)
-    }
-  } catch (const std::filesystem::filesystem_error& e) {
-    std::cerr << "Filesystem error while scanning episodes: " << e.what() << std::endl;
-    return 0;
-  }
-
-  // Return max_index + 1, or 0 if no episodes found
-  return found_any ? (max_index + 1) : 0;
-}
 
 std::filesystem::path SessionManager::build_episode_path(uint32_t index) const {
   // Generate filename: episode_NNNNNN.mcap (6-digit zero-padded)
@@ -376,9 +328,8 @@ std::filesystem::path SessionManager::build_episode_path(uint32_t index) const {
   if(config_.backend_config == nullptr) {
     throw std::runtime_error("SessionManager::build_episode_path: backend_config is null");
   } else if (config_.backend_config->type == "lerobot") {
-      oss << "episode_" << std::setfill('0') << std::setw(6) << index;
-  }
-  else if (config_.backend_config->type == "mcap") {
+      return config_.base_path;
+  } else if (config_.backend_config->type == "mcap") {
       oss << "episode_" << std::setfill('0') << std::setw(6) << index << ".mcap";
   } else {
     throw std::runtime_error("SessionManager::build_episode_path: Unsupported backend type: " + config_.backend_config->type);

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -37,7 +37,7 @@ SessionManager::SessionManager(SessionConfig&& config)
     config_.dataset_id = oss.str();
     std::cout << "Auto-generated dataset_id: " << config_.dataset_id << std::endl;
   }
-
+  // TODO (shantanuparab-tr): Make this backend-agnostic by using a factory method
   // Scan directory for existing episodes and resume from next index
   if(config_.backend_config->type == "mcap") {
     std::filesystem::path data_directory_path = config_.base_path / config_.dataset_id;
@@ -337,8 +337,6 @@ std::filesystem::path SessionManager::build_episode_path(uint32_t index) const {
   } else {
     throw std::runtime_error("SessionManager::build_episode_path: Unsupported backend type: " + config_.backend_config->type);
   }
-  // return empty path as fallback (should not reach here)
-  return std::filesystem::path();
 }
 
 std::shared_ptr<io::Backend> SessionManager::create_backend(


### PR DESCRIPTION
# Improved Dataset Storage and Episode Management

This PR adds functionality to scan for existing episodes in both MCAP and LeRobot backends, allowing for proper episode indexing when resuming data collection. 

Key changes:
- Added utility function to get default root path for dataset storage
- Moved common path utilities to a new `backend_utils.hpp` file
- Fixed MCAP storage directory structure to properly organize episodes
- Added repository ID parameter to LeRobot backend configuration
- Implemented episode scanning for both backends to determine next episode index
- Updated directory creation logic to ensure parent directories exist

These changes ensure consistent episode numbering across sessions and improve the organization of collected data.