### PR TITLE
Add JSON configuration system with backend configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(trossen_sdk SHARED
   src/hw/camera/mock_producer.cpp
   src/hw/camera/mock_synced_producer.cpp
   src/runtime/session_manager.cpp
+  src/configuration/global_config.cpp
+  src/configuration/loaders/json_loader.cpp
 )
 
 # Add architecture-specific CMAKE_PREFIX_PATH

--- a/config/sdk_config.json
+++ b/config/sdk_config.json
@@ -1,0 +1,28 @@
+{
+  "lerobot_backend": {
+    "type": "lerobot_backend",
+    "output_dir": "/data/lerobot_output",
+    "encoder_threads": 2,
+    "max_image_queue": 10,
+    "png_compression_level": 5,
+    "override_existing": true,
+    "encode_videos": true,
+    "task_name": "widowxai_pick_and_place",
+    "repository_id": "trossen-roboticsd/widowxai_dataset",
+    "dataset_id": "widowxai_v1",
+    "root_path": "/data/widowxai_dataset",
+    "episode_index": 0,
+    "robot_name": "widowxai",
+    "fps": 30.0
+  },
+  "mcap_backend": {
+    "type": "mcap_backend",
+    "output_dir": "/data/mcap_output",
+    "robot_name": "/robot/joint_states",
+    "chunk_size_bytes": 4194304,
+    "compression": "zstd",
+    "dataset_id": "mcap_dataset_v1",
+    "episode_index": 0
+  }
+}
+

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -31,6 +31,8 @@
 #include "trossen_sdk/hw/camera/opencv_producer.hpp"
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
 #include "trossen_sdk/io/backend_utils.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
 
 #include "./demo_utils.hpp"
 
@@ -142,6 +144,14 @@ int main(int argc, char** argv) {
     print_usage(argv[0]);
     return 0;
   }
+  if (!std::filesystem::exists("config/sdk_config.json")) {
+    std::cerr << "Error: config/sdk_config.json not found!" << std::endl;
+    return 1;
+  }
+
+  // Create and load global configuration
+  auto j = JsonLoader::load("config/sdk_config.json");
+  GlobalConfig::instance().load_from_json(j);
 
   // Print configuration
   std::vector<std::string> config_lines = {

--- a/include/trossen_sdk/configuration/config_registry.hpp
+++ b/include/trossen_sdk/configuration/config_registry.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include <memory>
+#include <unordered_map>
+#include <functional>
+#include <nlohmann/json.hpp>
+#include "i_config.hpp"
+
+class ConfigRegistry {
+public:
+    using BuilderFn = std::function<std::shared_ptr<IConfig>(const nlohmann::json&)>;
+
+    static ConfigRegistry& instance() {
+        static ConfigRegistry r;
+        return r;
+    }
+
+    void register_type(const std::string& name, BuilderFn fn) {
+        registry_[name] = fn;
+    }
+
+    std::shared_ptr<IConfig> create(const nlohmann::json& j) {
+        std::string type = j.at("type");
+        auto it = registry_.find(type);
+        if (it == registry_.end()) {
+            throw std::runtime_error("Unknown config type: " + type);
+        }
+        return it->second(j);
+    }
+
+private:
+    std::unordered_map<std::string, BuilderFn> registry_;
+};
+
+#define REGISTER_CONFIG(Type, Name) \
+    static bool reg_##Type = [](){ \
+        ConfigRegistry::instance().register_type(Name, \
+            [](const nlohmann::json& j){ return std::make_shared<Type>(Type::from_json(j)); } \
+        ); \
+        return true; \
+    }();

--- a/include/trossen_sdk/configuration/global_config.hpp
+++ b/include/trossen_sdk/configuration/global_config.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <unordered_map>
+#include <memory>
+#include <string>
+#include "i_config.hpp"
+#include <nlohmann/json.hpp>
+
+class GlobalConfig {
+public:
+    static GlobalConfig& instance();
+
+    void load_from_json(const nlohmann::json& j);
+
+    std::shared_ptr<IConfig> get(const std::string& key) const;
+
+    template<typename T>
+    std::shared_ptr<T> get_as(const std::string& key) const {
+        return std::static_pointer_cast<T>(get(key));
+    }
+
+private:
+    std::unordered_map<std::string, std::shared_ptr<IConfig>> config_map_;
+};

