### PR TITLE
Add producer metadata get_info() method for dataset introspection

### DIFF
--- a/include/trossen_sdk/hw/arm/arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/arm_producer.hpp
@@ -34,7 +34,10 @@ public:
     /// @brief Gripper type
     std::string gripper_type;
 
+    /// @brief Get producer info as JSON
+    /// @return JSON object containing producer information
     nlohmann::ordered_json get_info() const override {
+      //TODO (shantanuparab-tr): Implement JSON output when needed
       std::cout << "TrossenArmProducerMetadata: " << name << " (" << id << ") - " << description
                 << ", Model: " << arm_model << ", Gripper: " << gripper_type << "\n";
       return nlohmann::ordered_json{};

--- a/include/trossen_sdk/hw/arm/arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/arm_producer.hpp
@@ -33,6 +33,12 @@ public:
 
     /// @brief Gripper type
     std::string gripper_type;
+
+    nlohmann::ordered_json get_info() const override {
+      std::cout << "TrossenArmProducerMetadata: " << name << " (" << id << ") - " << description
+                << ", Model: " << arm_model << ", Gripper: " << gripper_type << "\n";
+      return nlohmann::ordered_json{};
+    }
   };
 
   /**

--- a/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
@@ -42,7 +42,10 @@ public:
     /// @brief Gripper type
     std::string gripper_type;
 
+    /// @brief Get producer info as JSON
+    /// @return JSON object containing producer information
     nlohmann::ordered_json   get_info() const override {
+      //TODO (shantanuparab-tr): Implement JSON output when needed
       std::cout << "MockJointStateProducerMetadata: " << name << " (" << id << ") - " << description
                 << ", Model: " << arm_model << ", Gripper: " << gripper_type << "\n";
       return nlohmann::ordered_json{};

--- a/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
@@ -42,6 +42,12 @@ public:
     /// @brief Gripper type
     std::string gripper_type;
 
+    nlohmann::ordered_json   get_info() const override {
+      std::cout << "MockJointStateProducerMetadata: " << name << " (" << id << ") - " << description
+                << ", Model: " << arm_model << ", Gripper: " << gripper_type << "\n";
+      return nlohmann::ordered_json{};
+    }
+
   };
 
   explicit MockJointStateProducer(Config cfg);

--- a/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
@@ -40,6 +40,8 @@ public:
     /// @brief Observation feature data type
     std::string observation_dtype;
 
+    /// @brief Get producer info as JSON
+    /// @return JSON object containing producer information
     nlohmann::ordered_json get_info() const override {
       nlohmann::ordered_json features;
       nlohmann::ordered_json action;

--- a/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
@@ -39,6 +39,23 @@ public:
 
     /// @brief Observation feature data type
     std::string observation_dtype;
+
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      nlohmann::ordered_json action;
+      action["dtype"] = action_dtype;
+      action["shape"] = {static_cast<int>(action_feature_names.size())};
+      action["names"] = action_feature_names;
+
+      nlohmann::ordered_json observation_state;
+      observation_state["dtype"] = observation_dtype;
+      observation_state["shape"] = {
+          static_cast<int>(observation_feature_names.size())};
+      observation_state["names"] = observation_feature_names;
+      features["action"] = action;
+      features["observation.state"] = observation_state;
+      return features;
+    }
   };
 
   /**

--- a/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
@@ -48,6 +48,8 @@ public:
     /// @brief Observation feature data type
     std::string observation_dtype;
 
+    /// @brief Get producer info as JSON
+    /// @return JSON object containing producer information
     nlohmann::ordered_json get_info() const override {
       nlohmann::ordered_json features;
       nlohmann::ordered_json action;

--- a/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp
@@ -48,6 +48,22 @@ public:
     /// @brief Observation feature data type
     std::string observation_dtype;
 
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      nlohmann::ordered_json action;
+      action["dtype"] = action_dtype;
+      action["shape"] = {static_cast<int>(action_feature_names.size())};
+      action["names"] = action_feature_names;
+
+      nlohmann::ordered_json observation_state;
+      observation_state["dtype"] = observation_dtype;
+      observation_state["shape"] = {
+          static_cast<int>(observation_feature_names.size())};
+      observation_state["names"] = observation_feature_names;
+      features["action"] = action;
+      features["observation.state"] = observation_state;
+      return features;
+    }
   };
 
   explicit TeleopMockJointStateProducer(Config cfg);

--- a/include/trossen_sdk/hw/camera/mock_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_producer.hpp
@@ -77,9 +77,12 @@ public:
     /// @brief Is this a depth camera?
     bool is_depth_map{false};
 
+    /// @brief Get producer info as JSON
+    /// @return JSON object containing producer information
     nlohmann::ordered_json get_info() const override {
       nlohmann::ordered_json features;
       nlohmann::ordered_json camera_feature;
+      camera_feature["id"] = id;
       camera_feature["dtype"] = "video";
       camera_feature["shape"] = {height, width, 3};
       camera_feature["names"] = {"height", "width", "channels"};

--- a/include/trossen_sdk/hw/camera/mock_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_producer.hpp
@@ -77,6 +77,21 @@ public:
     /// @brief Is this a depth camera?
     bool is_depth_map{false};
 
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      nlohmann::ordered_json camera_feature;
+      camera_feature["dtype"] = "video";
+      camera_feature["shape"] = {height, width, 3};
+      camera_feature["names"] = {"height", "width", "channels"};
+      camera_feature["info"] = {
+          {"video.fps", fps},           {"video.height", height},
+          {"video.width", width},       {"video.channels", channels},
+          {"video.codec", codec},                {"video.pix_fmt", pix_fmt},
+          {"video.is_depth_map", is_depth_map}, {"has_audio", has_audio}};
+      features["observation.images." + id] = camera_feature;
+      return features;
+    }
+
   };
 
   /**

--- a/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
@@ -68,6 +68,21 @@ public:
     /// @brief Is this a depth camera?
     bool is_depth_map{false};
 
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      nlohmann::ordered_json camera_feature;
+      camera_feature["dtype"] = "video";
+      camera_feature["shape"] = {height, width, 3};
+      camera_feature["names"] = {"height", "width", "channels"};
+      camera_feature["info"] = {
+          {"video.fps", fps},           {"video.height", height},
+          {"video.width", width},       {"video.channels", channels},
+          {"video.codec", codec},                {"video.pix_fmt", pix_fmt},
+          {"video.is_depth_map", is_depth_map}, {"has_audio", has_audio}};
+      features["observation.images." + id] = camera_feature;
+      return features;
+    }
+
   };
 
   explicit MockSyncedCameraProducer(Config cfg);

--- a/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
+++ b/include/trossen_sdk/hw/camera/mock_synced_producer.hpp
@@ -68,9 +68,12 @@ public:
     /// @brief Is this a depth camera?
     bool is_depth_map{false};
 
+    /// @brief Get producer info as JSON
+    /// @return JSON object containing producer information
     nlohmann::ordered_json get_info() const override {
       nlohmann::ordered_json features;
       nlohmann::ordered_json camera_feature;
+      camera_feature["id"] = id;
       camera_feature["dtype"] = "video";
       camera_feature["shape"] = {height, width, 3};
       camera_feature["names"] = {"height", "width", "channels"};

--- a/include/trossen_sdk/hw/camera/opencv_producer.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_producer.hpp
@@ -80,9 +80,12 @@ public:
     /// @brief Is this a depth camera?
     bool is_depth_map{false};
 
+    /// @brief Get producer info as JSON
+    /// @return JSON object containing producer information
     nlohmann::ordered_json get_info() const override {
       nlohmann::ordered_json features;
       nlohmann::ordered_json camera_feature;
+      camera_feature["id"] = id;
       camera_feature["dtype"] = "video";
       camera_feature["shape"] = {height, width, 3};
       camera_feature["names"] = {"height", "width", "channels"};

--- a/include/trossen_sdk/hw/camera/opencv_producer.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_producer.hpp
@@ -80,6 +80,21 @@ public:
     /// @brief Is this a depth camera?
     bool is_depth_map{false};
 
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      nlohmann::ordered_json camera_feature;
+      camera_feature["dtype"] = "video";
+      camera_feature["shape"] = {height, width, 3};
+      camera_feature["names"] = {"height", "width", "channels"};
+      camera_feature["info"] = {
+          {"video.fps", fps},           {"video.height", height},
+          {"video.width", width},       {"video.channels", channels},
+          {"video.codec", codec},                {"video.pix_fmt", pix_fmt},
+          {"video.is_depth_map", is_depth_map}, {"has_audio", has_audio}};
+      features["observation.images." + id] = camera_feature;
+      return features;
+    }
+
   };
 
   /**

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -72,6 +72,8 @@ public:
     /// @brief Virtual destructor
     virtual ~ProducerMetadata() = default;
 
+    /// @brief Get producer info as JSON
+    /// @return JSON object containing producer information
     virtual nlohmann::ordered_json get_info() const {
       std::cout << "ProducerMetadata: " << name << " (" << id << ") - " << description << "\n";
       return nlohmann::ordered_json{};

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -11,8 +11,9 @@
 #include <atomic>
 #include <cstdint>
 #include <string>
-
-#include "trossen_sdk/data/record.hpp"
+#include <iostream>
+#include "nlohmann/json.hpp"
+#include "trossen_sdk/data/record.hpp"  
 
 namespace trossen::hw {
 
@@ -70,6 +71,11 @@ public:
 
     /// @brief Virtual destructor
     virtual ~ProducerMetadata() = default;
+
+    virtual nlohmann::ordered_json get_info() const {
+      std::cout << "ProducerMetadata: " << name << " (" << id << ") - " << description << "\n";
+      return nlohmann::ordered_json{};
+    }
 
   };
 

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -598,10 +598,10 @@ void LeRobotBackend::computeStatistics() const {
       stats[field->name()] = computeFlatStats(array);
     }
   }
-
+  std::cout << "Computing image data statistics successfully." << std::endl;
   // Compute image statistics for each camera
   for (const auto &camera_info : camera_names_) {
-
+    std::cout << "Computing image statistics for camera: " << camera_info << std::endl;
     std::string image_key = "observation.images." + camera_info;
     // Get image paths for the current episode and camera
     std::string image_folder_path = images_root_.string();
@@ -1048,68 +1048,26 @@ void LeRobotBackend::writeMetadata() {
 
   nlohmann::ordered_json features;
 
-  for(const auto &metadata : metadata_ ){
-
-   if (metadata->type == "mock_teleop_arm"){
-      const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopMockJointStateProducer::TeleopMockJointStateProducerMetadata&>(*metadata);
-    
-      nlohmann::ordered_json action;
-      action["dtype"] = teleop_arm_metadata.action_dtype;
-      action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
-      action["names"] = teleop_arm_metadata.action_feature_names;
-
-      nlohmann::ordered_json observation_state;
-      observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
-      observation_state["shape"] = {
-          static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
-      observation_state["names"] = teleop_arm_metadata.observation_feature_names;
-      features["action"] = action;
-      features["observation.state"] = observation_state;
-    } else if (metadata->type == "teleop_arm"){
-      const auto &teleop_arm_metadata = dynamic_cast<const hw::arm::TeleopTrossenArmProducer::TeleopTrossenArmProducerMetadata&>(*metadata);
-    
-      nlohmann::ordered_json action;
-      action["dtype"] = teleop_arm_metadata.action_dtype;
-      action["shape"] = {static_cast<int>(teleop_arm_metadata.action_feature_names.size())};
-      action["names"] = teleop_arm_metadata.action_feature_names;
-
-      nlohmann::ordered_json observation_state;
-      observation_state["dtype"] = teleop_arm_metadata.observation_dtype;
-      observation_state["shape"] = {
-          static_cast<int>(teleop_arm_metadata.observation_feature_names.size())};
-      observation_state["names"] = teleop_arm_metadata.observation_feature_names;
-      features["action"] = action;
-      features["observation.state"] = observation_state;    
-    } else if (metadata->type == "mock_camera"){
-      camera_names_.push_back(metadata->id);
-      const auto &camera_metadata = dynamic_cast<const hw::camera::MockCameraProducer::MockCameraProducerMetadata&>(*metadata);
-      nlohmann::ordered_json camera_feature;
-      camera_feature["dtype"] = "video";
-      camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
-      camera_feature["names"] = {"height", "width", "channels"};
-      camera_feature["info"] = {
-          {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
-          {"video.width", camera_metadata.width},       {"video.channels", camera_metadata.channels},
-          {"video.codec", camera_metadata.codec},                {"video.pix_fmt", camera_metadata.pix_fmt},
-          {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", camera_metadata.has_audio}};
-      features["observation.images." + camera_metadata.id] = camera_feature;
-    } else if (metadata->type == "opencv_camera"){
-      camera_names_.push_back(metadata->id);
-      const auto &camera_metadata = dynamic_cast<const hw::camera::OpenCvCameraProducer::OpenCvCameraProducerMetadata&>(*metadata);
-      nlohmann::ordered_json camera_feature;
-      camera_feature["dtype"] = "video";
-      camera_feature["shape"] = {camera_metadata.height, camera_metadata.width, 3};
-      camera_feature["names"] = {"height", "width", "channels"};
-      camera_feature["info"] = {
-          {"video.fps", camera_metadata.fps},           {"video.height", camera_metadata.height},
-          {"video.width", camera_metadata.width},       {"video.channels", camera_metadata.channels},
-          {"video.codec", camera_metadata.codec},                {"video.pix_fmt", camera_metadata.pix_fmt},
-          {"video.is_depth_map", (camera_metadata.is_depth_map)}, {"has_audio", camera_metadata.has_audio}};
-      features["observation.images." + camera_metadata.id] = camera_feature;
-    } else {
-      std::cerr << "Unknown metadata type: " << metadata->type << std::endl;
+    for(const auto &metadata : metadata_ ){
+      nlohmann::ordered_json producer_feature = metadata->get_info();
+      // Merge producer_feature into features
+      for (auto it = producer_feature.begin(); it != producer_feature.end(); ++it) {
+        features[it.key()] = it.value();
+      }
+      // Check if metadata has a features["observation.images." + id] entry and add to camera_names_
+      // Extract camera IDs from image feature keys for later use in statistics computation.
+      // Camera names are derived from "observation.images.*" keys in producer metadata
+      // and are used to locate the corresponding image directories.
+      // TODO (shantanuparab-tr): This logic can be improved by having a dedicated method in
+      // metadata interface to get camera IDs.
+      for (auto it = producer_feature.begin(); it != producer_feature.end(); ++it) {
+        const std::string& key = it.key();
+        if (key.find("observation.images.") == 0) {
+          std::string camera_id = key.substr(std::string("observation.images.").length());
+          camera_names_.push_back(camera_id);
+        }
+      }
     }
-  }
 
   //TODO (shantanuparab-tr): Common Feature these can be moved to a constants file later
   

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -598,7 +598,6 @@ void LeRobotBackend::computeStatistics() const {
       stats[field->name()] = computeFlatStats(array);
     }
   }
-  std::cout << "Computing image data statistics successfully." << std::endl;
   // Compute image statistics for each camera
   for (const auto &camera_info : camera_names_) {
     std::cout << "Computing image statistics for camera: " << camera_info << std::endl;
@@ -1048,29 +1047,24 @@ void LeRobotBackend::writeMetadata() {
 
   nlohmann::ordered_json features;
 
-    for(const auto &metadata : metadata_ ){
-      nlohmann::ordered_json producer_feature = metadata->get_info();
-      // Merge producer_feature into features
-      for (auto it = producer_feature.begin(); it != producer_feature.end(); ++it) {
-        features[it.key()] = it.value();
-      }
-      // Check if metadata has a features["observation.images." + id] entry and add to camera_names_
-      // Extract camera IDs from image feature keys for later use in statistics computation.
-      // Camera names are derived from "observation.images.*" keys in producer metadata
-      // and are used to locate the corresponding image directories.
-      // TODO (shantanuparab-tr): This logic can be improved by having a dedicated method in
-      // metadata interface to get camera IDs.
-      for (auto it = producer_feature.begin(); it != producer_feature.end(); ++it) {
-        const std::string& key = it.key();
-        if (key.find("observation.images.") == 0) {
-          std::string camera_id = key.substr(std::string("observation.images.").length());
-          camera_names_.push_back(camera_id);
+  for(const auto &metadata : metadata_ ){
+    nlohmann::ordered_json producer_feature = metadata->get_info();
+    // Merge producer_feature into features
+    for (auto it = producer_feature.begin(); it != producer_feature.end(); ++it) {
+      features[it.key()] = it.value();
+    }
+    // Extract camera names for video features
+    for (auto it = producer_feature.begin(); it != producer_feature.end(); ++it) {
+      if (it.value().contains("dtype") && it.value()["dtype"] == "video") {
+        if (it.value().contains("id")) {
+          camera_names_.push_back(it.value()["id"].get<std::string>());
         }
       }
     }
+  }
 
   //TODO (shantanuparab-tr): Common Feature these can be moved to a constants file later
-  
+
   nlohmann::ordered_json timestamp_feature;
   timestamp_feature["dtype"] = "float32";
   timestamp_feature["shape"] = {1};
@@ -1095,20 +1089,17 @@ void LeRobotBackend::writeMetadata() {
   task_index_feature["dtype"] = "int64";
   task_index_feature["shape"] = {1};
   task_index_feature["names"] = {};
-  
+
   features["timestamp"] = timestamp_feature;
   features["frame_index"] = frame_index_feature;
   features["episode_index"] = episode_index_feature;
   features["index"] = index_feature;
-  features["task_index"] = task_index_feature;  
+  features["task_index"] = task_index_feature;
 
   info_["features"] = features;
 
   info_["data_path"] = "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet";
   info_["video_path"] = "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4";
-
-  {
-
 
   // // Write to info.json
   std::ofstream info_file(meta_root_ / JSON_INFO);
@@ -1120,6 +1111,6 @@ void LeRobotBackend::writeMetadata() {
   info_file << info_.dump(4);
   info_file.close();
   std::cout << "Metadata written to info.json successfully." << std::endl;
-  }
+
 }
 } // namespace trossen::io::backends


### PR DESCRIPTION
### TL;DR

Implemented `get_info()` method in producer metadata classes to standardize feature information retrieval.

### What changed?

- Added `get_info()` virtual method to the base `ProducerMetadata` class
- Implemented specialized versions of `get_info()` in various producer classes:
  - Arm producers (TrossenArmProducer, MockJointProducer)
  - Teleop producers (TeleopTrossenArmProducer, TeleopMockJointStateProducer)
  - Camera producers (MockCameraProducer, MockSyncedCameraProducer, OpenCvCameraProducer)
- Refactored `LeRobotBackend::writeMetadata()` to use the new `get_info()` method instead of type-specific logic
- Added camera ID extraction from metadata feature keys for statistics computation

### Why make this change?

This refactoring improves the code by:
1. Applying the polymorphism pattern to metadata handling
2. Reducing code duplication in the `writeMetadata()` method
3. Making it easier to add new producer types without modifying the backend code
4. Standardizing how feature information is retrieved across different producer types