### PR TITLE
Add session manager configuration and integrate with global config

### DIFF
--- a/config/sdk_config.json
+++ b/config/sdk_config.json
@@ -1,4 +1,10 @@
-{
+{ 
+  "session_manager": {
+    "type": "session_manager",
+    "max_duration": 3,
+    "max_episodes": 2,
+    "backend_type": "lerobot"
+  },
   "lerobot_backend": {
     "type": "lerobot_backend",
     "output_dir": "/data/lerobot_output",

--- a/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
+++ b/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <optional>
+#include <chrono>
+#include "../../i_config.hpp"
+// #include "../../json.hpp"
+#include "../../config_registry.hpp"
+
+struct SessionManagerConfig : public IConfig {
+    std::optional<std::chrono::duration<double>> max_duration = std::chrono::seconds(20);
+    std::optional<uint32_t> max_episodes = std::nullopt;
+    std::string backend_type = "mcap";
+
+    std::string type() const override { return "session_manager"; }
+
+    static  SessionManagerConfig from_json(const nlohmann::json& j) {
+        SessionManagerConfig c;
+        c.max_duration = j.contains("max_duration") ?
+            std::make_optional<std::chrono::duration<double>>(j.at("max_duration").get<double>()) :
+            std::nullopt;
+        c.max_episodes = j.contains("max_episodes") ?
+            std::make_optional<uint32_t>(j.at("max_episodes").get<uint32_t>()) :
+            std::nullopt;
+        c.backend_type = j.value("backend_type", "mcap");
+
+        return c;
+    }
+};
+
+REGISTER_CONFIG(SessionManagerConfig, "session_manager");

--- a/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
+++ b/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
@@ -7,19 +7,19 @@
 #include "../../config_registry.hpp"
 
 struct SessionManagerConfig : public IConfig {
-    std::optional<std::chrono::duration<double>> max_duration = std::chrono::seconds(20);
-    std::optional<uint32_t> max_episodes = std::nullopt;
-    std::string backend_type = "mcap";
+    std::optional<std::chrono::duration<double>> max_duration{std::chrono::seconds(20)};
+    std::optional<uint32_t> max_episodes{std::nullopt};
+    std::string backend_type{"mcap"};
 
     std::string type() const override { return "session_manager"; }
 
-    static  SessionManagerConfig from_json(const nlohmann::json& j) {
+    static SessionManagerConfig from_json(const nlohmann::json& j) {
         SessionManagerConfig c;
         c.max_duration = j.contains("max_duration") ?
-            std::make_optional<std::chrono::duration<double>>(j.at("max_duration").get<double>()) :
+            std::optional<std::chrono::duration<double>>{std::chrono::duration<double>{j.at("max_duration").get<double>()}} :
             std::nullopt;
         c.max_episodes = j.contains("max_episodes") ?
-            std::make_optional<uint32_t>(j.at("max_episodes").get<uint32_t>()) :
+            std::optional<uint32_t>{j.at("max_episodes").get<uint32_t>()} :
             std::nullopt;
         c.backend_type = j.value("backend_type", "mcap");
 

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -26,6 +26,9 @@
 #include "trossen_sdk/io/backends/mcap/mcap_backend.hpp"
 #include "trossen_sdk/io/sink.hpp"
 #include "trossen_sdk/runtime/scheduler.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/types/runtime/session_manager_config.hpp"
+
 
 namespace trossen::runtime {
 
@@ -177,6 +180,9 @@ public:
 private:
   /// @brief Configuration
   SessionConfig config_;
+
+  /// @brief Test Configuration
+  std::shared_ptr<SessionManagerConfig> test_config_;
 
   /// @brief Next episode index to use
   uint32_t next_episode_index_{0};

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -20,19 +20,29 @@ namespace trossen::runtime {
 SessionManager::SessionManager(SessionConfig&& config)
   : config_(std::move(config))
 { 
+
+  // This allows us to access the global configuration for the Session Manager
+  // without passing it explicitly.
+
+  test_config_ = GlobalConfig::instance().get_as<SessionManagerConfig>("session_manager");
+
+  if (!test_config_) {
+        std::cerr << "Session Manager config not found!" << std::endl;
+        return;
+  }
   std::cout << "================= Session Manager Config =================" << std::endl;
-  if (config_.max_duration.has_value()) {
-    std::cout << "Max Duration: " << config_.max_duration->count() << " seconds" << std::endl;
+  if (test_config_->max_duration.has_value()) {
+    std::cout << "Max Duration: " << test_config_->max_duration->count() << " seconds" << std::endl;
   } else {
     std::cout << "Max Duration: unlimited" << std::endl;
   }
-  if (config_.max_episodes.has_value()) {
-    std::cout << "Max Episodes: " << config_.max_episodes.value() << std::endl;
+  if (test_config_->max_episodes.has_value()) {
+    std::cout << "Max Episodes: " << test_config_->max_episodes.value() << std::endl;
   } else {
     std::cout << "Max Episodes: unlimited" << std::endl;
   }
-  if (config_.backend_config) {
-    std::cout << "Backend Type: " << config_.backend_config->type << std::endl;
+  if (test_config_->backend_type != "") {
+    std::cout << "Backend Type: " << test_config_->backend_type << std::endl;
   } else {
     std::cout << "Backend Type: (none)" << std::endl;
   }


### PR DESCRIPTION
### TL;DR

Added a SessionManagerConfig class to configure session parameters from JSON configuration files.

### What changed?

- Created a new `SessionManagerConfig` class that defines configuration options for the session manager
- Added a new section in `sdk_config.json` for session manager configuration
- Modified the `SessionManager` class to use the global configuration instead of the passed config
- Updated the session manager to read max_duration, max_episodes, and backend_type from the configuration

### How to test?

1. Update your `sdk_config.json` to include the new session_manager section
2. Run the application and verify that the session manager logs the correct configuration values
3. Test with different values for max_duration, max_episodes, and backend_type to ensure they're properly applied

### Why make this change?

This change allows for more flexible configuration of the session manager through external JSON files rather than hardcoded values. It centralizes configuration management and makes it easier to adjust session parameters without code changes.