--- a/include/trossen_sdk/configuration/global_config.hpp
+++ b/include/trossen_sdk/configuration/global_config.hpp
@@ -15,7 +15,19 @@ public:
 
     template<typename T>
     std::shared_ptr<T> get_as(const std::string& key) const {
-        return std::static_pointer_cast<T>(get(key));
+        auto base = get(key);
+        if (!base) {
+            throw std::runtime_error("Config key not found: " + key);
+        }
+
+        auto casted = std::dynamic_pointer_cast<T>(base);
+        if (!casted) {
+            throw std::runtime_error(
+                "Config key '" + key + "' has wrong type"
+            );
+        }
+
+        return casted;
     }
 
 private:

--- a/include/trossen_sdk/configuration/i_config.hpp
+++ b/include/trossen_sdk/configuration/i_config.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+struct IConfig {
+    virtual ~IConfig() = default;
+    virtual std::string type() const = 0;
+};

--- a/include/trossen_sdk/configuration/loaders/json_loader.hpp
+++ b/include/trossen_sdk/configuration/loaders/json_loader.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+#include <nlohmann/json.hpp>
+
+class JsonLoader {
+public:
+    static nlohmann::json load(const std::string& path);
+};

--- a/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include "../../i_config.hpp"
+// #include "../../json.hpp"
+#include "../../config_registry.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
+
+struct LeRobotBackendConfig : public IConfig {
+    std::string output_dir;
+    int encoder_threads{1};
+    int max_image_queue{0};
+    int png_compression_level{3};
+    bool overwrite_existing{false};
+    bool encode_videos{false};
+    std::string task_name{"default_task"};
+    std::string repository_id{"default_repo"};
+    std::string dataset_id{"default_dataset"};
+    std::string root_path{"/data/trossen"};
+    int episode_index{0};
+    std::string robot_name{"trossen_ai_generic"};
+    float fps{30.0f};
+
+    std::string type() const override { return "lerobot_backend"; }
+
+    static LeRobotBackendConfig from_json(const nlohmann::json& j) {
+        LeRobotBackendConfig c;
+        c.output_dir = j.at("output_dir").get<std::string>();
+        c.encoder_threads = j.value("encoder_threads", 1);
+        c.max_image_queue = j.value("max_image_queue", 0);
+        c.png_compression_level = j.value("png_compression_level", 3);
+        // c.drop_policy = j.value("drop_policy", "DropNewest");
+        c.overwrite_existing = j.value("overwrite_existing", false);
+        c.encode_videos = j.value("encode_videos", false);
+        c.task_name = j.value("task_name", "default_task");
+        c.repository_id = j.value("repository_id", "default_repo");
+        c.dataset_id = j.value("dataset_id", "default_dataset");
+        c.root_path = j.value("root_path", trossen::io::backends::get_default_root_path().string());
+        c.episode_index = j.value("episode_index", 0);
+        c.robot_name = j.value("robot_name", "trossen_ai_generic");
+        c.fps = j.value("fps", 30.0f);
+
+        return c;
+    }
+};
+
+REGISTER_CONFIG(LeRobotBackendConfig, "lerobot_backend");

