### PR TITLE
Add ActiveHardwareRegistry and registry demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ add_library(trossen_sdk SHARED
   src/backends/null/null_backend.cpp
   src/configuration/global_config.cpp
   src/configuration/loaders/json_loader.cpp
+  src/hw/hardware_registry.cpp
+  src/hw/active_hardware_registry.cpp
+  src/hw/arm/trossen_arm_component.cpp
   src/hw/arm/arm_producer.cpp
   src/hw/arm/teleop_arm_producer.cpp
   src/hw/arm/mock_joint_producer.cpp
@@ -24,6 +27,7 @@ add_library(trossen_sdk SHARED
   src/hw/arm/so101_arm_driver.cpp
   src/hw/arm/feetech_bus.cpp
   src/hw/arm/so101_teleop_arm_producer.cpp
+  src/hw/camera/opencv_camera_component.cpp
   src/hw/camera/opencv_producer.cpp
   src/hw/camera/mock_producer.cpp
   src/hw/camera/mock_synced_producer.cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,3 +25,7 @@ target_link_libraries(widowxai_bimanual demo_utils trossen_sdk libtrossen_arm)
 # Backend registry demo
 add_executable(backend_registry_demo backend_registry_demo.cpp)
 target_link_libraries(backend_registry_demo trossen_sdk)
+
+# Hardware registry demo
+add_executable(hardware_registry_demo hardware_registry_demo.cpp)
+target_link_libraries(hardware_registry_demo trossen_sdk)

--- a/examples/hardware_registry_demo.cpp
+++ b/examples/hardware_registry_demo.cpp
@@ -1,0 +1,82 @@
+/**
+ * @file hardware_registry_demo.cpp
+ * @brief Simple demo of the HardwareRegistry and ActiveHardwareRegistry systems
+ */
+
+#include <iostream>
+
+#include "nlohmann/json.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+
+// Mock hardware component for demo (doesn't require real devices)
+namespace demo {
+
+class MockArmComponent : public trossen::hw::HardwareComponent {
+public:
+  explicit MockArmComponent(const std::string& identifier)
+    : HardwareComponent(identifier) {}
+
+  void configure(const nlohmann::json& config) override {
+    num_joints_ = config.value("num_joints", 6);
+    std::cout << "  ✓ Configured '" << get_identifier()
+              << "' (" << num_joints_ << " joints)\n";
+  }
+
+  std::string get_type() const override { return "mock_arm"; }
+  nlohmann::json get_info() const override {
+    return {{"type", "mock_arm"}, {"num_joints", num_joints_}};
+  }
+  int get_num_joints() const { return num_joints_; }
+
+private:
+  int num_joints_ = 6;
+};
+
+// Register with the hardware registry
+REGISTER_HARDWARE(MockArmComponent, "mock_arm")
+
+}  // namespace demo
+
+int main() {
+  std::cout << "\nHardware Registry Demo\n";
+  std::cout << "======================\n\n";
+
+  // 1. Create hardware from config
+  std::cout << "Creating hardware from config:\n";
+  nlohmann::json config = {{"num_joints", 7}};
+  // Create left mock arm. It will be auto-registered.
+  auto left_arm = trossen::hw::HardwareRegistry::create("mock_arm", "left_arm", config);
+  // Create right mock arm but do not auto-register
+  auto right_arm = trossen::hw::HardwareRegistry::create(
+    "mock_arm", "right_arm", {{"num_joints", 6}}, false);
+
+  // 2. Register in active registry
+  std::cout << "\nRegistering hardware:\n";
+  // We only registered left_arm during creation; now register right_arm
+  trossen::hw::ActiveHardwareRegistry::register_active("right_arm", right_arm);
+  std::cout << "  ✓ " << trossen::hw::ActiveHardwareRegistry::count()
+            << " hardware components active\n";
+
+  // 3. Retrieve and use hardware
+  std::cout << "\nRetrieving hardware:\n";
+  auto arm = trossen::hw::ActiveHardwareRegistry::get_as<demo::MockArmComponent>("left_arm");
+  if (arm) {
+    std::cout << "  ✓ Retrieved '" << arm->get_identifier()
+              << "' with " << arm->get_num_joints() << " joints\n";
+  }
+
+  // 4. List all hardware
+  std::cout << "\nActive hardware:\n";
+  for (const auto& id : trossen::hw::ActiveHardwareRegistry::get_ids()) {
+    auto hw = trossen::hw::ActiveHardwareRegistry::get(id);
+    std::cout << "  • " << id << " (" << hw->get_type() << ")\n";
+  }
+
+  // 5. Cleanup
+  trossen::hw::ActiveHardwareRegistry::clear();
+  std::cout << "\n✓ Demo complete!\n\n";
+
+  return 0;
+}

--- a/include/trossen_sdk/hw/active_hardware_registry.hpp
+++ b/include/trossen_sdk/hw/active_hardware_registry.hpp
@@ -1,0 +1,112 @@
+/**
+ * @file active_hardware_registry.hpp
+ * @brief Registry for tracking active hardware component instances
+ */
+
+#ifndef TROSSEN_SDK__HW__ACTIVE_HARDWARE_REGISTRY_HPP_
+#define TROSSEN_SDK__HW__ACTIVE_HARDWARE_REGISTRY_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "trossen_sdk/hw/hardware_component.hpp"
+
+namespace trossen::hw {
+
+/**
+ * @brief Singleton registry for active hardware component instances
+ *
+ * Tracks hardware components that have been created and configured during
+ * application lifetime. Provides named access for producer creation.
+ *
+ * Lifecycle is tied to application scope (not session scope). Hardware
+ * persists across multiple recording episodes.
+ */
+class ActiveHardwareRegistry {
+public:
+  /**
+   * @brief Register an active hardware component
+   *
+   * @param id Unique identifier for this hardware instance
+   * @param component Shared pointer to hardware component
+   *
+   * @throws std::runtime_error if id is already registered
+   */
+  static void register_active(
+    const std::string& id,
+    std::shared_ptr<HardwareComponent> component);
+
+  /**
+   * @brief Get an active hardware component by ID
+   *
+   * @param id Hardware component identifier
+   * @return Shared pointer to component, or nullptr if not found
+   */
+  static std::shared_ptr<HardwareComponent> get(const std::string& id);
+
+  /**
+   * @brief Get an active hardware component with type checking
+   *
+   * @tparam T Expected hardware component type
+   * @param id Hardware component identifier
+   * @return Shared pointer to component of type T, or nullptr if not found or wrong type
+   */
+  template<typename T>
+  static std::shared_ptr<T> get_as(const std::string& id) {
+    auto component = get(id);
+    return std::dynamic_pointer_cast<T>(component);
+  }
+
+  /**
+   * @brief Get all active hardware components
+   *
+   * @return Map of id -> component for all registered hardware
+   */
+  static std::map<std::string, std::shared_ptr<HardwareComponent>> get_all();
+
+  /**
+   * @brief Get all active hardware IDs
+   *
+   * @return Vector of registered hardware IDs
+   */
+  static std::vector<std::string> get_ids();
+
+  /**
+   * @brief Check if a hardware ID is registered
+   *
+   * @param id Hardware component identifier
+   * @return true if hardware is registered, false otherwise
+   */
+  static bool is_registered(const std::string& id);
+
+  /**
+   * @brief Clear all active hardware components
+   *
+   * @note Should be called during application shutdown or when
+   *       reconfiguring hardware completely.
+   */
+  static void clear();
+
+  /**
+   * @brief Get the number of active hardware components
+   *
+   * @return Count of registered hardware
+   */
+  static size_t count();
+
+private:
+  /**
+   * @brief Get the singleton registry map
+   *
+   * @return Reference to the static registry map
+   *
+   * @note Using a function-local static ensures proper initialization order
+   */
+  static std::map<std::string, std::shared_ptr<HardwareComponent>>& get_registry();
+};
+
+}  // namespace trossen::hw
+
+#endif  // TROSSEN_SDK__HW__ACTIVE_HARDWARE_REGISTRY_HPP_

--- a/include/trossen_sdk/hw/hardware_registry.hpp
+++ b/include/trossen_sdk/hw/hardware_registry.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
 #include "trossen_sdk/hw/hardware_component.hpp"
 
 namespace trossen::hw {
@@ -47,6 +48,7 @@ public:
    * @param type Hardware type string
    * @param identifier Unique identifier for this hardware instance
    * @param config JSON configuration for the hardware
+   * @param mark_active If true, register the created hardware in ActiveHardwareRegistry
    *
    * @return Shared pointer to created hardware instance
    *
@@ -56,7 +58,8 @@ public:
   static std::shared_ptr<HardwareComponent> create(
     const std::string& type,
     const std::string& identifier,
-    const nlohmann::json& config);
+    const nlohmann::json& config,
+    bool mark_active = true);
 
   /**
    * @brief Check if a hardware type is registered

--- a/src/hw/active_hardware_registry.cpp
+++ b/src/hw/active_hardware_registry.cpp
@@ -1,0 +1,68 @@
+/**
+ * @file active_hardware_registry.cpp
+ * @brief Implementation of the active hardware registry
+ */
+
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include <stdexcept>
+
+namespace trossen::hw {
+
+std::map<std::string, std::shared_ptr<HardwareComponent>>&
+ActiveHardwareRegistry::get_registry() {
+  // This static variable is the singleton registry map and is initialized on first use
+  static std::map<std::string, std::shared_ptr<HardwareComponent>> registry;
+  return registry;
+}
+
+void ActiveHardwareRegistry::register_active(
+  const std::string& id,
+  std::shared_ptr<HardwareComponent> component)
+{
+  if (!component) {
+    throw std::runtime_error("Cannot register null hardware component with id: " + id);
+  }
+
+  auto& registry = get_registry();
+
+  if (registry.find(id) != registry.end()) {
+    throw std::runtime_error("Hardware component already registered with id: " + id);
+  }
+
+  registry[id] = component;
+}
+
+std::shared_ptr<HardwareComponent> ActiveHardwareRegistry::get(const std::string& id) {
+  auto& registry = get_registry();
+  auto it = registry.find(id);
+  return (it != registry.end()) ? it->second : nullptr;
+}
+
+std::map<std::string, std::shared_ptr<HardwareComponent>>
+ActiveHardwareRegistry::get_all() {
+  return get_registry();
+}
+
+std::vector<std::string> ActiveHardwareRegistry::get_ids() {
+  auto& registry = get_registry();
+  std::vector<std::string> ids;
+  ids.reserve(registry.size());
+  for (const auto& [id, _] : registry) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+bool ActiveHardwareRegistry::is_registered(const std::string& id) {
+  return get_registry().find(id) != get_registry().end();
+}
+
+void ActiveHardwareRegistry::clear() {
+  get_registry().clear();
+}
+
+size_t ActiveHardwareRegistry::count() {
+  return get_registry().size();
+}
+
+}  // namespace trossen::hw

--- a/src/hw/hardware_registry.cpp
+++ b/src/hw/hardware_registry.cpp
@@ -24,7 +24,8 @@ void HardwareRegistry::register_hardware(const std::string& type, FactoryFunc fa
 std::shared_ptr<HardwareComponent> HardwareRegistry::create(
   const std::string& type,
   const std::string& identifier,
-  const nlohmann::json& config)
+  const nlohmann::json& config,
+  bool mark_active)
 {
   auto& registry = get_registry();
   auto it = registry.find(type);
@@ -42,6 +43,11 @@ std::shared_ptr<HardwareComponent> HardwareRegistry::create(
     throw std::runtime_error(
       "Failed to configure hardware '" + identifier + "' of type '" + type + "': " +
       e.what());
+  }
+
+  // Optionally register in active hardware registry
+  if (mark_active) {
+    ActiveHardwareRegistry::register_active(identifier, hardware);
   }
 
   return hardware;


### PR DESCRIPTION
This PR adds the `ActiveHardwareRegistry` to track currently-used hardware components built from the standard `HardwareRegistry`. It also adds a simple usage demo.