### PR TITLE
Integrate backend registry with session manager

### DIFF
--- a/include/trossen_sdk/io/backend.hpp
+++ b/include/trossen_sdk/io/backend.hpp
@@ -15,6 +15,7 @@
 #include <string>
 
 #include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/types.hpp"
 
 namespace trossen::io {
 
@@ -47,6 +48,24 @@ public:
      */
     virtual ~Config() = default;
   };
+
+  /**
+   * @brief Prepare backend for a new episode with runtime parameters
+   *
+   * @param output_path Base output path for this episode
+   * @param episode_index Zero-based episode index
+   * @param dataset_id Dataset identifier
+   * @param repository_id Repository identifier (may be empty)
+   *
+   * This method is called after backend construction but before open() to allow backends to
+   * configure episode-specific paths and metadata. Default implementation does nothing (backends
+   * that don't need per-episode customization can ignore this).
+   */
+  virtual void preprocess_episode(
+    const std::string& output_path,
+    uint32_t episode_index,
+    const std::string& dataset_id = "",
+    const std::string& repository_id = "") {}
 
   /**
    * @brief Open a logging destination

--- a/include/trossen_sdk/io/backend_registry.hpp
+++ b/include/trossen_sdk/io/backend_registry.hpp
@@ -14,8 +14,11 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
+#include "trossen_sdk/hw/producer_base.hpp"
 #include "trossen_sdk/io/backend.hpp"
+#include "trossen_sdk/types.hpp"
 
 namespace trossen::io {
 
@@ -27,7 +30,9 @@ namespace trossen::io {
 class BackendRegistry {
 public:
   /// @brief Factory function signature for creating backend instances
-  using FactoryFunc = std::function<std::shared_ptr<Backend>(Backend::Config&)>;
+  using FactoryFunc = std::function<std::shared_ptr<Backend>(
+    Backend::Config&,
+    const ProducerMetadataList&)>;
 
   /**
    * @brief Register a backend factory function
@@ -47,6 +52,7 @@ public:
    *
    * @param type Backend type string
    * @param config Backend configuration (must be compatible with registered type)
+   * @param producer_metadatas Optional vector of producer metadata (used by some backends)
    *
    * @return Shared pointer to created backend instance
    *
@@ -55,7 +61,10 @@ public:
    * @note The config reference is downcast to the appropriate concrete config type by the
    *       registered factory function.
    */
-  static std::shared_ptr<Backend> create(const std::string& type, Backend::Config& config);
+  static std::shared_ptr<Backend> create(
+    const std::string& type,
+    Backend::Config& config,
+    const ProducerMetadataList& producer_metadatas = {});
 
   /**
    * @brief Check if a backend type is registered
@@ -97,8 +106,10 @@ private:
     ClassName##Registrar() {                                                             \
       ::trossen::io::BackendRegistry::register_backend(                                  \
         TypeString,                                                                      \
-        [](::trossen::io::Backend::Config& cfg) -> std::shared_ptr<::trossen::io::Backend> { \
-          return std::make_shared<ClassName>(static_cast<ClassName::Config&>(cfg));     \
+        [](::trossen::io::Backend::Config& cfg,                                          \
+           const ::trossen::ProducerMetadataList& metadata)                              \
+             -> std::shared_ptr<::trossen::io::Backend> {                                \
+          return std::make_shared<ClassName>(static_cast<ClassName::Config&>(cfg), metadata); \
         });                                                                              \
     }                                                                                    \
   };                                                                                     \

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -121,7 +121,21 @@ public:
    */
   explicit LeRobotBackend(
     Config cfg,
-    std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> metadata);
+    ProducerMetadataList metadata);
+
+  /**
+   * @brief Prepare backend for a new episode
+   *
+   * @param output_path Base output path for this episode
+   * @param episode_index Zero-based episode index
+   * @param dataset_id Dataset identifier
+   * @param repository_id Repository identifier (unused)
+   */
+  void preprocess_episode(
+    const std::string& output_path,
+    uint32_t episode_index,
+    const std::string& dataset_id,
+    const std::string& repository_id) override;
 
   /**
    * @brief Open a LeRobot V2 logging destination
@@ -417,7 +431,7 @@ private:
   Config cfg_;
 
   /// @brief Metadata for this backend
-  std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> metadata_;
+  ProducerMetadataList metadata_;
 
   /// @brief Store camera names from metadata for easy access
   std::vector<std::string> camera_names_;

--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -75,13 +75,30 @@ public:
    * @brief Construct an McapBackend with the given configuration
    *
    * @param cfg Configuration options
+   * @param metadata Optional producer metadata
    */
-  explicit McapBackend(Config cfg);
+  explicit McapBackend(
+    Config cfg,
+    const ProducerMetadataList& metadata = {});
 
   /**
    * @brief Destructor
    */
   ~McapBackend() override;