--- a/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include "../../i_config.hpp"
+// #include "../../json.hpp"
+#include "../../config_registry.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
+
+struct McapBackendConfig : public IConfig {
+    std::string output_dir;
+    std::string robot_name{"/robot/joint_states"};
+    int chunk_size_bytes{4 * 1024 * 1024};
+    std::string compression{""};
+    std::string dataset_id;
+    int episode_index{0};
+
+    std::string type() const override { return "mcap_backend"; }
+
+    static  McapBackendConfig from_json(const nlohmann::json& j) {
+        McapBackendConfig c;
+        c.output_dir = j.at("output_dir").get<std::string>();
+        c.robot_name = j.value("robot_name", "/robot/joint_states");
+        c.chunk_size_bytes = j.value("chunk_size_bytes", 4 * 1024 * 1024);
+        c.compression = j.value("compression", "");
+        c.dataset_id = j.at("dataset_id").get<std::string>();
+        c.episode_index = j.value("episode_index", 0);
+
+        return c;
+    }
+};
+
+REGISTER_CONFIG(McapBackendConfig, "mcap_backend");

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -25,6 +25,7 @@
 #include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/io/backend.hpp"
 #include "trossen_sdk/io/backends/lerobot/lerobot_constants.hpp"
+#include "trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp"
 
 namespace trossen::io::backends {
 
@@ -471,6 +472,9 @@ private:
 
   /// @brief Hash map to store the frame indices for each source
   std::unordered_map<std::string, uint64_t> source_frame_indices_;
+
+  /// @brief Test Config
+  std::shared_ptr<LeRobotBackendConfig> test_config_;
 };
 
 }  // namespace trossen::io::backends

--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -23,6 +23,7 @@
 
 #include "trossen_sdk/io/backend.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_schemas.hpp"
