### PR TITLE
Remove RealSense test and camera benchmark tools from build

### DIFF
--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -421,6 +421,11 @@ int main(int argc, char** argv) {
       false);
   }
 
+  // TODO(shantanuparab-tr): Create a method for checking if all the hardware
+  // producers are ready before starting the recording. For now, adding a sleep.
+  // Sleep briefly to ensure everything is settled
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+
   // ──────────────────────────────────────────────────────────
   // Recording loop: record requested number of episodes
   // ──────────────────────────────────────────────────────────


### PR DESCRIPTION
### TL;DR

Added a delay before recording starts and removed unnecessary build targets from examples CMakeLists.txt.

### What changed?

- Added a 5-second sleep before starting the recording loop in `widowxai_lerobot.cpp` to ensure all hardware producers are ready
- Removed build targets for RealSense test script and camera benchmark tool from `examples/CMakeLists.txt`

### Why make this change?

The 5-second delay was added to ensure hardware producers are properly initialized before recording begins, preventing potential issues with incomplete or corrupted recordings. The build targets were removed to clean up the build system and remove unnecessary components from the examples directory.