### PR TITLE
Add build, test, and lint workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          cmake \
+          libopencv-dev \
+          libprotobuf-dev \
+          protobuf-compiler \
+          libarrow-dev \
+          libparquet-dev \
+          pkg-config \
+          libbz2-dev \
+          zlib1g-dev
+
+    - name: Install libtrossen_arm
+      run: |
+        # Clone and install libtrossen_arm dependency
+        git clone https://github.com/TrossenRobotics/libtrossen_arm.git /tmp/libtrossen_arm
+        cd /tmp/libtrossen_arm
+        mkdir -p build && cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Release
+        make -j$(nproc)
+        sudo make install
+        sudo ldconfig
+
+    - name: Build SDK
+      run: |
+        make build
+
+    - name: Run Tests
+      run: |
+        make test-verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build-and-test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
@@ -24,11 +26,21 @@ jobs:
           libopencv-dev \
           libprotobuf-dev \
           protobuf-compiler \
-          libarrow-dev \
-          libparquet-dev \
           pkg-config \
           libbz2-dev \
           zlib1g-dev
+
+    - name: Install Parquet dependencies
+      run: |
+        wget https://packages.apache.org/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+        sudo apt-get update && \
+        sudo apt-get install -yqq --no-install-recommends \
+          ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+        sudo apt-get update && \
+        sudo apt-get install -yqq --no-install-recommends \
+          libarrow-dev \
+          libparquet-dev && \
+        rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 
     - name: Install libtrossen_arm
       run: |
@@ -43,7 +55,7 @@ jobs:
 
     - name: Build SDK
       run: |
-        make build
+        make build NPROC=$(nproc)
 
     - name: Run Tests
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+NPROC ?= 4
+
 build:
 	mkdir -p build
-	cd build && cmake .. && make -j4
+	cd build && cmake .. && make -j$(NPROC)
 .PHONY: build
 
 install: build
@@ -18,7 +20,7 @@ test:
 
 test-verbose:
 	mkdir -p build
-	cd build && cmake -DBUILD_TESTING=ON .. && make -j4
+	cd build && cmake -DBUILD_TESTING=ON .. && make -j$(NPROC)
 .PHONY: test-verbose
 
 clean:


### PR DESCRIPTION
This PR adds two workflows:
* build.yml - builds and tests the sdk
* lint.yml - runs pre-commit hooks on the sdk