### PR TITLE
Rename --output-dir to --root for consistent directory configuration

### DIFF
--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -11,7 +11,7 @@
  *
  * Usage:
  *   ./widowxai --episodes 5 --duration 10
- *   ./widowxai --episodes 3 --duration 5 --output-dir /data/recordings
+ *   ./widowxai --episodes 3 --duration 5 --root /data/recordings
  *   ./widowxai --mock  # Use mock producers for testing without hardware
  */
 
@@ -27,6 +27,7 @@
 #include "libtrossen_arm/trossen_arm.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 #include "trossen_sdk/hw/arm/arm_producer.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/hw/arm/mock_joint_producer.hpp"
 #include "trossen_sdk/hw/camera/opencv_producer.hpp"
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
@@ -41,7 +42,7 @@ struct Config {
   int duration_s = 10;
   int episodes = 3;
   std::string dataset_id = "";  // empty = auto-generate
-  std::string output_dir = "output/episodes";
+  std::string root = trossen::io::backends::get_default_root_path().string();
   bool use_mock = false;
   bool show_help = false;
 
@@ -67,7 +68,7 @@ void print_usage(const char* prog_name) {
     << "  --duration <seconds>     Duration per episode (default: 10)\n"
     << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
-    << "  --output-dir <path>      Output directory for episodes (default: output/episodes)\n"
+    << "  --root <path>      Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
     << "  --camera-index <num>     Camera device index (default: 2, i.e., /dev/video2)\n"
     << "  --camera-width <pixels>  Camera width (default: 1920)\n"
@@ -81,7 +82,7 @@ void print_usage(const char* prog_name) {
     << "Examples:\n"
     << "  " << prog_name << " --duration 10 --episodes 5\n"
     << "  " << prog_name << " --mock --duration 5 --episodes 3\n"
-    << "  " << prog_name << " --dataset-id solo_demo_001 --output-dir /data/recordings\n";
+    << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
 }
 
 Config parse_args(int argc, char** argv) {
@@ -97,8 +98,8 @@ Config parse_args(int argc, char** argv) {
       cfg.episodes = std::max(1, std::atoi(argv[++i]));
     } else if (arg == "--dataset-id" && i + 1 < argc) {
       cfg.dataset_id = argv[++i];
-    } else if (arg == "--output-dir" && i + 1 < argc) {
-      cfg.output_dir = argv[++i];
+    } else if (arg == "--root" && i + 1 < argc) {
+      cfg.root = argv[++i];
     } else if (arg == "--mock") {
       cfg.use_mock = true;
     } else if (arg == "--camera-index" && i + 1 < argc) {
@@ -142,7 +143,7 @@ int main(int argc, char** argv) {
     "Duration per episode: " + std::to_string(cfg.duration_s) + "s",
     "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
-    "Output directory:     " + cfg.output_dir,
+    "Root directory:       " + cfg.root,
     "Backend:              " + cfg.backend_type
   };
 
@@ -162,8 +163,8 @@ int main(int argc, char** argv) {
   // Install signal handler for graceful shutdown
   trossen::demo::install_signal_handler();
 
-  // Create output directory
-  std::filesystem::create_directories(cfg.output_dir);
+  // Create root directory
+  std::filesystem::create_directories(cfg.root);
 
   // ──────────────────────────────────────────────────────────
   // Initialize hardware (if not using mock)
@@ -235,7 +236,7 @@ int main(int argc, char** argv) {
     session_cfg.backend_config = std::move(mcap_cfg);
   } else if (cfg.backend_type == "lerobot") {
     auto lerobot_cfg = std::make_unique<trossen::io::backends::LeRobotBackend::Config>();
-    lerobot_cfg->output_dir = cfg.output_dir;
+    lerobot_cfg->root = cfg.root;
     lerobot_cfg->task_name = "trossen_ai_solo_demo";
     lerobot_cfg->repository_id = "TrossenRoboticsCommunity";
     lerobot_cfg->dataset_id = "trossen_ai_solo_dataset";
@@ -422,7 +423,7 @@ int main(int argc, char** argv) {
 
     // Build the file path and print summary
     std::string file_path = trossen::demo::generate_episode_path(
-      cfg.output_dir,
+      cfg.root,
       recording_episode_index);
     trossen::demo::print_episode_summary(file_path, last_record_count);
 
@@ -481,7 +482,7 @@ int main(int argc, char** argv) {
   }
 
   auto final_stats = mgr.stats();
-  trossen::demo::print_final_summary(final_stats.total_episodes_completed, cfg.output_dir);
+  trossen::demo::print_final_summary(final_stats.total_episodes_completed, cfg.root);
 
   return 0;
 }

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -68,7 +68,7 @@ void print_usage(const char* prog_name) {
     << "  --duration <seconds>     Duration per episode (default: 10)\n"
     << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
-    << "  --root <path>      Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
+    << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
     << "  --camera-index <num>     Camera device index (default: 2, i.e., /dev/video2)\n"
     << "  --camera-width <pixels>  Camera width (default: 1920)\n"

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -18,7 +18,7 @@
  *
  * Usage:
  *   ./widowxai_bimanual --episodes 5 --duration 10
- *   ./widowxai_bimanual --episodes 3 --duration 5 --output-dir /data/recordings
+ *   ./widowxai_bimanual --episodes 3 --duration 5 --root /data/recordings
  *   ./widowxai_bimanual --mock  # Use mock producers for testing without hardware
  */
 
@@ -36,6 +36,7 @@
 #include "libtrossen_arm/trossen_arm.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 #include "trossen_sdk/hw/arm/arm_producer.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/hw/arm/mock_joint_producer.hpp"
 #include "trossen_sdk/hw/camera/opencv_producer.hpp"
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
@@ -46,7 +47,7 @@ struct Config {
   int duration_s = 10;
   int episodes = 3;
   std::string dataset_id = "";  // empty = auto-generate
-  std::string output_dir = "output/episodes";
+  std::string root = trossen::io::backends::get_default_root_path().string();
   bool use_mock = false;
   bool show_help = false;
 
@@ -74,7 +75,7 @@ void print_usage(const char* prog_name) {
     << "  --duration <seconds>     Duration per episode (default: 10)\n"
     << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
-    << "  --output-dir <path>      Output directory for episodes (default: output/episodes)\n"
+    << "  --root <path>      Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
     << "  --camera-width <pixels>  Camera width (default: 1280 for 720p)\n"
     << "  --camera-height <pixels> Camera height (default: 720)\n"
@@ -91,7 +92,7 @@ void print_usage(const char* prog_name) {
     << "Examples:\n"
     << "  " << prog_name << " --duration 10 --episodes 5\n"
     << "  " << prog_name << " --mock --duration 5 --episodes 3\n"
-    << "  " << prog_name << " --dataset-id stationary_demo_001 --output-dir /data/recordings\n";
+    << "  " << prog_name << " --dataset-id stationary_demo_001 --root /data/recordings\n";
 }
 
 Config parse_args(int argc, char** argv) {
@@ -107,8 +108,8 @@ Config parse_args(int argc, char** argv) {
       cfg.episodes = std::max(1, std::atoi(argv[++i]));
     } else if (arg == "--dataset-id" && i + 1 < argc) {
       cfg.dataset_id = argv[++i];
-    } else if (arg == "--output-dir" && i + 1 < argc) {
-      cfg.output_dir = argv[++i];
+    } else if (arg == "--root" && i + 1 < argc) {
+      cfg.root = argv[++i];
     } else if (arg == "--mock") {
       cfg.use_mock = true;
     } else if (arg == "--camera-width" && i + 1 < argc) {
@@ -142,7 +143,7 @@ int main(int argc, char** argv) {
     "Duration per episode: " + std::to_string(cfg.duration_s) + "s",
     "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
-    "Output directory:     " + cfg.output_dir,
+    "Root directory:       " + cfg.root,
     "Backend:              " + cfg.backend_type
   };
 
@@ -176,8 +177,8 @@ int main(int argc, char** argv) {
   // Install signal handler for graceful shutdown
   trossen::demo::install_signal_handler();
 
-  // Create output directory
-  std::filesystem::create_directories(cfg.output_dir);
+  // Create root directory
+  std::filesystem::create_directories(cfg.root);
 
   std::unique_ptr<trossen_arm::TrossenArmDriver> leader_left_driver;
   std::unique_ptr<trossen_arm::TrossenArmDriver> leader_right_driver;
@@ -291,7 +292,7 @@ int main(int argc, char** argv) {
     session_cfg.backend_config = std::move(mcap_cfg);
   } else if (cfg.backend_type == "lerobot") {
     auto lerobot_cfg = std::make_unique<trossen::io::backends::LeRobotBackend::Config>();
-    lerobot_cfg->output_dir = cfg.output_dir;
+    lerobot_cfg->root = cfg.root;
     lerobot_cfg->task_name = "trossen_ai_solo_demo";
     lerobot_cfg->repository_id = "TrossenRoboticsCommunity";
     lerobot_cfg->dataset_id = "trossen_ai_bimanual_dataset";
@@ -525,7 +526,7 @@ int main(int argc, char** argv) {
 
     // Build the file path and print summary
     std::string file_path = trossen::demo::generate_episode_path(
-      cfg.output_dir,
+      cfg.root,
       recording_episode_index);
     trossen::demo::print_episode_summary(file_path, last_record_count);
 
@@ -600,7 +601,7 @@ int main(int argc, char** argv) {
   };
   trossen::demo::print_final_summary(
     final_stats.total_episodes_completed,
-    cfg.output_dir,
+    cfg.root,
     extra_info);
 
   return 0;

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -75,7 +75,7 @@ void print_usage(const char* prog_name) {
     << "  --duration <seconds>     Duration per episode (default: 10)\n"
     << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
-    << "  --root <path>      Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
+    << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
     << "  --camera-width <pixels>  Camera width (default: 1280 for 720p)\n"
     << "  --camera-height <pixels> Camera height (default: 720)\n"

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -72,7 +72,7 @@ void print_usage(const char* prog_name) {
     << "  --duration <seconds>     Duration per episode (default: 10)\n"
     << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
-    << "  --root <path>      Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
+    << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --repository-id <string> Repository identifier (default: TrossenRoboticsCommunity, "
     << "only for LeRobot backend)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -11,7 +11,7 @@
  *
  * Usage:
  *   ./widowxai_lerobot --episodes 5 --duration 10
- *   ./widowxai_lerobot --episodes 3 --duration 5 --output-dir /data/recordings
+ *   ./widowxai_lerobot --episodes 3 --duration 5 --root-dir /data/recordings
  *   ./widowxai_lerobot --mock  # Use mock producers for testing without hardware
  */
 
@@ -45,7 +45,7 @@ struct Config {
   int duration_s = 10;
   int episodes = 3;
   std::string dataset_id = "";  // empty = auto-generate
-  std::string output_dir = trossen::io::backends::get_default_root_path().string();
+  std::string root = trossen::io::backends::get_default_root_path().string();
   std::string repository_id = "TrossenRoboticsCommunity";  // Valid only for LeRobot backend
   bool use_mock = false;
   bool show_help = false;
@@ -72,7 +72,7 @@ void print_usage(const char* prog_name) {
     << "  --duration <seconds>     Duration per episode (default: 10)\n"
     << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
-    << "  --output-dir <path>      Output directory for episodes (default: output/episodes)\n"
+    << "  --root <path>      Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --repository-id <string> Repository identifier (default: TrossenRoboticsCommunity, "
     << "only for LeRobot backend)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
@@ -88,7 +88,7 @@ void print_usage(const char* prog_name) {
     << "Examples:\n"
     << "  " << prog_name << " --duration 10 --episodes 5\n"
     << "  " << prog_name << " --mock --duration 5 --episodes 3\n"
-    << "  " << prog_name << " --dataset-id solo_demo_001 --output-dir /data/recordings\n";
+    << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
 }
 
 Config parse_args(int argc, char** argv) {
@@ -104,8 +104,8 @@ Config parse_args(int argc, char** argv) {
       cfg.episodes = std::max(1, std::atoi(argv[++i]));
     } else if (arg == "--dataset-id" && i + 1 < argc) {
       cfg.dataset_id = argv[++i];
-    } else if (arg == "--output-dir" && i + 1 < argc) {
-      cfg.output_dir = argv[++i];
+    } else if (arg == "--root" && i + 1 < argc) {
+      cfg.root = argv[++i];
     } else if (arg == "--repository-id" && i + 1 < argc) {
       cfg.repository_id = argv[++i];
     } else if (arg == "--mock") {
@@ -159,8 +159,8 @@ int main(int argc, char** argv) {
     "Duration per episode: " + std::to_string(cfg.duration_s) + "s",
     "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
-    "Output directory:     " + cfg.output_dir,
-    "Repository ID:       " + cfg.repository_id,
+    "Root directory:       " + cfg.root,
+    "Repository ID:        " + cfg.repository_id,
     "Backend:              " + cfg.backend_type
   };
 
@@ -175,13 +175,13 @@ int main(int argc, char** argv) {
     " @ " + std::to_string(cfg.camera_width) + "x" + std::to_string(cfg.camera_height) +
     " @ " + std::to_string(cfg.camera_fps) + " fps");
 
-  trossen::demo::print_config_banner("Trossen AI Solo Complete Demo", config_lines);
+  trossen::demo::print_config_banner("Trossen AI LeRobot Solo Complete Demo", config_lines);
 
   // Install signal handler for graceful shutdown
   trossen::demo::install_signal_handler();
 
-  // Create output directory
-  std::filesystem::create_directories(cfg.output_dir);
+  // Create root directory
+  std::filesystem::create_directories(cfg.root);
 
   // ──────────────────────────────────────────────────────────
   // Initialize hardware (if not using mock)
@@ -250,12 +250,12 @@ int main(int argc, char** argv) {
     mcap_cfg->chunk_size_bytes = 4 * 1024 * 1024;  // 4 MB chunks
     mcap_cfg->robot_name = "/robots/widowxai";
     mcap_cfg->type = "mcap";
-    mcap_cfg->output_path = cfg.output_dir;  // Will be set per episode
+    mcap_cfg->root = cfg.root;  // Will be set per episode
     mcap_cfg->dataset_id = cfg.dataset_id;
     session_cfg.backend_config = std::move(mcap_cfg);
   } else if (cfg.backend_type == "lerobot") {
     auto lerobot_cfg = std::make_unique<trossen::io::backends::LeRobotBackend::Config>();
-    lerobot_cfg->output_dir = cfg.output_dir;
+    lerobot_cfg->root = cfg.root;
     lerobot_cfg->task_name = "trossen_ai_solo_demo";
     lerobot_cfg->repository_id = cfg.repository_id;
     lerobot_cfg->dataset_id = cfg.dataset_id;
@@ -448,7 +448,7 @@ int main(int argc, char** argv) {
 
     // Build the file path and print summary
     std::string file_path = trossen::demo::generate_episode_path(
-      cfg.output_dir,
+      cfg.root,
       recording_episode_index);
     trossen::demo::print_episode_summary(file_path, last_record_count);
 
@@ -507,7 +507,7 @@ int main(int argc, char** argv) {
   }
 
   auto final_stats = mgr.stats();
-  trossen::demo::print_final_summary(final_stats.total_episodes_completed, cfg.output_dir);
+  trossen::demo::print_final_summary(final_stats.total_episodes_completed, cfg.root);
 
   return 0;
 }

--- a/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
@@ -13,7 +13,7 @@ struct LeRobotBackendConfig : public IConfig {
     std::string task_name{"default_task"};
     std::string repository_id{"default_repo"};
     std::string dataset_id{"default_dataset"};
-    std::string root{"/data/trossen"};
+    std::string root{trossen::io::backends::get_default_root_path().string()};
     int episode_index{0};
     std::string robot_name{"trossen_ai_generic"};
     float fps{30.0f};
@@ -23,9 +23,6 @@ struct LeRobotBackendConfig : public IConfig {
     static LeRobotBackendConfig from_json(const nlohmann::json& j) {
         LeRobotBackendConfig c;
         c.root = j.value("root", "");
-        if (c.root.empty()) {
-            c.root = trossen::io::backends::get_default_root_path().string();
-        }
         c.encoder_threads = j.value("encoder_threads", 1);
         c.max_image_queue = j.value("max_image_queue", 0);
         c.png_compression_level = j.value("png_compression_level", 3);

--- a/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
@@ -5,7 +5,6 @@
 #include "trossen_sdk/io/backend_utils.hpp"
 
 struct LeRobotBackendConfig : public IConfig {
-    std::string output_dir;
     int encoder_threads{1};
     int max_image_queue{0};
     int png_compression_level{3};
@@ -14,7 +13,7 @@ struct LeRobotBackendConfig : public IConfig {
     std::string task_name{"default_task"};
     std::string repository_id{"default_repo"};
     std::string dataset_id{"default_dataset"};
-    std::string root_path{"/data/trossen"};
+    std::string root{"/data/trossen"};
     int episode_index{0};
     std::string robot_name{"trossen_ai_generic"};
     float fps{30.0f};
@@ -23,7 +22,10 @@ struct LeRobotBackendConfig : public IConfig {
 
     static LeRobotBackendConfig from_json(const nlohmann::json& j) {
         LeRobotBackendConfig c;
-        c.output_dir = j.at("output_dir").get<std::string>();
+        c.root = j.value("root", "");
+        if (c.root.empty()) {
+            c.root = trossen::io::backends::get_default_root_path().string();
+        }
         c.encoder_threads = j.value("encoder_threads", 1);
         c.max_image_queue = j.value("max_image_queue", 0);
         c.png_compression_level = j.value("png_compression_level", 3);
@@ -33,7 +35,6 @@ struct LeRobotBackendConfig : public IConfig {
         c.task_name = j.value("task_name", "default_task");
         c.repository_id = j.value("repository_id", "default_repo");
         c.dataset_id = j.value("dataset_id", "default_dataset");
-        c.root_path = j.value("root_path", trossen::io::backends::get_default_root_path().string());
         c.episode_index = j.value("episode_index", 0);
         c.robot_name = j.value("robot_name", "trossen_ai_generic");
         c.fps = j.value("fps", 30.0f);

--- a/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
@@ -5,7 +5,7 @@
 #include "trossen_sdk/io/backend_utils.hpp"
 
 struct McapBackendConfig : public IConfig {
-    std::string output_dir;
+    std::string root;
     std::string robot_name{"/robot/joint_states"};
     int chunk_size_bytes{4 * 1024 * 1024};
     std::string compression{""};
@@ -16,7 +16,10 @@ struct McapBackendConfig : public IConfig {
 
     static  McapBackendConfig from_json(const nlohmann::json& j) {
         McapBackendConfig c;
-        c.output_dir = j.at("output_dir").get<std::string>();
+        c.root = j.value("root", "");
+        if (c.root.empty()) {
+            c.root = trossen::io::backends::get_default_root_path().string();
+        }
         c.robot_name = j.value("robot_name", "/robot/joint_states");
         c.chunk_size_bytes = j.value("chunk_size_bytes", 4 * 1024 * 1024);
         c.compression = j.value("compression", "");

--- a/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
@@ -5,7 +5,7 @@
 #include "trossen_sdk/io/backend_utils.hpp"
 
 struct McapBackendConfig : public IConfig {
-    std::string root;
+    std::string root{trossen::io::backends::get_default_root_path().string()};
     std::string robot_name{"/robot/joint_states"};
     int chunk_size_bytes{4 * 1024 * 1024};
     std::string compression{""};
@@ -17,9 +17,6 @@ struct McapBackendConfig : public IConfig {
     static  McapBackendConfig from_json(const nlohmann::json& j) {
         McapBackendConfig c;
         c.root = j.value("root", "");
-        if (c.root.empty()) {
-            c.root = trossen::io::backends::get_default_root_path().string();
-        }
         c.robot_name = j.value("robot_name", "/robot/joint_states");
         c.chunk_size_bytes = j.value("chunk_size_bytes", 4 * 1024 * 1024);
         c.compression = j.value("compression", "");

--- a/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
+++ b/include/trossen_sdk/hw/arm/mock_joint_producer.hpp
@@ -76,11 +76,6 @@ public:
      * @return JSON object containing producer information
      */
     nlohmann::ordered_json   get_info() const override {
-      // TODO(shantanuparab-tr): Implement JSON output when needed
-      std::cout << "MockJointStateProducerMetadata: " << name << " (" << id << ") - "
-                << description
-                << ", Model: " << arm_model
-                << ", Gripper: " << gripper_type << "\n";
       return nlohmann::ordered_json{};
     }
   };

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -83,7 +83,6 @@ public:
      * @return JSON object containing producer information
      */
     virtual nlohmann::ordered_json get_info() const {
-      std::cout << "ProducerMetadata: " << name << " (" << id << ") - " << description << "\n";
       return nlohmann::ordered_json{};
     }
   };

--- a/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot/lerobot_backend.hpp
@@ -101,8 +101,8 @@ public:
     /// @brief Dataset ID
     std::string dataset_id{"default_dataset"};
 
-    /// @brief Root path
-    std::string root_path{trossen::io::backends::get_default_root_path().string()};
+    /// @brief Root directory
+    std::string root{trossen::io::backends::get_default_root_path().string()};
 
     /// @brief Episode index (for organizing output)
     uint32_t episode_index{0};

--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -22,6 +22,7 @@
 #include "foxglove/schemas.hpp"
 
 #include "trossen_sdk/io/backend.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_schemas.hpp"
 #include "trossen_sdk/configuration/types/backends/mcap_backend_config.hpp"
 
@@ -39,8 +40,8 @@ public:
    * @brief Configuration options for McapBackend
    */
   struct Config : public io::Backend::Config {
-    /// @brief .mcap file path
-    std::string output_path;
+    /// @brief Root directory for episode files
+    std::string root{trossen::io::backends::get_default_root_path().string()};
 
     /// @brief prefix used for joint states
     std::string robot_name{"/robot/joint_states"};

--- a/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
@@ -16,6 +16,7 @@
 #include <unordered_map>
 
 #include "trossen_sdk/io/backend.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
 
 namespace trossen::io::backends {
 
@@ -51,7 +52,7 @@ public:
    */
   struct Config : public io::Backend::Config {
     /// @brief Root output directory
-    std::string output_dir;
+    std::string root{trossen::io::backends::get_default_root_path().string()};
 
     /// @brief Number of image encoding threads
     size_t encoder_threads{1};

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -57,6 +57,10 @@ LeRobotBackend::LeRobotBackend(
         std::cerr << "Backend config not found!" << std::endl;
         return;
   }
+  // If the root path is empty, set to default
+  if (test_config_->root.empty()) {
+      test_config_->root = trossen::io::backends::get_default_root_path().string();
+  }
 
   // Print the stored values
   std::cout << "================= LeRobot Backend Config =================" << std::endl;

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -61,7 +61,7 @@ LeRobotBackend::LeRobotBackend(
   // Print the stored values
   std::cout << "================= LeRobot Backend Config =================" << std::endl;
   std::cout << "Backend Config Loaded:" << std::endl;
-  std::cout << "  storage_path = " << test_config_->output_dir << std::endl;
+  std::cout << "  root = " << test_config_->root << std::endl;
   std::cout << "  encoder_threads = " << test_config_->encoder_threads << std::endl;
   std::cout << "  max_image_queue = " << test_config_->max_image_queue << std::endl;
   std::cout << "  png_compression_level = " << test_config_->png_compression_level << std::endl;
@@ -70,7 +70,6 @@ LeRobotBackend::LeRobotBackend(
   std::cout << "  task_name = " << test_config_->task_name << std::endl;
   std::cout << "  repository_id = " << test_config_->repository_id << std::endl;
   std::cout << "  dataset_id = " << test_config_->dataset_id << std::endl;
-  std::cout << "  root_path = " << test_config_->root_path << std::endl;
   std::cout << "  episode_index = " << test_config_->episode_index << std::endl;
   std::cout << "  robot_name = " << test_config_->robot_name << std::endl;
   std::cout << "  fps = " << test_config_->fps << std::endl;
@@ -115,10 +114,6 @@ bool LeRobotBackend::open() {
   if (opened_) {
     return true;
   }
-  std::cout << "=====================================================================" << std::endl;
-  std::cout << "Opening LeRobotBackend at: " << root_ << "\n";
-  std::cout << "=====================================================================" << std::endl;
-
 
   std::ostringstream oss;
   oss << "episode_" << std::setfill('0') << std::setw(6) << episode_index_;
@@ -284,7 +279,8 @@ void LeRobotBackend::convert_to_videos() const {
       const fs::path output_video_path = videos_cam_dir / (episode_name + ".mp4");
 
       if (fs::exists(output_video_path)) {
-        std::cout << "Skipping existing video: " << output_video_path.string() << std::endl;
+        // TODO (shantanuparab-tr): Make this into debug log
+        // std::cout << "Skipping existing video: " << output_video_path.string() << std::endl;
         video_count++;
         continue;
       }
@@ -316,7 +312,8 @@ void LeRobotBackend::convert_to_videos() const {
 
         if (image_paths.empty()) {
           std::lock_guard<std::mutex> lk(log_mutex);
-          std::cout << "No images found in episode folder: " << task.episode_name << std::endl;
+          // TODO (shantanuparab-tr): Make this into debug log
+          // std::cout << "No images found in episode folder: " << task.episode_name << std::endl;
           continue;
         }
 
@@ -332,9 +329,10 @@ void LeRobotBackend::convert_to_videos() const {
             << task.output_path.string();
 
         auto t0 = std::chrono::steady_clock::now();
-        std::cout << "\n[Worker " << worker_id << "] Encoding video"<< std::endl;
+        // TODO (shantanuparab-tr): Make this into debug log
+        // std::cout << "\n[Worker " << worker_id << "] Encoding video"<< std::endl;
         int ret = std::system(ffmpeg_cmd.str().c_str());
-        std::cout << std::endl;
+        // std::cout << std::endl;
 
         auto t1 = std::chrono::steady_clock::now();
         auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
@@ -343,12 +341,12 @@ void LeRobotBackend::convert_to_videos() const {
         if (ret == 0) {
           video_count++;
         } else {
-          std::cout << "[Worker " << worker_id << "] FFmpeg failed for "
+          std::cerr << "[Worker " << worker_id << "] FFmpeg failed for "
                     << task.output_path.string() << " (code " << ret << ")" << std::endl;
         }
       } catch (const std::exception &e) {
         std::lock_guard<std::mutex> lk(log_mutex);
-        std::cout << "[Worker " << worker_id << "] Exception for "
+        std::cerr << "[Worker " << worker_id << "] Exception for "
                   << task.episode_name << ": " << e.what() << std::endl;
       }
     }
@@ -428,7 +426,7 @@ std::vector<cv::Mat> LeRobotBackend::sample_images(
     if (img_float.channels() == 3) {
       images.push_back(img_float);
     } else {
-      std::cout << "Unexpected channel count: " << img_float.channels() << std::endl;
+      std::cerr << "Unexpected channel count: " << img_float.channels() << std::endl;
     }
   }
 
@@ -439,7 +437,7 @@ nlohmann::ordered_json LeRobotBackend::compute_image_stats(
   const std::vector<cv::Mat> &images) const{
   nlohmann::ordered_json stats_json;
   if (images.empty()) {
-    std::cout << "No images provided." << std::endl;
+    std::cerr << "No images provided." << std::endl;
     stats_json["min"] = {};
     stats_json["max"] = {};
     stats_json["mean"] = {};
@@ -637,7 +635,6 @@ void LeRobotBackend::compute_statistics() const {
   }
   // Compute image statistics for each camera
   for (const auto &camera_info : camera_names_) {
-    std::cout << "Computing image statistics for camera: " << camera_info << std::endl;
     std::string image_key = "observation.images." + camera_info;
     // Get image paths for the current episode and camera
     std::string image_folder_path = images_root_.string();
@@ -652,7 +649,7 @@ void LeRobotBackend::compute_statistics() const {
     std::filesystem::path episode_image_dir =
         std::filesystem::path(image_folder_path) / camera_info/ episode_folder_name;
     if (!std::filesystem::exists(episode_image_dir)) {
-      std::cout << "Image directory does not exist: "
+      std::cerr << "Image directory does not exist: "
                 << episode_image_dir.string() << std::endl;
       continue;
     }
@@ -1099,8 +1096,6 @@ void LeRobotBackend::write_metadata() {
   // Check if info.json already exists
   fs::path info_path = meta_root_ / JSON_INFO;
   if (fs::exists(info_path)) {
-    std::cout << "Info file already exists at " << info_path
-              << ". Skipping metadata write." << std::endl;
     return;
   }
   nlohmann::ordered_json info_;
@@ -1197,7 +1192,6 @@ void LeRobotBackend::write_metadata() {
 
 uint32_t LeRobotBackend::scan_existing_episodes() {
   std::filesystem::path base_path = std::filesystem::path(cfg_.output_dir) / std::filesystem::path(cfg_.repository_id) / std::filesystem::path(cfg_.dataset_id) / "data" / "chunk-000";
-  std::cout << "Scanning existing episodes in: " << base_path << std::endl;
 
   // If directory doesn't exist, return 0
   if (!std::filesystem::exists(base_path)) {

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -41,7 +41,7 @@ McapBackend::McapBackend(
   }
   // Print the stored values
   std::cout << "================= MCAP Backend Config =================" << std::endl;
-  std::cout << "Output Dir: " << test_config_->output_dir << std::endl;
+  std::cout << "Root Dir: " << test_config_->root << std::endl;
   std::cout << "Robot Name: " << test_config_->robot_name << std::endl;
   std::cout << "Chunk Size Bytes: " << test_config_->chunk_size_bytes << std::endl;
   std::cout << "Compression: " << test_config_->compression << std::endl;
@@ -65,7 +65,7 @@ bool McapBackend::open() {
     return true;
   }
   std::ostringstream oss;
-  oss << cfg_.output_path << "/"
+  oss << cfg_.root << "/"
       << cfg_.dataset_id << "/"
       << "episode_" << std::setw(6) << std::setfill('0') << episode_index_ << ".mcap";
   // Parse configs
@@ -422,8 +422,7 @@ bool McapBackend::is_depth_encoding(const std::string& enc) {
 
 
 uint32_t McapBackend::scan_existing_episodes() {
-  std::filesystem::path base_path = std::filesystem::path(cfg_.output_path) / cfg_.dataset_id;
-  std::cout << "Scanning existing episodes in: " << base_path << std::endl;
+  std::filesystem::path base_path = std::filesystem::path(cfg_.root) / cfg_.dataset_id;
   // If directory doesn't exist, return 0
   if (!std::filesystem::exists(base_path)) {
     return 0;

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -39,6 +39,10 @@ McapBackend::McapBackend(
         std::cerr << "Backend config not found!" << std::endl;
         return;
   }
+  // If the root path is empty, set to default
+  if (test_config_->root.empty()) {
+      test_config_->root = trossen::io::backends::get_default_root_path().string();
+  }
   // Print the stored values
   std::cout << "================= MCAP Backend Config =================" << std::endl;
   std::cout << "Root Dir: " << test_config_->root << std::endl;

--- a/src/backends/trossen/trossen_backend.cpp
+++ b/src/backends/trossen/trossen_backend.cpp
@@ -36,25 +36,25 @@ TrossenBackend::TrossenBackend(
     cfg_.png_compression_level = 3;
   }
 
-  // URI is absolute path to output directory. Set to absolute path and check write access.
-  // Validate output directory path
+  // URI is absolute path to root directory. Set to absolute path and check write access.
+  // Validate root directory path
   try {
-    root_ = fs::absolute(cfg_.output_dir);
+    root_ = fs::absolute(cfg_.root);
   } catch (const std::exception& e) {
     throw std::runtime_error(
-      "Failed to resolve absolute path of output directory: " + std::string(e.what()));
+      "Failed to resolve absolute path of root directory: " + std::string(e.what()));
   }
   // Validate non-empty path
   if (root_.empty()) {
-    throw std::runtime_error("Output directory path is empty");
+    throw std::runtime_error("Root directory path is empty");
   }
-  // Check that we can write to the output directory
+  // Check that we can write to the root directory
   try {
     if (!fs::exists(root_)) {
       fs::create_directories(root_);
     }
   } catch (const std::exception& e) {
-    throw std::runtime_error("Failed to create output directory: " + std::string(e.what()));
+    throw std::runtime_error("Failed to create root directory: " + std::string(e.what()));
   }
   fs::path test_path = root_ / "trossen_sdk_lerobot_v2_test.tmp";
   std::ofstream test_file(test_path.string(), std::ios::out | std::ios::trunc);
@@ -64,18 +64,19 @@ TrossenBackend::TrossenBackend(
   test_file.close();
   fs::remove(test_path);
 
-  // Print off configuration
-  std::cout << "TrossenBackend configuration:\n"
-            << "  Output dir: " << root_ << "\n"
-            << "  Encoder threads: " << cfg_.encoder_threads << "\n"
-            << "  Max image queue: "
+  // Print off configuration in MCAP style
+  std::cout << "================= Trossen Backend Config =================" << std::endl;
+  std::cout << "Root Directory: " << root_ << std::endl;
+  std::cout << "Encoder Threads: " << cfg_.encoder_threads << std::endl;
+  std::cout << "Max Image Queue: "
             << (cfg_.max_image_queue == 0 ? "unbounded" : std::to_string(cfg_.max_image_queue))
-            << "\n"
-            << "  Drop policy: "
+            << std::endl;
+  std::cout << "Drop Policy: "
             << (cfg_.drop_policy == DropPolicy::DropNewest ? "DropNewest" :
                 (cfg_.drop_policy == DropPolicy::DropOldest ? "DropOldest" : "Block"))
-            << "\n"
-            << "  PNG compression level: " << cfg_.png_compression_level << "\n";
+            << std::endl;
+  std::cout << "PNG Compression Level: " << cfg_.png_compression_level << std::endl;
+  std::cout << "==========================================================" << std::endl;
 }
 
 bool TrossenBackend::open() {

--- a/src/backends/trossen/trossen_backend.cpp
+++ b/src/backends/trossen/trossen_backend.cpp
@@ -64,7 +64,7 @@ TrossenBackend::TrossenBackend(
   test_file.close();
   fs::remove(test_path);
 
-  // Print off configuration in MCAP style
+  // Print off configuration
   std::cout << "================= Trossen Backend Config =================" << std::endl;
   std::cout << "Root Directory: " << root_ << std::endl;
   std::cout << "Encoder Threads: " << cfg_.encoder_threads << std::endl;

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -110,12 +110,9 @@ bool SessionManager::start_episode() {
   for (const auto& pt : producer_tasks_) {
     // Dynamic cast to PolledProducer to access metadata()
     if (auto polled_producer = std::dynamic_pointer_cast<hw::PolledProducer>(pt.producer)) {
-      std::cout << "  Pushed Producer: " << polled_producer->metadata()->name
-                << " (ID: " << polled_producer->metadata()->id << ")\n";
       producer_metadata.push_back(polled_producer->metadata());
     }
   }
-  std::cout<< "Number of Producers Pushed: " << producer_metadata.size() << std::endl;
   // Create backend
   try {
     current_backend_ = create_backend(producer_metadata);

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -20,17 +20,23 @@ namespace trossen::runtime {
 SessionManager::SessionManager(SessionConfig&& config)
   : config_(std::move(config))
 { 
-  std::cout<< "Initializing Session Manager with configuration:" << std::endl;
+  std::cout << "================= Session Manager Config =================" << std::endl;
   if (config_.max_duration.has_value()) {
-    std::cout << "  Max Duration: " << config_.max_duration->count() << " seconds" << std::endl;
+    std::cout << "Max Duration: " << config_.max_duration->count() << " seconds" << std::endl;
   } else {
-    std::cout << "  Max Duration: unlimited" << std::endl;
+    std::cout << "Max Duration: unlimited" << std::endl;
   }
   if (config_.max_episodes.has_value()) {
-    std::cout << "  Max Episodes: " << config_.max_episodes.value() << std::endl;
+    std::cout << "Max Episodes: " << config_.max_episodes.value() << std::endl;
   } else {
-    std::cout << "  Max Episodes: unlimited" << std::endl;
+    std::cout << "Max Episodes: unlimited" << std::endl;
   }
+  if (config_.backend_config) {
+    std::cout << "Backend Type: " << config_.backend_config->type << std::endl;
+  } else {
+    std::cout << "Backend Type: (none)" << std::endl;
+  }
+  std::cout << "==========================================================" << std::endl;
   // TODO(shantanuparab-tr): Move this logic to a backend utility function
   // Validate required configuration
   // if (config_.base_path.empty()) {

--- a/tests/test_backend_registry.cpp
+++ b/tests/test_backend_registry.cpp
@@ -65,7 +65,7 @@ TEST(BackendRegistryTest, CreateNullBackend) {
 TEST(BackendRegistryTest, CreateMcapBackend) {
   McapBackend::Config cfg;
   cfg.type = "mcap";
-  cfg.output_path = "/tmp/test_registry.mcap";
+  cfg.root = "/tmp/test_registry.mcap";
   cfg.robot_name = "test_robot";
   cfg.dataset_id = "test_dataset";
   cfg.episode_index = 0;
@@ -100,7 +100,7 @@ TEST(BackendRegistryTest, MultipleBackendsWithDifferentConfigs) {
   // Create mcap backend
   McapBackend::Config cfg3;
   cfg3.type = "mcap";
-  cfg3.output_path = "/tmp/test.mcap";
+  cfg3.root = "/tmp/test.mcap";
   auto backend3 = BackendRegistry::create("mcap", cfg3);
   ASSERT_NE(backend3, nullptr);
 
@@ -162,7 +162,7 @@ TEST(BackendRegistryTest, TypicalUsageDemo) {
   } else if (backend_type == "mcap") {
     auto mcap_cfg = std::make_unique<McapBackend::Config>();
     mcap_cfg->type = "mcap";
-    mcap_cfg->output_path = "/tmp/demo.mcap";
+    mcap_cfg->root = "/tmp/demo.mcap";
     cfg = std::move(mcap_cfg);
   }
 


### PR DESCRIPTION
### TL;DR

Renamed `output_dir` parameter to `root` across all backends for consistency and improved default path handling.

### What changed?

- Renamed the `output_dir` parameter to `root` in all backend configurations (MCAP, LeRobot, Trossen)
- Updated command-line arguments in example applications from `--output-dir` to `--root`
- Updated usage documentation and help text to reflect the parameter name change
- Standardized the default root path to use `~/.cache/trossen_sdk/` via the `get_default_root_path()` utility
- Removed redundant `root_path` parameter in LeRobot backend config
- Cleaned up verbose debug logging in backend implementations
- Improved configuration display formatting for better readability

### Why make this change?

This change standardizes parameter naming across all backends, making the API more consistent and intuitive. The term "root" better represents the top-level directory where all data is stored, rather than "output_dir" which could be confused with a specific episode directory. This also simplifies configuration by providing a sensible default path that works across platforms.