+
+  /**
+   * @brief Prepare backend for a new episode
+   *
+   * @param output_path Output file path for this episode
+   * @param episode_index Zero-based episode index (unused)
+   * @param dataset_id Dataset identifier (unused)
+   * @param repository_id Repository identifier (unused)
+   */
+  void preprocess_episode(
+    const std::string& output_path,
+    uint32_t episode_index,
+    const std::string& dataset_id,
+    const std::string& repository_id) override;
 
   /**
    * @brief Open the MCAP writer

--- a/include/trossen_sdk/io/backends/null/null_backend.hpp
+++ b/include/trossen_sdk/io/backends/null/null_backend.hpp
@@ -7,7 +7,10 @@
 #define TROSSEN_SDK__IO__BACKENDS__NULL_BACKEND_HPP
 
 #include <atomic>
+#include <memory>
+#include <vector>
 
+#include "trossen_sdk/hw/producer_base.hpp"
 #include "trossen_sdk/io/backend.hpp"
 
 namespace trossen::io::backends {
@@ -31,8 +34,11 @@ public:
    * @brief Construct a NullBackend with the given configuration
    *
    * @param cfg Configuration options
+   * @param metadata Optional producer metadata
    */
-  explicit NullBackend(const Config& cfg);
+  explicit NullBackend(
+    const Config& cfg,
+    const ProducerMetadataList& metadata = {});
 
   /**
    * @brief Open a null logging destination

--- a/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
@@ -69,9 +69,12 @@ public:
   /**
    * @brief Construct a TrossenBackend
    *
-   * @param cfg Configuration parameters
+   * @param cfg Configuration options
+   * @param metadata Optional producer metadata
    */
-  explicit TrossenBackend(Config cfg);
+  explicit TrossenBackend(
+    Config cfg,
+    const ProducerMetadataList& metadata = {});
 
   /**
    * @brief Open a LeRobot V2 logging destination

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -260,7 +260,7 @@ private:
   std::shared_ptr<io::Backend> create_backend(
     const std::string& output_path,
     uint32_t episode_index,
-    const std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>>& producer_metadatas);
+    const ProducerMetadataList& producer_metadatas);
 
   /**
    * @brief Background monitoring loop for auto-stop

--- a/include/trossen_sdk/types.hpp
+++ b/include/trossen_sdk/types.hpp
@@ -1,0 +1,21 @@
+/**
+ * @file types.hpp
+ * @brief Common type definitions for Trossen SDK.
+ */
+
+#ifndef TROSSEN_SDK__TYPES_HPP
+#define TROSSEN_SDK__TYPES_HPP
+
+#include <memory>
+#include <vector>
+
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen
+{
+
+using ProducerMetadataList = std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>>;
+
+}  // namespace trossen
+
+#endif  // TROSSEN_SDK__TYPES_HPP

--- a/src/backends/backend_registry.cpp
+++ b/src/backends/backend_registry.cpp
@@ -21,13 +21,17 @@ void BackendRegistry::register_backend(const std::string& type, FactoryFunc fact
   registry[type] = factory;
 }
 
