### PR TITLE
Add Trossen and Null backend configurations

### DIFF
--- a/config/sdk_config.json
+++ b/config/sdk_config.json
@@ -29,6 +29,19 @@
     "compression": "zstd",
     "dataset_id": "mcap_dataset_v1",
     "episode_index": 0
+  },
+  "trossen_backend": {
+    "type": "trossen_backend",
+    "root": "/data/trossen",
+    "encoder_threads": 2,
+    "max_image_queue": 10,
+    "png_compression_level": 5,
+    "drop_policy": "DropNewest"
+
+  },
+  "null_backend": {
+    "type": "null_backend",
+    "uri": "/data/trossen"
   }
 }
 

--- a/config/sdk_config.json
+++ b/config/sdk_config.json
@@ -1,4 +1,4 @@
-{ 
+{
   "session_manager": {
     "type": "session_manager",
     "max_duration": 3,
@@ -40,8 +40,6 @@
 
   },
   "null_backend": {
-    "type": "null_backend",
-    "uri": "/data/trossen"
+    "type": "null_backend"
   }
 }
-

--- a/examples/backend_registry_demo.cpp
+++ b/examples/backend_registry_demo.cpp
@@ -24,7 +24,6 @@ int main() {
   std::cout << "Creating null backend...\n";
   trossen::io::backends::NullBackend::Config cfg;
   cfg.type = "null";
-  cfg.uri = "null://demo";
 
   auto backend = trossen::io::BackendRegistry::create("null", cfg);
   backend->open();

--- a/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
@@ -3,6 +3,8 @@
 // #include "../../json.hpp"
 #include "../../config_registry.hpp"
 #include "trossen_sdk/io/backend_utils.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
+
 
 struct LeRobotBackendConfig : public IConfig {
     int encoder_threads{1};

--- a/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
@@ -3,6 +3,7 @@
 // #include "../../json.hpp"
 #include "../../config_registry.hpp"
 #include "trossen_sdk/io/backend_utils.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
 
 struct McapBackendConfig : public IConfig {
     std::string root{trossen::io::backends::get_default_root_path().string()};

--- a/include/trossen_sdk/configuration/types/backends/null_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/null_backend_config.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "../../i_config.hpp"
+// #include "../../json.hpp"
+#include "../../config_registry.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
+
+struct NullBackendConfig : public IConfig {
+    std::string uri{"/data/trossen"};
+
+    std::string type() const override { return "null_backend"; }
+
+    static NullBackendConfig from_json(const nlohmann::json& j) {
+        NullBackendConfig c;
+        c.uri = j.value("uri", "");
+        if (c.uri.empty()) {
+            c.uri = trossen::io::backends::get_default_root_path().string();
+        }
+        return c;
+    }
+};
+
+REGISTER_CONFIG(NullBackendConfig, "null_backend");

--- a/include/trossen_sdk/configuration/types/backends/null_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/null_backend_config.hpp
@@ -6,16 +6,10 @@
 #include "trossen_sdk/configuration/global_config.hpp"
 
 struct NullBackendConfig : public IConfig {
-    std::string uri{"/data/trossen"};
-
     std::string type() const override { return "null_backend"; }
 
     static NullBackendConfig from_json(const nlohmann::json& j) {
         NullBackendConfig c;
-        c.uri = j.value("uri", "");
-        if (c.uri.empty()) {
-            c.uri = trossen::io::backends::get_default_root_path().string();
-        }
         return c;
     }
 };

--- a/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include "../../i_config.hpp"
+// #include "../../json.hpp"
+#include "../../config_registry.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
+
+struct TrossenBackendConfig : public IConfig {
+    std::string root{"/data/trossen"};
+    int encoder_threads{1};
+    int max_image_queue{0};
+    int png_compression_level{3};
+    std::string drop_policy{"DropNewest"};
+
+    std::string type() const override { return "trossen_backend"; }
+
+    static TrossenBackendConfig from_json(const nlohmann::json& j) {
+        TrossenBackendConfig c;
+        c.root = j.value("root", "");
+        if (c.root.empty()) {
+            c.root = trossen::io::backends::get_default_root_path().string();
+        }
+        c.encoder_threads = j.value("encoder_threads", 1);
+        c.max_image_queue = j.value("max_image_queue", 0);
+        c.png_compression_level = j.value("png_compression_level", 3);
+        c.drop_policy = j.value("drop_policy", "DropNewest");
+
+        return c;
+    }
+};
+
+REGISTER_CONFIG(TrossenBackendConfig, "trossen_backend");

--- a/include/trossen_sdk/io/backends/null/null_backend.hpp
+++ b/include/trossen_sdk/io/backends/null/null_backend.hpp
@@ -12,6 +12,8 @@
 
 #include "trossen_sdk/hw/producer_base.hpp"
 #include "trossen_sdk/io/backend.hpp"
+#include "trossen_sdk/configuration/types/backends/null_backend_config.hpp"
+
 
 namespace trossen::io::backends {
 

--- a/include/trossen_sdk/io/backends/null/null_backend.hpp
+++ b/include/trossen_sdk/io/backends/null/null_backend.hpp
@@ -27,10 +27,7 @@ public:
   /**
    * @brief Configuration for NullBackend
    */
-  struct Config : public io::Backend::Config {
-    /// @brief URI for the null backend (defaults to "null://")
-    std::string uri{"null://"};
-  };
+  struct Config : public io::Backend::Config {};
 
   /**
    * @brief Construct a NullBackend with the given configuration

--- a/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
@@ -17,6 +17,7 @@
 
 #include "trossen_sdk/io/backend.hpp"
 #include "trossen_sdk/io/backend_utils.hpp"
+#include "trossen_sdk/configuration/types/backends/trossen_backend_config.hpp"
 
 namespace trossen::io::backends {
 
@@ -268,6 +269,9 @@ private:
 
   /// @brief Config for this backend
   Config cfg_;
+
+  /// @brief Global configuration for testing
+  std::shared_ptr<TrossenBackendConfig> test_config_;
 
   /// @brief Whether image worker threads should keep running
   std::atomic<bool> image_worker_running_{false};

--- a/src/backends/lerobot/lerobot_backend.cpp
+++ b/src/backends/lerobot/lerobot_backend.cpp
@@ -26,7 +26,6 @@
 #include "trossen_sdk/hw/camera/opencv_producer.hpp"
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/lerobot/lerobot_backend.hpp"
-#include "trossen_sdk/configuration/global_config.hpp"
 
 namespace trossen::io::backends {
 

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -16,7 +16,6 @@
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_backend.hpp"
 #include "trossen_sdk/version.hpp"
-#include "trossen_sdk/configuration/global_config.hpp"
 #include "trossen_sdk/configuration/types/backends/mcap_backend_config.hpp"
 
 

--- a/src/backends/trossen/trossen_backend.cpp
+++ b/src/backends/trossen/trossen_backend.cpp
@@ -64,6 +64,14 @@ TrossenBackend::TrossenBackend(
   test_file.close();
   fs::remove(test_path);
 
+  // Load global configuration for logging
+  test_config_ = GlobalConfig::instance().get_as<TrossenBackendConfig>("trossen_backend");
+
+  if (!test_config_) {
+        std::cerr << "Backend config not found!" << std::endl;
+        return;
+  }
+
   // Print off configuration
   std::cout << "================= Trossen Backend Config =================" << std::endl;
   std::cout << "Root Directory: " << root_ << std::endl;

--- a/tests/test_backend_registry.cpp
+++ b/tests/test_backend_registry.cpp
@@ -36,7 +36,6 @@ TEST(BackendRegistryTest, UnknownBackendNotRegistered) {
 TEST(BackendRegistryTest, CreateNullBackend) {
   NullBackend::Config cfg;
   cfg.type = "null";
-  cfg.uri = "null://test";
 
   auto backend = BackendRegistry::create("null", cfg);
   ASSERT_NE(backend, nullptr);
@@ -83,14 +82,12 @@ TEST(BackendRegistryTest, MultipleBackendsWithDifferentConfigs) {
   // Create first null backend
   NullBackend::Config cfg1;
   cfg1.type = "null";
-  cfg1.uri = "null://instance1";
   auto backend1 = BackendRegistry::create("null", cfg1);
   ASSERT_NE(backend1, nullptr);
 
   // Create second null backend with different config
   NullBackend::Config cfg2;
   cfg2.type = "null";
-  cfg2.uri = "null://instance2";
   auto backend2 = BackendRegistry::create("null", cfg2);
   ASSERT_NE(backend2, nullptr);
 
@@ -114,7 +111,6 @@ TEST(BackendRegistryTest, ConfigDowncasting) {
   // Create config as concrete type
   NullBackend::Config null_cfg;
   null_cfg.type = "null";
-  null_cfg.uri = "null://downcast_test";
 
   // Pass as base reference (simulating SessionManager usage)
   Backend::Config& base_cfg = null_cfg;
@@ -157,7 +153,6 @@ TEST(BackendRegistryTest, TypicalUsageDemo) {
   if (backend_type == "null") {
     auto null_cfg = std::make_unique<NullBackend::Config>();
     null_cfg->type = "null";
-    null_cfg->uri = "null://demo";
     cfg = std::move(null_cfg);
   } else if (backend_type == "mcap") {
     auto mcap_cfg = std::make_unique<McapBackend::Config>();

--- a/tests/test_null_backend.cpp
+++ b/tests/test_null_backend.cpp
@@ -26,7 +26,6 @@ TEST(NullBackendTest, Construction) {
 // Test NullBackend construction with custom URI
 TEST(NullBackendTest, ConstructionWithURI) {
   NullBackend::Config cfg;
-  cfg.uri = "null://test";
   NullBackend backend(cfg);
   EXPECT_EQ(backend.count(), 0);
 }
@@ -261,7 +260,6 @@ TEST(NullBackendTest, URIStorage) {
   NullBackend backend1(cfg1);
 
   NullBackend::Config cfg2;
-  cfg2.uri = "null://custom";
   NullBackend backend2(cfg2);
 
   // The base class stores the URI, though we can't directly test it without accessing


### PR DESCRIPTION
### TL;DR

Added configuration support for Trossen and Null backends.

### What changed?

- Added configuration definitions for Trossen and Null backends in the SDK config
- Created new configuration type headers for these backends:
  - `trossen_backend_config.hpp`
  - `null_backend_config.hpp`
- Updated existing backend implementations to use these configuration types
- Added global configuration loading in the Trossen backend implementation
- Standardized includes across backend configuration files

### How to test?

1. Verify the new backend configurations in `config/sdk_config.json`
2. Test the Trossen backend with the new configuration parameters:
   - `encoder_threads: 2`
   - `max_image_queue: 10`
   - `png_compression_level: 5`
   - `drop_policy: "DropNewest"`
3. Test the Null backend with the configured URI

### Why make this change?

This change standardizes the configuration approach across all backends, making it easier to configure and customize backend behavior through the SDK config file rather than hardcoded values. It also improves maintainability by using a consistent pattern for backend configuration.