+#include "trossen_sdk/configuration/types/backends/mcap_backend_config.hpp"
 
 namespace trossen::io::backends {
 
@@ -220,6 +221,9 @@ private:
 
   /// @brief Statistics about written records
   Stats stats_{};
+
+  /// @brief Test Config
+  std::shared_ptr<McapBackendConfig> test_config_;
 };
 
 }  // namespace trossen::io::backends

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -26,6 +26,7 @@
 #include "trossen_sdk/hw/camera/opencv_producer.hpp"
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/lerobot/lerobot_backend.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
 
 namespace trossen::io::backends {
 
@@ -46,6 +47,35 @@ LeRobotBackend::LeRobotBackend(
   if (cfg_.png_compression_level < 0 || cfg_.png_compression_level > 9) {
     cfg_.png_compression_level = 3;
   }
+
+  // This allows us to access the global configuration for the LeRobot backend
+  // without passing it explicitly.
+
+  test_config_ = GlobalConfig::instance().get_as<LeRobotBackendConfig>("lerobot_backend");
+
+  if (!test_config_) {
+        std::cerr << "Backend config not found!" << std::endl;
+        return;
+  }
+
+  // Print the stored values
+  std::cout << "================= LeRobot Backend Config =================" << std::endl;
+  std::cout << "Backend Config Loaded:" << std::endl;
+  std::cout << "  storage_path = " << test_config_->output_dir << std::endl;
+  std::cout << "  encoder_threads = " << test_config_->encoder_threads << std::endl;
+  std::cout << "  max_image_queue = " << test_config_->max_image_queue << std::endl;
+  std::cout << "  png_compression_level = " << test_config_->png_compression_level << std::endl;
+  std::cout << "  overwrite_existing = " << (test_config_->overwrite_existing ? "true" : "false") << std::endl;
+  std::cout << "  encode_videos = " << (test_config_->encode_videos ? "true" : "false") << std::endl;
+  std::cout << "  task_name = " << test_config_->task_name << std::endl;
+  std::cout << "  repository_id = " << test_config_->repository_id << std::endl;
+  std::cout << "  dataset_id = " << test_config_->dataset_id << std::endl;
+  std::cout << "  root_path = " << test_config_->root_path << std::endl;
+  std::cout << "  episode_index = " << test_config_->episode_index << std::endl;
+  std::cout << "  robot_name = " << test_config_->robot_name << std::endl;
+  std::cout << "  fps = " << test_config_->fps << std::endl;
+  std::cout << "==========================================================" << std::endl;
+
 }
 
 void LeRobotBackend::preprocess_episode(

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -16,6 +16,9 @@
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_backend.hpp"
 #include "trossen_sdk/version.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/types/backends/mcap_backend_config.hpp"
+
 
 
 namespace trossen::io::backends {
@@ -25,7 +28,28 @@ REGISTER_BACKEND(McapBackend, "mcap")
 McapBackend::McapBackend(
   Config cfg,
   const ProducerMetadataList&)
-  : io::Backend(cfg.output_path), cfg_(std::move(cfg)) {}
+  : io::Backend(cfg.output_path), cfg_(std::move(cfg)) {
+
+
+  // This allows us to access the global configuration for the Mcap backend
+  // without passing it explicitly.
+
+  test_config_ = GlobalConfig::instance().get_as<McapBackendConfig>("mcap_backend");
+  if (!test_config_) {
+        std::cerr << "Backend config not found!" << std::endl;
+        return;
+  }
+  // Print the stored values
+  std::cout << "================= MCAP Backend Config =================" << std::endl;
+  std::cout << "Output Dir: " << test_config_->output_dir << std::endl;
+  std::cout << "Robot Name: " << test_config_->robot_name << std::endl;
+  std::cout << "Chunk Size Bytes: " << test_config_->chunk_size_bytes << std::endl;
+  std::cout << "Compression: " << test_config_->compression << std::endl;
+  std::cout << "Dataset ID: " << test_config_->dataset_id << std::endl;
+  std::cout << "Episode Index: " << test_config_->episode_index << std::endl;
+  std::cout << "======================================================" << std::endl;
+
+  }
 McapBackend::~McapBackend() { close(); }
 
 void McapBackend::preprocess_episode(

--- a/src/configuration/global_config.cpp
+++ b/src/configuration/global_config.cpp
@@ -1,0 +1,29 @@
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/config_registry.hpp"
+
+GlobalConfig& GlobalConfig::instance() {
+    static GlobalConfig g;
+    return g;
+}
+
+std::shared_ptr<IConfig> GlobalConfig::get(const std::string& key) const {
+    auto it = config_map_.find(key);
+    if (it == config_map_.end()) return nullptr;
+    return it->second;
+}
+
+void GlobalConfig::load_from_json(const nlohmann::json& j) {
+    for (auto& [key, value] : j.items()) {
+
+        // Handle nested namespaces like cameras.wrist
+        if (value.is_object() && !value.contains("type")) {
+            for (auto& [subkey, subvalue] : value.items()) {
+                auto cfg = ConfigRegistry::instance().create(subvalue);
+                config_map_[key + "." + subkey] = cfg;
+            }
+        } else {
+            auto cfg = ConfigRegistry::instance().create(value);
+            config_map_[key] = cfg;
+        }
+    }
+}

--- a/src/configuration/loaders/json_loader.cpp
+++ b/src/configuration/loaders/json_loader.cpp
@@ -1,0 +1,7 @@
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+#include <fstream>
+
+nlohmann::json JsonLoader::load(const std::string& path) {
+    std::ifstream f(path);
+    return nlohmann::json::parse(f);
+}


### PR DESCRIPTION
# Configuration System for Trossen SDK

### TL;DR

Added a configuration system that loads settings from JSON files, with support for backend-specific configurations.

### What changed?

- Created a configuration system with a registry pattern for different config types
- Added a global configuration singleton to access configs throughout the codebase
- Implemented JSON loading functionality for configuration files
- Added specific configuration types for LeRobot and MCAP backends
- Created a default SDK configuration file (`config/sdk_config.json`)
- Updated the WidowXAI example to load and use the configuration system
- Integrated configuration with existing backends to demonstrate functionality

### How to test?

1. Run the WidowXAI example which now loads configuration from `config/sdk_config.json`
2. Verify that both backends (LeRobot and MCAP) print their loaded configuration values
3. Modify values in the config file and confirm the changes are reflected in the output
4. Test with missing configuration file to ensure proper error handling

### Why make this change?

This change improves the SDK's flexibility by:
- Centralizing configuration management instead of hardcoding values
- Making it easier to modify settings without recompiling
- Providing a consistent pattern for adding new configurable components
- Enabling runtime configuration changes through JSON files
- Creating a foundation for more sophisticated configuration management