-std::shared_ptr<Backend> BackendRegistry::create(const std::string& type, Backend::Config& config) {
+std::shared_ptr<Backend> BackendRegistry::create(
+  const std::string& type,
+  Backend::Config& config,
+  const ProducerMetadataList& producer_metadatas)
+{
   auto& registry = get_registry();
   auto it = registry.find(type);
   if (it == registry.end()) {
     throw std::runtime_error("Unsupported backend type: '" + type + "'");
   }
-  return it->second(config);
+  return it->second(config, producer_metadatas);
 }
 
 bool BackendRegistry::is_registered(const std::string& type) {

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -35,7 +35,7 @@ namespace fs = std::filesystem;
 
 LeRobotBackend::LeRobotBackend(
   Config cfg,
-  std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> metadata = {})
+  ProducerMetadataList metadata = {})
   : io::Backend(cfg.output_dir), cfg_(std::move(cfg)), metadata_(std::move(metadata))
 {
   // Validate encoder threads
@@ -46,6 +46,20 @@ LeRobotBackend::LeRobotBackend(
   if (cfg_.png_compression_level < 0 || cfg_.png_compression_level > 9) {
     cfg_.png_compression_level = 3;
   }
+}
+
+void LeRobotBackend::preprocess_episode(
+  const std::string& output_path,
+  uint32_t episode_index,
+  const std::string& dataset_id,
+  const std::string& repository_id)
+{
+  // Update config with episode-specific values
+  cfg_.output_dir = output_path;
+  cfg_.episode_index = episode_index;
+  cfg_.dataset_id = dataset_id;
+  cfg_.repository_id = repository_id;
+
   // Create a root folder for dataset using repo-id and dataset-name and default root
 
   // URI is absolute path to output directory. Set to absolute path and check write access.

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -22,9 +22,21 @@ namespace trossen::io::backends {
 
 REGISTER_BACKEND(McapBackend, "mcap")
 
-McapBackend::McapBackend(Config cfg)
+McapBackend::McapBackend(
+  Config cfg,
+  const ProducerMetadataList&)
   : io::Backend(cfg.output_path), cfg_(std::move(cfg)) {}
 McapBackend::~McapBackend() { close(); }
+
+void McapBackend::preprocess_episode(
+  const std::string& output_path,
+  uint32_t episode_index,
+  const std::string& dataset_id,
+  const std::string& repository_id)
+{
+  cfg_.output_path = output_path;
+  uri_ = output_path;
+}
 
 bool McapBackend::open() {
   std::scoped_lock lk(writer_mutex_);

--- a/src/backends/null/null_backend.cpp
+++ b/src/backends/null/null_backend.cpp
@@ -10,7 +10,10 @@ namespace trossen::io::backends {
 
 REGISTER_BACKEND(NullBackend, "null")
 
-NullBackend::NullBackend(const Config& cfg) : Backend(cfg.uri) {}
+NullBackend::NullBackend(
+  const Config& cfg,
+  const ProducerMetadataList&)
+  : Backend(cfg.uri) {}
 
 bool NullBackend::open() {
   opened_ = true;

--- a/src/backends/trossen/trossen_backend.cpp
+++ b/src/backends/trossen/trossen_backend.cpp
@@ -22,8 +22,11 @@ REGISTER_BACKEND(TrossenBackend, "trossen")
 
 namespace fs = std::filesystem;
 
-TrossenBackend::TrossenBackend(Config cfg)
-  : Backend(cfg.output_dir), cfg_(std::move(cfg)) {
+TrossenBackend::TrossenBackend(
+  Config cfg,
+  const ProducerMetadataList&)
+  : io::Backend(cfg.output_dir), cfg_(std::move(cfg))
+{
   // Validate encoder threads
   if (cfg_.encoder_threads <= 0) {
     cfg_.encoder_threads = 1;

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 
 namespace trossen::runtime {
@@ -117,7 +118,7 @@ bool SessionManager::start_episode() {
   // Build episode file path
   auto path = build_episode_path(next_episode_index_);
 
-  std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>> producer_metadata;
+  ProducerMetadataList producer_metadata;
 
   // Fetch Metadata from producers as a vector of the base class
   for (const auto& pt : producer_tasks_) {
@@ -329,8 +330,6 @@ SessionManager::Stats SessionManager::stats() const {
   return s;
 }
 
-
-
 std::filesystem::path SessionManager::build_episode_path(uint32_t index) const {
   // Generate filename: episode_NNNNNN.mcap (6-digit zero-padded)
   // TODO(lukeschmitt-tr): This is specific to MCAP files; consider making more generic
@@ -353,39 +352,26 @@ std::filesystem::path SessionManager::build_episode_path(uint32_t index) const {
 std::shared_ptr<io::Backend> SessionManager::create_backend(
   const std::string& output_path,
   uint32_t episode_index,
-  const std::vector<std::shared_ptr<hw::PolledProducer::ProducerMetadata>>& producer_metadatas)
+  const ProducerMetadataList& producer_metadatas)
 {
   if (config_.backend_config == nullptr) {
     throw std::runtime_error("SessionManager::create_backend: backend_config is null");
-  } else if (config_.backend_config->type == "lerobot") {
-      // Copy backend config template and customize for this episode
-    auto* lerobot_cfg =
-      static_cast<io::backends::LeRobotBackend::Config*>(config_.backend_config.get());
-    lerobot_cfg->output_dir = output_path;
-    if (!lerobot_cfg) {
-      throw std::runtime_error(
-        "SessionManager::create_backend: backend_config is not LeRobotBackend::Config");
-    }
-    lerobot_cfg->dataset_id = config_.dataset_id;
-    lerobot_cfg->episode_index = episode_index;
-    // TODO(shantanuparab-tr): Use the producer metadata to populate backend metadata
-    // Print registered producers
-    std::cout << "\nRegistered Producers Metadata:\n";
-    for (const auto& pm : producer_metadatas) {
-      std::cout << "  [ID: " << pm->id << "] Name: " << pm->name << "\n";
-      std::cout << "      Description: " << pm->description << "\n";
-    }
-
-    return std::make_shared<io::backends::LeRobotBackend>(*lerobot_cfg, producer_metadatas);
-  } else if (config_.backend_config->type == "mcap") {
-    // Copy backend config template and customize for this episode
-    auto* mcap_cfg = static_cast<io::backends::McapBackend::Config*>(config_.backend_config.get());
-    mcap_cfg->output_path = output_path;
-    return std::make_shared<io::backends::McapBackend>(*mcap_cfg);
-  } else {
-    throw std::runtime_error(
-      "SessionManager::create_backend: Unsupported backend type: " + config_.backend_config->type);
   }
+
+  // Create backend instance via registry
+  auto backend = io::BackendRegistry::create(
+    config_.backend_config->type,
+    *config_.backend_config,
+    producer_metadatas);
+
+  // Let the backend configure itself for this episode
+  backend->preprocess_episode(
+    output_path,
+    episode_index,
+    config_.dataset_id,
+    config_.repository_id);
+
+  return backend;
 }
 
 void SessionManager::monitor_duration() {


### PR DESCRIPTION
This PR does the following:
* Adds a new `preprocess_episode` method to backends, allowing them to do any pre-recording logic needed, like further parsing config after initialization, creating directories, and anything else they may need
* Integrates the backend registry into the session manager