### PR TITLE
Add backend registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ project(trossen_sdk
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_library(trossen_sdk
+add_library(trossen_sdk SHARED
+  src/backends/backend_registry.cpp
   src/backends/trossen/trossen_backend.cpp
   src/backends/lerobot/lerobot_backend.cpp
   src/backends/mcap/mcap_backend.cpp
@@ -57,6 +58,7 @@ find_package(BZip2 REQUIRED)
 
 find_package(Arrow REQUIRED)
 find_package(Parquet REQUIRED)
+find_package(libtrossen_arm REQUIRED)
 
 include(FetchContent)
 
@@ -115,7 +117,13 @@ if(NOT OpenCV_FOUND)
 endif()
 message(STATUS "Found OpenCV: ${OpenCV_VERSION}")
 target_include_directories(trossen_sdk PUBLIC ${OpenCV_INCLUDE_DIRS})
-target_link_libraries(trossen_sdk PUBLIC ${OpenCV_LIBS} Arrow::arrow_shared Parquet::parquet_shared)
+target_link_libraries(
+  trossen_sdk PUBLIC
+  ${OpenCV_LIBS}
+  Arrow::arrow_shared
+  Parquet::parquet_shared
+  libtrossen_arm
+)
 
 # List proto files for MCAP backend
 set(TROSSEN_PROTO_PATH ${CMAKE_CURRENT_SOURCE_DIR}/include/trossen_sdk/io/backends/mcap/proto)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,3 +19,7 @@ target_link_libraries(widowxai_lerobot demo_utils trossen_sdk libtrossen_arm)
 find_package(libtrossen_arm)
 add_executable(widowxai_bimanual widowxai_bimanual.cpp)
 target_link_libraries(widowxai_bimanual demo_utils trossen_sdk libtrossen_arm)
+
+# Backend registry demo
+add_executable(backend_registry_demo backend_registry_demo.cpp)
+target_link_libraries(backend_registry_demo trossen_sdk)

--- a/examples/backend_registry_demo.cpp
+++ b/examples/backend_registry_demo.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file backend_registry_demo.cpp
+ * @brief Simple demo of the BackendRegistry system
+ *
+ * Shows how to create backends at runtime without hardcoded type checking.
+ */
+
+#include <iostream>
+#include <memory>
+
+#include "trossen_sdk/trossen_sdk.hpp"
+
+int main() {
+  // List registered backends
+  std::cout << "Registered backends:\n";
+  for (const auto& type : {"null", "mcap", "lerobot", "trossen"}) {
+    if (trossen::io::BackendRegistry::is_registered(type)) {
+      std::cout << "  Is Registered: " << type << "\n";
+    }
+  }
+  std::cout << "\n";
+
+  // Create and use a backend through the registry
+  std::cout << "Creating null backend...\n";
+  trossen::io::backends::NullBackend::Config cfg;
+  cfg.type = "null";
+  cfg.uri = "null://demo";
+
+  auto backend = trossen::io::BackendRegistry::create("null", cfg);
+  backend->open();
+
+  // Write some data
+  trossen::data::JointStateRecord record;
+  record.ts = trossen::data::make_timestamp_now();
+  record.seq = 0;
+  record.id = "demo/joints";
+  record.positions = {0.1f, 0.2f, 0.3f};
+
+  backend->write(record);
+  backend->flush();
+  backend->close();
+
+  std::cout << "Successfully wrote data through registry-created backend!\n\n";
+
+  return 0;
+}

--- a/include/trossen_sdk/io/backend_registry.hpp
+++ b/include/trossen_sdk/io/backend_registry.hpp
@@ -1,0 +1,110 @@
+/**
+ * @file backend_registry.hpp
+ * @brief Factory registry for backend types.
+ *
+ * Provides a static registry that maps backend type strings to factory functions,
+ * enabling extensible backend creation without hardcoded type-checking.
+ */
+
+#ifndef TROSSEN_SDK__IO__BACKEND_REGISTRY_HPP
+#define TROSSEN_SDK__IO__BACKEND_REGISTRY_HPP
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "trossen_sdk/io/backend.hpp"
+
+namespace trossen::io {
+
+/**
+ * @brief Static registry for backend factory functions.
+ *
+ * Backend implementations register themselves at static initialization time.
+ */
+class BackendRegistry {
+public:
+  /// @brief Factory function signature for creating backend instances
+  using FactoryFunc = std::function<std::shared_ptr<Backend>(Backend::Config&)>;
+
+  /**
+   * @brief Register a backend factory function
+   *
+   * @param type Backend type string (e.g., "mcap", "lerobot")
+   * @param factory Factory function that creates backend instances
+   *
+   * @throws std::runtime_error if type is already registered
+   *
+   * @note This should be called during static initialization, typically using a static registrar
+   *       object in the backend implementation file.
+   */
+  static void register_backend(const std::string& type, FactoryFunc factory);
+
+  /**
+   * @brief Create a backend instance by type
+   *
+   * @param type Backend type string
+   * @param config Backend configuration (must be compatible with registered type)
+   *
+   * @return Shared pointer to created backend instance
+   *
+   * @throws std::runtime_error if type is not registered
+   *
+   * @note The config reference is downcast to the appropriate concrete config type by the
+   *       registered factory function.
+   */
+  static std::shared_ptr<Backend> create(const std::string& type, Backend::Config& config);
+
+  /**
+   * @brief Check if a backend type is registered
+   *
+   * @param type Backend type string
+   * @return true if the type is registered, false otherwise
+   */
+  static bool is_registered(const std::string& type);
+
+private:
+  /**
+   * @brief Get the singleton registry map
+   *
+   * @return Reference to the static registry map
+   *
+   * @note Using a function-local static ensures proper initialization order
+   */
+  static std::map<std::string, FactoryFunc>& get_registry();
+};
+
+/**
+ * @brief Macro to register a backend type with the BackendRegistry
+ *
+ * This macro creates a static registrar object that registers the backend factory function during
+ * static initialization. Use this in your backend implementation (.cpp) file.
+ *
+ * @param ClassName The backend class name (e.g., FooBackend)
+ * @param TypeString The type string for this backend (e.g., "foo")
+ *
+ * Example usage:
+ * @code
+ * namespace trossen::io::backends { REGISTER_BACKEND(FooBackend, "foo")
+ * }
+ * @endcode
+ */
+#define REGISTER_BACKEND(ClassName, TypeString)                                          \
+  namespace {                                                                            \
+  struct ClassName##Registrar {                                                          \
+    ClassName##Registrar() {                                                             \
+      ::trossen::io::BackendRegistry::register_backend(                                  \
+        TypeString,                                                                      \
+        [](::trossen::io::Backend::Config& cfg) -> std::shared_ptr<::trossen::io::Backend> { \
+          return std::make_shared<ClassName>(static_cast<ClassName::Config&>(cfg));     \
+        });                                                                              \
+    }                                                                                    \
+  };                                                                                     \
+  static ClassName##Registrar ClassName##_registrar_instance;                           \
+  }  /* anonymous namespace */
+
+}  // namespace trossen::io
+
+#endif  // TROSSEN_SDK__IO__BACKEND_REGISTRY_HPP

--- a/include/trossen_sdk/trossen_sdk.hpp
+++ b/include/trossen_sdk/trossen_sdk.hpp
@@ -16,6 +16,7 @@
 #include "trossen_sdk/hw/camera/opencv_producer.hpp"
 
 #include "trossen_sdk/io/backend.hpp"
+#include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/trossen/trossen_backend.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_backend.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_schemas.hpp"

--- a/src/backends/backend_registry.cpp
+++ b/src/backends/backend_registry.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file backend_registry.cpp
+ * @brief Implementation of the backend registry.
+ */
+
+#include "trossen_sdk/io/backend_registry.hpp"
+
+namespace trossen::io {
+
+std::map<std::string, BackendRegistry::FactoryFunc>& BackendRegistry::get_registry() {
+  // This static variable is the singleton registry map and is initialized on first use.
+  static std::map<std::string, FactoryFunc> registry;
+  return registry;
+}
+
+void BackendRegistry::register_backend(const std::string& type, FactoryFunc factory) {
+  auto& registry = get_registry();
+  if (registry.find(type) != registry.end()) {
+    throw std::runtime_error("Backend type '" + type + "' is already registered");
+  }
+  registry[type] = factory;
+}
+
+std::shared_ptr<Backend> BackendRegistry::create(const std::string& type, Backend::Config& config) {
+  auto& registry = get_registry();
+  auto it = registry.find(type);
+  if (it == registry.end()) {
+    throw std::runtime_error("Unsupported backend type: '" + type + "'");
+  }
+  return it->second(config);
+}
+
+bool BackendRegistry::is_registered(const std::string& type) {
+  auto& registry = get_registry();
+  return registry.find(type) != registry.end();
+}
+
+}  // namespace trossen::io

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -20,13 +20,16 @@
 #include "parquet/arrow/reader.h"
 
 #include "trossen_sdk/data/record.hpp"
-#include "trossen_sdk/io/backends/lerobot/lerobot_backend.hpp"
 #include "trossen_sdk/hw/arm/teleop_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp"
-#include "trossen_sdk/hw/camera/opencv_producer.hpp"
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
+#include "trossen_sdk/hw/camera/opencv_producer.hpp"
+#include "trossen_sdk/io/backend_registry.hpp"
+#include "trossen_sdk/io/backends/lerobot/lerobot_backend.hpp"
 
 namespace trossen::io::backends {
+
+REGISTER_BACKEND(LeRobotBackend, "lerobot")
 
 namespace fs = std::filesystem;
 

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -13,11 +13,14 @@
 
 #include "JointState.pb.h"
 #include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_backend.hpp"
 #include "trossen_sdk/version.hpp"
 
 
 namespace trossen::io::backends {
+
+REGISTER_BACKEND(McapBackend, "mcap")
 
 McapBackend::McapBackend(Config cfg)
   : io::Backend(cfg.output_path), cfg_(std::move(cfg)) {}

--- a/src/backends/null/null_backend.cpp
+++ b/src/backends/null/null_backend.cpp
@@ -4,8 +4,11 @@
  */
 
 #include "trossen_sdk/io/backends/null/null_backend.hpp"
+#include "trossen_sdk/io/backend_registry.hpp"
 
 namespace trossen::io::backends {
+
+REGISTER_BACKEND(NullBackend, "null")
 
 NullBackend::NullBackend(const Config& cfg) : Backend(cfg.uri) {}
 

--- a/src/backends/trossen/trossen_backend.cpp
+++ b/src/backends/trossen/trossen_backend.cpp
@@ -13,9 +13,12 @@
 #include "opencv2/imgcodecs.hpp"
 
 #include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/trossen/trossen_backend.hpp"
 
 namespace trossen::io::backends {
+
+REGISTER_BACKEND(TrossenBackend, "trossen")
 
 namespace fs = std::filesystem;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,8 +20,13 @@ add_executable(test_null_backend test_null_backend.cpp)
 target_link_libraries(test_null_backend PRIVATE trossen_sdk GTest::gtest_main)
 add_test(NAME test_null_backend COMMAND test_null_backend)
 
+add_executable(test_backend_registry test_backend_registry.cpp)
+target_link_libraries(test_backend_registry PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_backend_registry COMMAND test_backend_registry)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
 gtest_discover_tests(test_record)
 gtest_discover_tests(test_null_backend)
+gtest_discover_tests(test_backend_registry)

--- a/tests/test_backend_registry.cpp
+++ b/tests/test_backend_registry.cpp
@@ -1,0 +1,178 @@
+/**
+ * @file test_backend_registry.cpp
+ * @brief Unit tests for BackendRegistry
+ */
+
+#include <memory>
+#include <stdexcept>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/io/backend_registry.hpp"
+#include "trossen_sdk/io/backends/null/null_backend.hpp"
+#include "trossen_sdk/io/backends/mcap/mcap_backend.hpp"
+
+using trossen::io::BackendRegistry;
+using trossen::io::Backend;
+using trossen::io::backends::NullBackend;
+using trossen::io::backends::McapBackend;
+
+// Test that common backend types are registered
+TEST(BackendRegistryTest, CommonBackendsAreRegistered) {
+  EXPECT_TRUE(BackendRegistry::is_registered("lerobot"));
+  EXPECT_TRUE(BackendRegistry::is_registered("mcap"));
+  EXPECT_TRUE(BackendRegistry::is_registered("null"));
+  EXPECT_TRUE(BackendRegistry::is_registered("trossen"));
+}
+
+// Test that unknown backend types are not registered
+TEST(BackendRegistryTest, UnknownBackendNotRegistered) {
+  EXPECT_FALSE(BackendRegistry::is_registered("unknown"));
+  EXPECT_FALSE(BackendRegistry::is_registered(""));
+}
+
+// Test creating a NullBackend through the registry
+TEST(BackendRegistryTest, CreateNullBackend) {
+  NullBackend::Config cfg;
+  cfg.type = "null";
+  cfg.uri = "null://test";
+
+  auto backend = BackendRegistry::create("null", cfg);
+  ASSERT_NE(backend, nullptr);
+
+  // Verify it works as expected
+  EXPECT_TRUE(backend->open());
+
+  // Write a test record
+  trossen::data::JointStateRecord record;
+  record.ts = trossen::data::make_timestamp_now();
+  record.seq = 1;
+  record.id = "test/joints";
+  record.positions = {1.0f, 2.0f, 3.0f};
+
+  backend->write(record);
+  backend->flush();
+  backend->close();
+
+  // Verify it's actually a NullBackend
+  auto* null_backend = dynamic_cast<NullBackend*>(backend.get());
+  ASSERT_NE(null_backend, nullptr);
+  EXPECT_EQ(null_backend->count(), 1);
+}
+
+// Test creating an McapBackend through the registry
+TEST(BackendRegistryTest, CreateMcapBackend) {
+  McapBackend::Config cfg;
+  cfg.type = "mcap";
+  cfg.output_path = "/tmp/test_registry.mcap";
+  cfg.robot_name = "test_robot";
+  cfg.dataset_id = "test_dataset";
+  cfg.episode_index = 0;
+
+  auto backend = BackendRegistry::create("mcap", cfg);
+  ASSERT_NE(backend, nullptr);
+
+  // Verify it's actually an McapBackend
+  auto* mcap_backend = dynamic_cast<McapBackend*>(backend.get());
+  ASSERT_NE(mcap_backend, nullptr);
+}
+
+// Test registry with different backend configurations
+TEST(BackendRegistryTest, MultipleBackendsWithDifferentConfigs) {
+  // Create first null backend
+  NullBackend::Config cfg1;
+  cfg1.type = "null";
+  cfg1.uri = "null://instance1";
+  auto backend1 = BackendRegistry::create("null", cfg1);
+  ASSERT_NE(backend1, nullptr);
+
+  // Create second null backend with different config
+  NullBackend::Config cfg2;
+  cfg2.type = "null";
+  cfg2.uri = "null://instance2";
+  auto backend2 = BackendRegistry::create("null", cfg2);
+  ASSERT_NE(backend2, nullptr);
+
+  // Both should be independent
+  EXPECT_NE(backend1.get(), backend2.get());
+
+  // Create mcap backend
+  McapBackend::Config cfg3;
+  cfg3.type = "mcap";
+  cfg3.output_path = "/tmp/test.mcap";
+  auto backend3 = BackendRegistry::create("mcap", cfg3);
+  ASSERT_NE(backend3, nullptr);
+
+  // Should be different types
+  EXPECT_EQ(dynamic_cast<NullBackend*>(backend3.get()), nullptr);
+  EXPECT_EQ(dynamic_cast<McapBackend*>(backend1.get()), nullptr);
+}
+
+// Test that base Backend::Config works with proper downcasting
+TEST(BackendRegistryTest, ConfigDowncasting) {
+  // Create config as concrete type
+  NullBackend::Config null_cfg;
+  null_cfg.type = "null";
+  null_cfg.uri = "null://downcast_test";
+
+  // Pass as base reference (simulating SessionManager usage)
+  Backend::Config& base_cfg = null_cfg;
+
+  auto backend = BackendRegistry::create("null", base_cfg);
+  ASSERT_NE(backend, nullptr);
+
+  auto* null_backend = dynamic_cast<NullBackend*>(backend.get());
+  ASSERT_NE(null_backend, nullptr);
+}
+
+// Test polymorphic behavior through registry
+TEST(BackendRegistryTest, PolymorphicBackendUsage) {
+  NullBackend::Config cfg;
+  cfg.type = "null";
+
+  // Create through registry, use through base class interface
+  std::shared_ptr<Backend> backend = BackendRegistry::create("null", cfg);
+
+  // All backends should support these operations
+  EXPECT_TRUE(backend->open());
+
+  trossen::data::JointStateRecord record;
+  record.ts = trossen::data::make_timestamp_now();
+  record.seq = 1;
+  record.id = "test";
+
+  backend->write(record);
+  backend->flush();
+  backend->close();
+}
+
+// Demo test showing typical usage pattern
+TEST(BackendRegistryTest, TypicalUsageDemo) {
+  // Simulate selecting backend type at runtime (e.g., from config file)
+  std::string backend_type = "null";
+
+  // Create appropriate config based on type
+  std::unique_ptr<Backend::Config> cfg;
+  if (backend_type == "null") {
+    auto null_cfg = std::make_unique<NullBackend::Config>();
+    null_cfg->type = "null";
+    null_cfg->uri = "null://demo";
+    cfg = std::move(null_cfg);
+  } else if (backend_type == "mcap") {
+    auto mcap_cfg = std::make_unique<McapBackend::Config>();
+    mcap_cfg->type = "mcap";
+    mcap_cfg->output_path = "/tmp/demo.mcap";
+    cfg = std::move(mcap_cfg);
+  }
+
+  ASSERT_NE(cfg, nullptr);
+
+  // Create backend through registry
+  auto backend = BackendRegistry::create(backend_type, *cfg);
+  ASSERT_NE(backend, nullptr);
+
+  // Use backend polymorphically
+  EXPECT_TRUE(backend->open());
+  backend->close();
+}


### PR DESCRIPTION
This PR does the following:

- Adds a backend registry system, allowing users to build backends without hardcoding or explicit type checking
- Adds a registry macro that statically registers a backend
- Adds tests for the backend registry/factor
- Adds a script demonstrating how to use the registry
- Implements the null backend in its source file to guarantee proper linking