### PR TITLE
Fix CI failing on main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  SKIP: no-commit-to-branch
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
   - id: check-added-large-files
   - id: check-case-conflict
   - id: check-docstring-first
+  - id: check-json
   - id: check-merge-conflict
   - id: check-symlinks
   - id: check-yaml


### PR DESCRIPTION
### TL;DR

Added JSON file checking to pre-commit hooks and disabled the no-commit-to-branch check in GitHub Actions.

### What changed?

- Added the `check-json` pre-commit hook to validate JSON files
- Set the `SKIP: no-commit-to-branch` environment variable in the GitHub Actions lint workflow to bypass the branch restriction check during CI runs

### How to test?

1. Run `pre-commit run --all-files` locally to verify the JSON checking works
2. Create a PR to confirm the GitHub Actions workflow runs without being blocked by the branch restriction

### Why make this change?

The JSON file validation helps catch syntax errors early in the development process, improving code quality. Disabling the branch restriction check in CI prevents the workflow from failing when commits are made directly to protected branches during automated processes.