### PR TITLE
Refactor backend configuration to move episode path handling into backends

### DIFF
--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -223,8 +223,6 @@ int main(int argc, char** argv) {
   // ──────────────────────────────────────────────────────────
 
   trossen::runtime::SessionConfig session_cfg;
-  session_cfg.base_path = cfg.output_dir;
-  session_cfg.dataset_id = cfg.dataset_id;
   session_cfg.max_duration = std::chrono::seconds(cfg.duration_s);
   session_cfg.max_episodes = cfg.episodes;
 

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -279,8 +279,6 @@ int main(int argc, char** argv) {
   }
 
   trossen::runtime::SessionConfig session_cfg;
-  session_cfg.base_path = cfg.output_dir;
-  session_cfg.dataset_id = cfg.dataset_id;
   session_cfg.max_duration = std::chrono::seconds(cfg.duration_s);
   session_cfg.max_episodes = cfg.episodes;
 

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -241,11 +241,8 @@ int main(int argc, char** argv) {
   // ──────────────────────────────────────────────────────────
 
   trossen::runtime::SessionConfig session_cfg;
-  session_cfg.base_path = cfg.output_dir;
-  session_cfg.dataset_id = cfg.dataset_id;
   session_cfg.max_duration = std::chrono::seconds(cfg.duration_s);
   session_cfg.max_episodes = cfg.episodes;
-  session_cfg.repository_id = cfg.repository_id;
 
   if (cfg.backend_type == "mcap") {
     auto mcap_cfg = std::make_unique<trossen::io::backends::McapBackend::Config>();
@@ -253,6 +250,8 @@ int main(int argc, char** argv) {
     mcap_cfg->chunk_size_bytes = 4 * 1024 * 1024;  // 4 MB chunks
     mcap_cfg->robot_name = "/robots/widowxai";
     mcap_cfg->type = "mcap";
+    mcap_cfg->output_path = cfg.output_dir;  // Will be set per episode
+    mcap_cfg->dataset_id = cfg.dataset_id;
     session_cfg.backend_config = std::move(mcap_cfg);
   } else if (cfg.backend_type == "lerobot") {
     auto lerobot_cfg = std::make_unique<trossen::io::backends::LeRobotBackend::Config>();

--- a/include/trossen_sdk/io/backend.hpp
+++ b/include/trossen_sdk/io/backend.hpp
@@ -106,6 +106,7 @@ public:
 
   /**
    * @brief Scan directory for existing episode files and return next index
+   * @return Next episode index to use
    */
   virtual uint32_t scan_existing_episodes() = 0;
 
@@ -124,7 +125,7 @@ protected:
   /// @brief Whether the backend is opened
   bool opened_{false};
 
-  /// @brief Episode index
+  /// @brief Episode index for current recording session
   uint32_t episode_index_{0};
 };
 

--- a/include/trossen_sdk/io/backend.hpp
+++ b/include/trossen_sdk/io/backend.hpp
@@ -29,7 +29,7 @@ public:
    *
    * @param uri Path or logical destination identifier
    */
-  explicit Backend(const std::string& uri) : uri_(uri) {}
+  explicit Backend(){}
 
   /**
    * @brief Virtual destructor
@@ -61,11 +61,7 @@ public:
    * configure episode-specific paths and metadata. Default implementation does nothing (backends
    * that don't need per-episode customization can ignore this).
    */
-  virtual void preprocess_episode(
-    const std::string& output_path,
-    uint32_t episode_index,
-    const std::string& dataset_id = "",
-    const std::string& repository_id = "") {}
+  virtual void preprocess_episode() {}
 
   /**
    * @brief Open a logging destination
@@ -108,12 +104,28 @@ public:
    */
   virtual void close() = 0;
 
+  /**
+   * @brief Scan directory for existing episode files and return next index
+   */
+  virtual uint32_t scan_existing_episodes() = 0;
+
+  /**
+   * @brief Set episode index
+   *
+   * Default implementation sets the episode_index_ member.
+   * Children can override if custom behavior is needed.
+   */
+  virtual void set_episode_index(uint32_t episode_index) {
+    episode_index_ = episode_index;
+  }
+
 protected:
-  /// @brief Destination identifier (file path, etc.)
-  std::string uri_{""};
 
   /// @brief Whether the backend is opened
   bool opened_{false};
+
+  /// @brief Episode index
+  uint32_t episode_index_{0};
 };
 
 }  // namespace trossen::io

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -132,11 +132,7 @@ public:
    * @param dataset_id Dataset identifier
    * @param repository_id Repository identifier (unused)
    */
-  void preprocess_episode(
-    const std::string& output_path,
-    uint32_t episode_index,
-    const std::string& dataset_id,
-    const std::string& repository_id) override;
+  void preprocess_episode() override;
 
   /**
    * @brief Open a LeRobot V2 logging destination
@@ -265,10 +261,9 @@ public:
   /**
    * @brief Scan directory for existing episode files and return next index
    *
-   * @param base_path Directory to scan
    * @return Next episode index (max_found + 1, or 0 if none found)
    */
-  static uint32_t scan_existing_episodes(const std::filesystem::path& base_path);
+   uint32_t scan_existing_episodes() override;
 
   /**
    * @brief Image encoding statistics

--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -95,11 +95,7 @@ public:
    * @param dataset_id Dataset identifier (unused)
    * @param repository_id Repository identifier (unused)
    */
-  void preprocess_episode(
-    const std::string& output_path,
-    uint32_t episode_index,
-    const std::string& dataset_id,
-    const std::string& repository_id) override;
+  void preprocess_episode() override;
 
   /**
    * @brief Open the MCAP writer
@@ -142,10 +138,9 @@ public:
   /**
    * @brief Scan directory for existing episode files and return next index
    *
-   * @param base_path Directory to scan
    * @return Next episode index (max_found + 1, or 0 if none found)
    */
-  static uint32_t scan_existing_episodes(const std::filesystem::path& base_path);
+  uint32_t scan_existing_episodes() override;
 
 private:
   /**

--- a/include/trossen_sdk/io/backends/null/null_backend.hpp
+++ b/include/trossen_sdk/io/backends/null/null_backend.hpp
@@ -78,6 +78,14 @@ public:
    */
   uint64_t count() const;
 
+  /**
+   * @brief Scan directory for existing episode files and return next index
+   */
+  uint32_t scan_existing_episodes() override {
+    // NullBackend has no files, so always return 0
+    return 0;
+  };
+
 private:
   /// @brief Count of records "written"
   std::atomic<uint64_t> count_{0};

--- a/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
@@ -108,6 +108,14 @@ public:
   void close() override;
 
   /**
+   * @brief Scan directory for existing episode files and return next index
+   */
+  uint32_t scan_existing_episodes() override {
+    // TrossenBackend has incomplete implementation, so always return 0
+    return 0;
+  };
+
+  /**
    * @brief Image encoding statistics
    */
   struct ImageEncodeStats {

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -33,23 +33,12 @@ namespace trossen::runtime {
  * @brief Configuration for the Session Manager
  */
 struct SessionConfig {
-  /// @brief Base directory for episode files
-  std::filesystem::path base_path;
-
-  /// @brief Dataset identifier (user-provided or auto-generated UUID)
-  /// @note Empty string triggers auto-generation in constructor
-  std::string dataset_id = "";
 
   /// @brief Maximum duration per episode (nullopt = unlimited)
   std::optional<std::chrono::duration<double>> max_duration = std::chrono::seconds(20);
 
   /// @brief Maximum number of episodes (nullopt = unlimited)
   std::optional<uint32_t> max_episodes = std::nullopt;
-
-  // TODO(shantanuparab-tr): Make this generic or remove it after making backend-agnostic
-
-  /// @brief Repository identifier (used by LeRobot backend)
-  std::string repository_id = "";
 
   /// @brief Backend configuration template (output_path will be overwritten per episode)
   std::unique_ptr<trossen::io::Backend::Config> backend_config;
@@ -242,14 +231,6 @@ private:
   std::vector<ProducerTask> producer_tasks_;
 
   /**
-   * @brief Build episode file path with zero-padded index
-   *
-   * @param index Episode index (0-999999)
-   * @return Full path to episode file (e.g., /data/episode_000042.mcap)
-   */
-  std::filesystem::path build_episode_path(uint32_t index) const;
-
-  /**
    * @brief Create backend instance for the given episode
    *
    * @param output_path Path to output file
@@ -258,8 +239,6 @@ private:
    * @return Shared pointer to backend instance
    */
   std::shared_ptr<io::Backend> create_backend(
-    const std::string& output_path,
-    uint32_t episode_index,
     const ProducerMetadataList& producer_metadatas);
 
   /**

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -37,7 +37,7 @@ namespace fs = std::filesystem;
 LeRobotBackend::LeRobotBackend(
   Config cfg,
   ProducerMetadataList metadata = {})
-  : io::Backend(cfg.output_dir), cfg_(std::move(cfg)), metadata_(std::move(metadata))
+  : io::Backend(), cfg_(std::move(cfg)), metadata_(std::move(metadata))
 {
   // Validate encoder threads
   if (cfg_.encoder_threads <= 0) {
@@ -78,41 +78,30 @@ LeRobotBackend::LeRobotBackend(
 
 }
 
-void LeRobotBackend::preprocess_episode(
-  const std::string& output_path,
-  uint32_t episode_index,
-  const std::string& dataset_id,
-  const std::string& repository_id)
+void LeRobotBackend::preprocess_episode()
 {
-  // Update config with episode-specific values
-  cfg_.output_dir = output_path;
-  cfg_.episode_index = episode_index;
-  cfg_.dataset_id = dataset_id;
-  cfg_.repository_id = repository_id;
-
-  // Create a root folder for dataset using repo-id and dataset-name and default root
-
-  // URI is absolute path to output directory. Set to absolute path and check write access.
-  // Validate output directory path
+  // Root is the base output directory for this episode
+  // Constructed as: output_dir/repository_id/dataset_id/ for LeRobot V2
+  // This is used to form the full paths for images, videos, metadata, and data
   try {
-    uri_ = (fs::path(cfg_.output_dir) / cfg_.repository_id / cfg_.dataset_id).string();
+    root_ = fs::path(cfg_.output_dir) / cfg_.repository_id / cfg_.dataset_id;
   } catch (const std::exception& e) {
     throw std::runtime_error(
       "Failed to resolve absolute path of output directory: " + std::string(e.what()));
   }
   // Validate non-empty path
-  if (uri_.empty()) {
+  if (root_.empty()) {
     throw std::runtime_error("Output directory path is empty");
   }
   // Check that we can write to the output directory
   try {
-    if (!fs::exists(uri_)) {
-      fs::create_directories(uri_);
+    if (!fs::exists(root_)) {
+      fs::create_directories(root_);
     }
   } catch (const std::exception& e) {
     throw std::runtime_error("Failed to create output directory: " + std::string(e.what()));
   }
-  fs::path test_path = fs::path(uri_) / "trossen_sdk_lerobot_v2_test.tmp";
+  fs::path test_path = root_ / "trossen_sdk_lerobot_v2_test.tmp";
   std::ofstream test_file(test_path.string(), std::ios::out | std::ios::trunc);
   if (!test_file) {
     throw std::runtime_error("Failed to open test file for writing: " + test_path.string());
@@ -126,14 +115,13 @@ bool LeRobotBackend::open() {
   if (opened_) {
     return true;
   }
-  root_ = fs::path(uri_);
   std::cout << "=====================================================================" << std::endl;
   std::cout << "Opening LeRobotBackend at: " << root_ << "\n";
   std::cout << "=====================================================================" << std::endl;
 
 
   std::ostringstream oss;
-  oss << "episode_" << std::setfill('0') << std::setw(6) << cfg_.episode_index;
+  oss << "episode_" << std::setfill('0') << std::setw(6) << episode_index_;
 
   // Create images root directory from camera names
   images_root_ = root_ / "images" / "chunk-000";
@@ -266,11 +254,6 @@ void LeRobotBackend::convert_to_videos() const {
 
   const std::string images_path = images_root_.string();
 
-  const fs::path base_path =
-    fs::path(this->config().root_path) /
-    this->config().repository_id /
-    this->config().dataset_id;
-
   std::atomic<int> video_count{0};
   std::mutex log_mutex;
 
@@ -291,7 +274,7 @@ void LeRobotBackend::convert_to_videos() const {
     std::ostringstream oss;
     oss << "videos/chunk-" << std::setw(3) << std::setfill('0') << episode_chunk
         << "/" << video_key;
-    const fs::path videos_cam_dir = base_path / oss.str();
+    const fs::path videos_cam_dir = root_ / oss.str();
     fs::create_directories(videos_cam_dir);
 
     for (const auto &episode_dir : fs::directory_iterator(cam_dir.path())) {
@@ -613,7 +596,7 @@ nlohmann::ordered_json LeRobotBackend::compute_list_stats(
 
 void LeRobotBackend::compute_statistics() const {
   std::ostringstream oss;
-  oss << "episode_" << std::setfill('0') << std::setw(6) << cfg_.episode_index << ".parquet";
+  oss << "episode_" << std::setfill('0') << std::setw(6) << episode_index_ << ".parquet";
   fs::path episode_path = data_root_ / oss.str();
 
   std::unique_ptr<parquet::ParquetFileReader> parquet_reader =
@@ -661,7 +644,7 @@ void LeRobotBackend::compute_statistics() const {
 
     std::ostringstream episode_folder_ss;
     episode_folder_ss << "episode_" << std::setfill('0') << std::setw(6)
-                      << cfg_.episode_index;
+                      << episode_index_;
     std::string episode_folder_name = episode_folder_ss.str();
 
     // Construct the full path to the episode's image directory for the current
@@ -694,7 +677,7 @@ void LeRobotBackend::compute_statistics() const {
   std::ofstream episode_stats_file(meta_root_ / JSONL_EPISODE_STATS, std::ios::app);
 
   nlohmann::ordered_json episode_stats;
-  episode_stats["episode_index"] = cfg_.episode_index;
+  episode_stats["episode_index"] = episode_index_;
   episode_stats["stats"] = stats;
 
   if (!episode_stats_file.is_open()) {
@@ -705,7 +688,7 @@ void LeRobotBackend::compute_statistics() const {
   episode_stats_file.close();
 
   nlohmann::ordered_json episode_metadata;
-  episode_metadata["episode_index"] = cfg_.episode_index;
+  episode_metadata["episode_index"] = episode_index_;
   episode_metadata["tasks"] = {cfg_.task_name};
   episode_metadata["length"] = table->num_rows();
 
@@ -720,7 +703,7 @@ void LeRobotBackend::compute_statistics() const {
 
   // TODO(shantanuparab-tr): Implement logic to check for existing task entries
   nlohmann::ordered_json task_metadata;
-  task_metadata["task_index"] = cfg_.episode_index;
+  task_metadata["task_index"] = episode_index_;
   task_metadata["task"] = cfg_.task_name;
 
   std::ofstream tasks_file(meta_root_ / JSONL_TASKS, std::ios::app);
@@ -738,7 +721,7 @@ void LeRobotBackend::compute_statistics() const {
 }
 
 void LeRobotBackend::print_stats_table(const nlohmann::ordered_json& stats) const {
-  std::cout << "\n================ Episode: " << cfg_.episode_index << " ================\n";
+  std::cout << "\n================ Episode: " << episode_index_ << " ================\n";
   for (auto it = stats.begin(); it != stats.end(); ++it) {
     const std::string& column_name = it.key();
     const auto& metrics = it.value();
@@ -881,7 +864,7 @@ void LeRobotBackend::write_joint_state(const data::RecordBase& base) {
   }
 
   // Scalar columns
-  check_status(epi_idx_builder.Append(cfg_.episode_index), "Failed to append episode index");
+  check_status(epi_idx_builder.Append(episode_index_), "Failed to append episode index");
   check_status(frame_idx_builder.Append(frame_id), "Failed to append frame index");
   check_status(index_builder.Append(js.seq), "Failed to append global index");
   check_status(task_idx_builder.Append(0), "Failed to append task index");
@@ -949,7 +932,7 @@ void LeRobotBackend::write_image(const data::RecordBase& base) {
   auto it = image_dir_cache_.find(img.id);
   if (it == image_dir_cache_.end()) {
     std::ostringstream oss;
-    oss << "episode_" << std::setfill('0') << std::setw(6) << cfg_.episode_index;
+    oss << "episode_" << std::setfill('0') << std::setw(6) << episode_index_;
     fs::path camera_dir = images_root_ / img.id / oss.str();
     std::error_code ec;
     fs::create_directories(camera_dir, ec);
@@ -1212,7 +1195,8 @@ void LeRobotBackend::write_metadata() {
   info_file.close();
 }
 
-uint32_t LeRobotBackend::scan_existing_episodes(const std::filesystem::path& base_path) {
+uint32_t LeRobotBackend::scan_existing_episodes() {
+  std::filesystem::path base_path = std::filesystem::path(cfg_.output_dir) / std::filesystem::path(cfg_.repository_id) / std::filesystem::path(cfg_.dataset_id) / "data" / "chunk-000";
   std::cout << "Scanning existing episodes in: " << base_path << std::endl;
 
   // If directory doesn't exist, return 0

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -28,7 +28,7 @@ REGISTER_BACKEND(McapBackend, "mcap")
 McapBackend::McapBackend(
   Config cfg,
   const ProducerMetadataList&)
-  : io::Backend(cfg.output_path), cfg_(std::move(cfg)) {
+  : io::Backend(), cfg_(std::move(cfg)) {
 
 
   // This allows us to access the global configuration for the Mcap backend
@@ -52,14 +52,11 @@ McapBackend::McapBackend(
   }
 McapBackend::~McapBackend() { close(); }
 
-void McapBackend::preprocess_episode(
-  const std::string& output_path,
-  uint32_t episode_index,
-  const std::string& dataset_id,
-  const std::string& repository_id)
+void McapBackend::preprocess_episode()
 {
-  cfg_.output_path = output_path;
-  uri_ = output_path;
+  // No-op Delete If not needed
+  std::cout << "McapBackend::preprocess_episode() called." << std::endl;
+
 }
 
 bool McapBackend::open() {
@@ -69,9 +66,12 @@ bool McapBackend::open() {
   if (opened_) {
     return true;
   }
-
+  std::ostringstream oss;
+  oss << cfg_.output_path << "/"
+      << cfg_.dataset_id << "/"
+      << "episode_" << std::setw(6) << std::setfill('0') << episode_index_ << ".mcap";
   // Parse configs
-  path_ = cfg_.output_path;
+  path_ = std::filesystem::path(oss.str());
 
   // Create Foxglove context
   context_ = foxglove::Context::create();
@@ -98,7 +98,7 @@ bool McapBackend::open() {
   }
   // Check if the output path parent directory exists
   auto parent_path = path_.parent_path();
-  if (!std::filesystem::exists(parent_path)) {
+  if (!parent_path.empty() && !std::filesystem::exists(parent_path)) {
     try {
       std::filesystem::create_directories(parent_path);
     } catch (const std::exception& e) {
@@ -123,7 +123,7 @@ bool McapBackend::open() {
   std::map<std::string, std::string> metadata;
   metadata["tool_version"] = trossen::core::version();
   metadata["dataset_id"] = cfg_.dataset_id;
-  metadata["episode_index"] = std::to_string(cfg_.episode_index);
+  metadata["episode_index"] = std::to_string(episode_index_);
   auto now = trossen::data::now_real();
   metadata["recording_start_time"] = std::to_string(now.to_ns());
 
@@ -423,7 +423,8 @@ bool McapBackend::is_depth_encoding(const std::string& enc) {
 }
 
 
-uint32_t McapBackend::scan_existing_episodes(const std::filesystem::path& base_path) {
+uint32_t McapBackend::scan_existing_episodes() {
+  std::filesystem::path base_path = std::filesystem::path(cfg_.output_path) / cfg_.dataset_id;
   std::cout << "Scanning existing episodes in: " << base_path << std::endl;
   // If directory doesn't exist, return 0
   if (!std::filesystem::exists(base_path)) {

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -55,8 +55,6 @@ McapBackend::~McapBackend() { close(); }
 void McapBackend::preprocess_episode()
 {
   // No-op Delete If not needed
-  std::cout << "McapBackend::preprocess_episode() called." << std::endl;
-
 }
 
 bool McapBackend::open() {

--- a/src/backends/null/null_backend.cpp
+++ b/src/backends/null/null_backend.cpp
@@ -13,7 +13,7 @@ REGISTER_BACKEND(NullBackend, "null")
 NullBackend::NullBackend(
   const Config& cfg,
   const ProducerMetadataList&)
-  : Backend(cfg.uri) {}
+  : Backend() {}
 
 bool NullBackend::open() {
   opened_ = true;

--- a/src/backends/trossen/trossen_backend.cpp
+++ b/src/backends/trossen/trossen_backend.cpp
@@ -25,7 +25,7 @@ namespace fs = std::filesystem;
 TrossenBackend::TrossenBackend(
   Config cfg,
   const ProducerMetadataList&)
-  : io::Backend(cfg.output_dir), cfg_(std::move(cfg))
+  : io::Backend(), cfg_(std::move(cfg))
 {
   // Validate encoder threads
   if (cfg_.encoder_threads <= 0) {
@@ -39,24 +39,24 @@ TrossenBackend::TrossenBackend(
   // URI is absolute path to output directory. Set to absolute path and check write access.
   // Validate output directory path
   try {
-    uri_ = fs::absolute(cfg_.output_dir).string();
+    root_ = fs::absolute(cfg_.output_dir);
   } catch (const std::exception& e) {
     throw std::runtime_error(
       "Failed to resolve absolute path of output directory: " + std::string(e.what()));
   }
   // Validate non-empty path
-  if (uri_.empty()) {
+  if (root_.empty()) {
     throw std::runtime_error("Output directory path is empty");
   }
   // Check that we can write to the output directory
   try {
-    if (!fs::exists(uri_)) {
-      fs::create_directories(uri_);
+    if (!fs::exists(root_)) {
+      fs::create_directories(root_);
     }
   } catch (const std::exception& e) {
     throw std::runtime_error("Failed to create output directory: " + std::string(e.what()));
   }
-  fs::path test_path = fs::path(uri_) / "trossen_sdk_lerobot_v2_test.tmp";
+  fs::path test_path = root_ / "trossen_sdk_lerobot_v2_test.tmp";
   std::ofstream test_file(test_path.string(), std::ios::out | std::ios::trunc);
   if (!test_file) {
     throw std::runtime_error("Failed to open test file for writing: " + test_path.string());
@@ -66,7 +66,7 @@ TrossenBackend::TrossenBackend(
 
   // Print off configuration
   std::cout << "TrossenBackend configuration:\n"
-            << "  Output dir: " << uri_ << "\n"
+            << "  Output dir: " << root_ << "\n"
             << "  Encoder threads: " << cfg_.encoder_threads << "\n"
             << "  Max image queue: "
             << (cfg_.max_image_queue == 0 ? "unbounded" : std::to_string(cfg_.max_image_queue))
@@ -83,7 +83,6 @@ bool TrossenBackend::open() {
   if (opened_) {
     return true;
   }
-  root_ = fs::path(uri_);
   images_root_ = root_ / "observations" / "images";
   try {
     fs::create_directories(images_root_);

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -19,49 +19,43 @@ namespace trossen::runtime {
 
 SessionManager::SessionManager(SessionConfig&& config)
   : config_(std::move(config))
-{
+{ 
+  std::cout<< "Initializing Session Manager with configuration:" << std::endl;
+  if (config_.max_duration.has_value()) {
+    std::cout << "  Max Duration: " << config_.max_duration->count() << " seconds" << std::endl;
+  } else {
+    std::cout << "  Max Duration: unlimited" << std::endl;
+  }
+  if (config_.max_episodes.has_value()) {
+    std::cout << "  Max Episodes: " << config_.max_episodes.value() << std::endl;
+  } else {
+    std::cout << "  Max Episodes: unlimited" << std::endl;
+  }
   // Validate required configuration
-  if (config_.base_path.empty()) {
-    throw std::invalid_argument("SessionConfig::base_path cannot be empty");
-  }
+  // if (config_.base_path.empty()) {
+  //   throw std::invalid_argument("SessionConfig::base_path cannot be empty");
+  // }
 
-  // Create base directory if it doesn't exist
-  if (!std::filesystem::exists(config_.base_path)) {
-    // TODO(lukeschmitt-tr): Handle potential errors
-    std::filesystem::create_directories(config_.base_path);
-  }
+  // // Create base directory if it doesn't exist
+  // if (!std::filesystem::exists(config_.base_path)) {
+  //   // TODO(lukeschmitt-tr): Handle potential errors
+  //   std::filesystem::create_directories(config_.base_path);
+  // }
 
-  // Auto-generate dataset_id if not provided
-  if (config_.dataset_id.empty()) {
-    // TODO(lukeschmitt-tr): Generate UUID (for now, use timestamp-based ID)
-    auto now = std::chrono::system_clock::now();
-    auto time_t_now = std::chrono::system_clock::to_time_t(now);
-    std::ostringstream oss;
-    // Format: dataset_YYYYMMDD_HHMMSS in local time
-    oss << "dataset_" << std::put_time(std::localtime(&time_t_now), "%Y%m%d_%H%M%S");
-    config_.dataset_id = oss.str();
-    std::cout << "Auto-generated dataset_id: " << config_.dataset_id << std::endl;
-  }
+  // // Auto-generate dataset_id if not provided
+  // if (config_.dataset_id.empty()) {
+  //   // TODO(lukeschmitt-tr): Generate UUID (for now, use timestamp-based ID)
+  //   auto now = std::chrono::system_clock::now();
+  //   auto time_t_now = std::chrono::system_clock::to_time_t(now);
+  //   std::ostringstream oss;
+  //   // Format: dataset_YYYYMMDD_HHMMSS in local time
+  //   oss << "dataset_" << std::put_time(std::localtime(&time_t_now), "%Y%m%d_%H%M%S");
+  //   config_.dataset_id = oss.str();
+  //   std::cout << "Auto-generated dataset_id: " << config_.dataset_id << std::endl;
+  // }
   // TODO(shantanuparab-tr): Make this backend-agnostic by using a factory method
   // Scan directory for existing episodes and resume from next index
-  if (config_.backend_config->type == "mcap") {
-    std::filesystem::path data_directory_path = config_.base_path / config_.dataset_id;
-    next_episode_index_ = io::backends::McapBackend::scan_existing_episodes(data_directory_path);
-  } else if (config_.backend_config->type == "lerobot") {
-    std::filesystem::path data_directory_path =
-      config_.base_path /
-      config_.repository_id /
-      config_.dataset_id /
-      "data" /
-      "chunk-000";
-    next_episode_index_ = io::backends::LeRobotBackend::scan_existing_episodes(data_directory_path);
-  } else {
-    throw std::invalid_argument("Unsupported backend type: " + config_.backend_config->type);
-  }
-  if (next_episode_index_ > 0) {
-    std::cout << "Found " << next_episode_index_ << " existing episode(s). "
-              << "Next episode index: " << next_episode_index_ << std::endl;
-  }
+
 }
 
 SessionManager::~SessionManager() {
@@ -106,18 +100,6 @@ bool SessionManager::start_episode() {
     return false;
   }
 
-  // Check max_episodes limit
-  //
-  // TODO(lukeschmitt-tr): This "end of recording" check could be moved elsewhere - right now it
-  // will stop recording on episode N+1 start attempt
-  if (config_.max_episodes.has_value() && next_episode_index_ >= config_.max_episodes.value()) {
-    std::cerr << "Max episodes (" << config_.max_episodes.value() << ") reached." << std::endl;
-    return false;
-  }
-
-  // Build episode file path
-  auto path = build_episode_path(next_episode_index_);
-
   ProducerMetadataList producer_metadata;
 
   // Fetch Metadata from producers as a vector of the base class
@@ -132,15 +114,33 @@ bool SessionManager::start_episode() {
   std::cout<< "Number of Producers Pushed: " << producer_metadata.size() << std::endl;
   // Create backend
   try {
-    current_backend_ = create_backend(path.string(), next_episode_index_, producer_metadata);
+    current_backend_ = create_backend(producer_metadata);
   } catch (const std::exception& e) {
     std::cerr << "Backend creation failed: " << e.what() << std::endl;
     return false;
   }
 
+  next_episode_index_ = current_backend_->scan_existing_episodes();
+
+  if (next_episode_index_ > 0) {
+    std::cout << "Found " << next_episode_index_ << " existing episode(s). "
+              << "Next episode index: " << next_episode_index_ << std::endl;
+  }
+
+  current_backend_->set_episode_index(next_episode_index_);
+
+  // Check max_episodes limit
+  //
+  // TODO(lukeschmitt-tr): This "end of recording" check could be moved elsewhere - right now it
+  // will stop recording on episode N+1 start attempt
+  if (config_.max_episodes.has_value() && next_episode_index_ >= config_.max_episodes.value()) {
+    std::cerr << "Max episodes (" << config_.max_episodes.value() << ") reached." << std::endl;
+    return false;
+  }
+
   // Open backend
   if (!current_backend_->open()) {
-    std::cerr << "Backend open failed for: " << path << std::endl;
+    std::cerr << "Backend open failed for: " << std::endl;
     current_backend_.reset();
     return false;
   }
@@ -196,7 +196,7 @@ bool SessionManager::start_episode() {
     monitor_thread_ = std::thread([this]() { monitor_duration(); });
   }
 
-  std::cout << "Episode " << next_episode_index_ << " started: " << path << std::endl;
+  std::cout << "Episode " << next_episode_index_ << " started." << std::endl;
 
   return true;
 }
@@ -330,28 +330,7 @@ SessionManager::Stats SessionManager::stats() const {
   return s;
 }
 
-std::filesystem::path SessionManager::build_episode_path(uint32_t index) const {
-  // Generate filename: episode_NNNNNN.mcap (6-digit zero-padded)
-  // TODO(lukeschmitt-tr): This is specific to MCAP files; consider making more generic
-  std::ostringstream oss;
-  if (config_.backend_config == nullptr) {
-    throw std::runtime_error("SessionManager::build_episode_path: backend_config is null");
-  } else if (config_.backend_config->type == "lerobot") {
-      return config_.base_path;
-  } else if (config_.backend_config->type == "mcap") {
-      oss << "episode_" << std::setfill('0') << std::setw(6) << index << ".mcap";
-      return config_.base_path / config_.dataset_id / oss.str();
-
-  } else {
-    throw std::runtime_error(
-      "SessionManager::build_episode_path: Unsupported backend type: "
-      + config_.backend_config->type);
-  }
-}
-
 std::shared_ptr<io::Backend> SessionManager::create_backend(
-  const std::string& output_path,
-  uint32_t episode_index,
   const ProducerMetadataList& producer_metadatas)
 {
   if (config_.backend_config == nullptr) {
@@ -365,11 +344,7 @@ std::shared_ptr<io::Backend> SessionManager::create_backend(
     producer_metadatas);
 
   // Let the backend configure itself for this episode
-  backend->preprocess_episode(
-    output_path,
-    episode_index,
-    config_.dataset_id,
-    config_.repository_id);
+  backend->preprocess_episode();
 
   return backend;
 }

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -31,6 +31,7 @@ SessionManager::SessionManager(SessionConfig&& config)
   } else {
     std::cout << "  Max Episodes: unlimited" << std::endl;
   }
+  // TODO(shantanuparab-tr): Move this logic to a backend utility function
   // Validate required configuration
   // if (config_.base_path.empty()) {
   //   throw std::invalid_argument("SessionConfig::base_path cannot be empty");
@@ -53,9 +54,6 @@ SessionManager::SessionManager(SessionConfig&& config)
   //   config_.dataset_id = oss.str();
   //   std::cout << "Auto-generated dataset_id: " << config_.dataset_id << std::endl;
   // }
-  // TODO(shantanuparab-tr): Make this backend-agnostic by using a factory method
-  // Scan directory for existing episodes and resume from next index
-
 }
 
 SessionManager::~SessionManager() {
@@ -140,7 +138,7 @@ bool SessionManager::start_episode() {
 
   // Open backend
   if (!current_backend_->open()) {
-    std::cerr << "Backend open failed for: " << std::endl;
+    std::cerr << "Failed to open backend" << std::endl;
     current_backend_.reset();
     return false;
   }


### PR DESCRIPTION
### TL;DR

Refactored backend configuration to move dataset and path management from SessionManager to individual backends.

### What changed?

- Removed `base_path`, `dataset_id`, and `repository_id` from `SessionConfig` and moved them to backend-specific configurations
- Modified `Backend` base class to remove URI constructor parameter and add episode index tracking
- Updated backend implementations to handle their own path construction and episode management
- Added `scan_existing_episodes()` method to the `Backend` interface
- Simplified `preprocess_episode()` method to take no parameters
- Updated all backend implementations to conform to the new interface
- Modified `SessionManager` to delegate episode path management to backends

### How to test?

1. Run the example applications (widowxai, widowxai_bimanual, widowxai_lerobot)
2. Verify that episodes are correctly created with proper naming and organization
3. Confirm that episode indexing works correctly when resuming recording sessions
4. Check that all backends (MCAP, LeRobot, Null, Trossen) function as expected

### Why make this change?

This change improves the separation of concerns by making each backend responsible for its own path construction and episode management. It removes the need for the SessionManager to understand backend-specific details, making the system more modular and easier to extend with new backends. The refactoring also simplifies the API by removing redundant parameters and consolidating configuration in the appropriate backend classes.