### PR TITLE
Additional prep for backend registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(trossen_sdk
   src/backends/trossen/trossen_backend.cpp
   src/backends/lerobot/lerobot_backend.cpp
   src/backends/mcap/mcap_backend.cpp
+  src/backends/null/null_backend.cpp
   src/hw/arm/arm_producer.cpp
   src/hw/arm/teleop_arm_producer.cpp
   src/hw/arm/mock_joint_producer.cpp

--- a/include/trossen_sdk/io/backends/null/null_backend.hpp
+++ b/include/trossen_sdk/io/backends/null/null_backend.hpp
@@ -32,58 +32,45 @@ public:
    *
    * @param cfg Configuration options
    */
-  explicit NullBackend(const Config& cfg) : Backend(cfg.uri) {}
+  explicit NullBackend(const Config& cfg);
 
   /**
    * @brief Open a null logging destination
    *
-   * @param uri Voided backend uri
    * @return true on success
    */
-  bool open() override {
-    opened_ = true;
-    return true;
-  }
+  bool open() override;
 
   /**
    * @brief Discard a single record, counting it.
    *
    * @param record Voided record
    */
-  void write(const data::RecordBase& record) override {
-    (void)record;
-    ++count_;
-  }
+  void write(const data::RecordBase& record) override;
 
   /**
    * @brief Discard a batch of records, counting them.
    *
    * @param records Voided record pointers
    */
-  void write_batch(std::span<const data::RecordBase* const> records) override {
-    count_ += records.size();
-  }
+  void write_batch(std::span<const data::RecordBase* const> records) override;
 
   /**
    * @brief No-op flush
    */
-  void flush() override {}
+  void flush() override;
 
   /**
    * @brief Close the null backend
    */
-  void close() override {
-    opened_ = false;
-  }
+  void close() override;
 
   /**
    * @brief Get the number of records "written"
    *
    * @return Count of records
    */
-  uint64_t count() const {
-    return count_.load();
-  }
+  uint64_t count() const;
 
 private:
   /// @brief Count of records "written"

--- a/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
@@ -49,7 +49,7 @@ public:
   /**
    * @brief Configuration parameters
    */
-  struct Config {
+  struct Config : public io::Backend::Config {
     /// @brief Root output directory
     std::string output_dir;
 

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -32,7 +32,7 @@ namespace fs = std::filesystem;
 
 LeRobotBackend::LeRobotBackend(
   Config cfg,
-  std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> metadata)
+  std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> metadata = {})
   : io::Backend(cfg.output_dir), cfg_(std::move(cfg)), metadata_(std::move(metadata))
 {
   // Validate encoder threads

--- a/src/backends/null/null_backend.cpp
+++ b/src/backends/null/null_backend.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file null_backend.cpp
+ * @brief Implementation of NullBackend.
+ */
+
+#include "trossen_sdk/io/backends/null/null_backend.hpp"
+
+namespace trossen::io::backends {
+
+NullBackend::NullBackend(const Config& cfg) : Backend(cfg.uri) {}
+
+bool NullBackend::open() {
+  opened_ = true;
+  return true;
+}
+
+void NullBackend::write(const data::RecordBase& record) {
+  (void)record;
+  count_.fetch_add(1);
+}
+
+void NullBackend::write_batch(std::span<const data::RecordBase* const> records) {
+  count_.fetch_add(records.size());
+}
+
+void NullBackend::flush() {
+  // No-op
+}
+
+void NullBackend::close() {
+  opened_ = false;
+}
+
+uint64_t NullBackend::count() const {
+  return count_.load();
+}
+
+}  // namespace trossen::io::backends


### PR DESCRIPTION
This PR does the following to prepare for the backend registry system:
* Creates an implementation source file for the null backend
* Makes the trossen backend config inherit from the base backend config
* Makes the lerobot producers metadata constructor param optional

This is part of an effort to make all interfaces for all backends generic as this will be necessary for the backend registry.