### PR TITLE
Add default configuration values and auto generate dataset id

### DIFF
--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -316,82 +316,83 @@ int main(int argc, char** argv) {
   auto camera_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.camera_fps));
   mgr.add_producer(camera_producer, camera_period);
 
-  // Create a Realsense Camera Producer (Hardcoded configuration for demo purposes)
+  // TODO(shantanuparab-tr): Add this to configurations after main executable is created
+  // // Create a Realsense Camera Producer (Hardcoded configuration for demo purposes)
 
-  trossen::hw::camera::RealsenseCameraProducer::Config realsense_cfg;
-  realsense_cfg.serial_number = "218622274938";  // Replace with your camera's serial number
-  realsense_cfg.stream_id = "realsense_camera0";
-  realsense_cfg.encoding = "bgr8";
-  realsense_cfg.width = 640;
-  realsense_cfg.height = 480;
-  realsense_cfg.fps = 30;
-  realsense_cfg.use_device_time = true;
-  realsense_cfg.warmup_seconds = 2.0;
+  // trossen::hw::camera::RealsenseCameraProducer::Config realsense_cfg;
+  // realsense_cfg.serial_number = "218622274938";  // Replace with your camera's serial number
+  // realsense_cfg.stream_id = "realsense_camera0";
+  // realsense_cfg.encoding = "bgr8";
+  // realsense_cfg.width = 640;
+  // realsense_cfg.height = 480;
+  // realsense_cfg.fps = 30;
+  // realsense_cfg.use_device_time = true;
+  // realsense_cfg.warmup_seconds = 2.0;
 
-  // Create Realsense config
-  rs2::config cam_cfg;
+  // // Create Realsense config
+  // rs2::config cam_cfg;
 
-  // Create a realsense pipeline
-  rs2::pipeline realsense_pipeline;
-  auto camera_ = std::make_shared<rs2::pipeline>(realsense_pipeline);
+  // // Create a realsense pipeline
+  // rs2::pipeline realsense_pipeline;
+  // auto camera_ = std::make_shared<rs2::pipeline>(realsense_pipeline);
 
-  // Enable the device using the unique ID
-  if (!realsense_cfg.serial_number.empty()) {
-    cam_cfg.enable_device(realsense_cfg.serial_number);
-  } else {
-    std::cout << "Unique ID is empty. Cannot connect to RealSense camera: "
-      << realsense_cfg.stream_id << std::endl;
-    throw std::runtime_error("Unique ID is empty for camera: " + realsense_cfg.stream_id);
-  }
+  // // Enable the device using the unique ID
+  // if (!realsense_cfg.serial_number.empty()) {
+  //   cam_cfg.enable_device(realsense_cfg.serial_number);
+  // } else {
+  //   std::cout << "Unique ID is empty. Cannot connect to RealSense camera: "
+  //     << realsense_cfg.stream_id << std::endl;
+  //   throw std::runtime_error("Unique ID is empty for camera: " + realsense_cfg.stream_id);
+  // }
 
-  // Enable the color stream as default
-  cam_cfg.enable_stream(RS2_STREAM_COLOR, realsense_cfg.width, realsense_cfg.height,
-                    RS2_FORMAT_RGB8, realsense_cfg.fps);
+  // // Enable the color stream as default
+  // cam_cfg.enable_stream(RS2_STREAM_COLOR, realsense_cfg.width, realsense_cfg.height,
+  //                   RS2_FORMAT_RGB8, realsense_cfg.fps);
 
-  // Make this conditional to enable depth stream
-  cam_cfg.enable_stream(RS2_STREAM_DEPTH, realsense_cfg.width, realsense_cfg.height,
-                    RS2_FORMAT_Z16, realsense_cfg.fps);
-  try {
-    // Start the camera pipeline
-    rs2::pipeline_profile profile = camera_->start(cam_cfg);
-  } catch (const rs2::error& e) {
-    std::cout << "Failed to enable device with Unique ID: " << realsense_cfg.serial_number
-              << ". Error: " << e.what() << ". Listing all available cameras." << std::endl;
-    std::cout << "Available cameras listed above. Please check outputs folder to get "
-        "Available cameras listed above. Please check outputs folder to get "
-        "images associated "
-        "with each camera." << std::endl;
-    throw std::runtime_error(
-        "Unique ID (serial number) is required to connect to RealSense camera");
-  }
+  // // Make this conditional to enable depth stream
+  // cam_cfg.enable_stream(RS2_STREAM_DEPTH, realsense_cfg.width, realsense_cfg.height,
+  //                   RS2_FORMAT_Z16, realsense_cfg.fps);
+  // try {
+  //   // Start the camera pipeline
+  //   rs2::pipeline_profile profile = camera_->start(cam_cfg);
+  // } catch (const rs2::error& e) {
+  //   std::cout << "Failed to enable device with Unique ID: " << realsense_cfg.serial_number
+  //             << ". Error: " << e.what() << ". Listing all available cameras." << std::endl;
+  //   std::cout << "Available cameras listed above. Please check outputs folder to get "
+  //       "Available cameras listed above. Please check outputs folder to get "
+  //       "images associated "
+  //       "with each camera." << std::endl;
+  //   throw std::runtime_error(
+  //       "Unique ID (serial number) is required to connect to RealSense camera");
+  // }
 
-  auto frame_cache = std::make_shared<trossen::hw::camera::RealsenseFrameCache>(camera_, 2);
+  // auto frame_cache = std::make_shared<trossen::hw::camera::RealsenseFrameCache>(camera_, 2);
 
-  auto realsense_producer =
-    std::make_shared<trossen::hw::camera::RealsenseCameraProducer>(frame_cache, realsense_cfg);
+  // auto realsense_producer =
+  //   std::make_shared<trossen::hw::camera::RealsenseCameraProducer>(frame_cache, realsense_cfg);
 
-  auto realsense_period = std::chrono::milliseconds(static_cast<int>(1000.0f / 30.0f));
+  // auto realsense_period = std::chrono::milliseconds(static_cast<int>(1000.0f / 30.0f));
 
-  mgr.add_producer(realsense_producer, realsense_period);
-  std::cout << "  ✓ Realsense camera producer (30 Hz, 640x480)\n";
+  // mgr.add_producer(realsense_producer, realsense_period);
+  // std::cout << "  ✓ Realsense camera producer (30 Hz, 640x480)\n";
 
-  trossen::hw::camera::RealsenseDepthCameraProducer::Config realsense_depth_cfg;
+  // trossen::hw::camera::RealsenseDepthCameraProducer::Config realsense_depth_cfg;
+  // // Replace with your camera's serial number
+  // realsense_depth_cfg.serial_number = "218622274938";
+  // realsense_depth_cfg.stream_id = "realsense_depth_camera0";
+  // realsense_depth_cfg.encoding = "16UC1";
+  // realsense_depth_cfg.width = 640;
+  // realsense_depth_cfg.height = 480;
+  // realsense_depth_cfg.fps = 30;
+  // realsense_depth_cfg.use_device_time = true;
+  // realsense_depth_cfg.warmup_seconds = 2.0;
 
-  realsense_depth_cfg.serial_number = "218622274938";  // Replace with your camera's serial number
-  realsense_depth_cfg.stream_id = "realsense_depth_camera0";
-  realsense_depth_cfg.encoding = "16UC1";
-  realsense_depth_cfg.width = 640;
-  realsense_depth_cfg.height = 480;
-  realsense_depth_cfg.fps = 30;
-  realsense_depth_cfg.use_device_time = true;
-  realsense_depth_cfg.warmup_seconds = 2.0;
-
-  auto realsense_depth_producer =
-    std::make_shared<trossen::hw::camera::RealsenseDepthCameraProducer>(
-      frame_cache,
-      realsense_depth_cfg);
-  mgr.add_producer(realsense_depth_producer, realsense_period);
-  std::cout << "  ✓ Realsense depth camera producer (30 Hz, 640x480)\n";
+  // auto realsense_depth_producer =
+  //   std::make_shared<trossen::hw::camera::RealsenseDepthCameraProducer>(
+  //     frame_cache,
+  //     realsense_depth_cfg);
+  // mgr.add_producer(realsense_depth_producer, realsense_period);
+  // std::cout << "  ✓ Realsense depth camera producer (30 Hz, 640x480)\n";
 
   std::cout << "\nProducers registered. Ready to record.\n";
 

--- a/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
@@ -14,36 +14,39 @@
 namespace trossen::configuration {
 
 struct LeRobotBackendConfig : public BaseConfig {
-  int encoder_threads{1};
-  int max_image_queue{0};
-  int png_compression_level{3};
-  bool overwrite_existing{false};
-  bool encode_videos{false};
-  std::string task_name{"default_task"};
-  std::string repository_id{"default_repo"};
-  std::string dataset_id{"default_dataset"};
+  int encoder_threads{trossen::io::backends::DEFAULT_ENCODER_THREADS};
+  int max_image_queue{trossen::io::backends::DEFAULT_MAX_IMAGE_QUEUE};
+  int png_compression_level{trossen::io::backends::DEFAULT_PNG_COMPRESSION_LEVEL};
+  bool overwrite_existing{trossen::io::backends::DEFAULT_OVERWRITE_EXISTING};
+  bool encode_videos{trossen::io::backends::DEFAULT_ENCODE_VIDEOS};
+  std::string task_name{trossen::io::backends::DEFAULT_TASK_NAME};
+  std::string repository_id{trossen::io::backends::DEFAULT_REPOSITORY_ID};
+  std::string dataset_id{trossen::io::backends::auto_generate_dataset_id()};
   std::string root{trossen::io::backends::get_default_root_path().string()};
-  int episode_index{0};
-  std::string robot_name{"trossen_ai_generic"};
-  float fps{30.0f};
+  // TODO(shantanuparab-tr): DRemove episode index if not being used
+  int episode_index{trossen::io::backends::DEFAULT_EPISODE_INDEX};
+  std::string robot_name{trossen::io::backends::DEFAULT_ROBOT_NAME};
+  float fps{trossen::io::backends::DEFAULT_FPS};
 
   std::string type() const override { return "lerobot_backend"; }
 
   static LeRobotBackendConfig from_json(const nlohmann::json& j) {
-    LeRobotBackendConfig c;
-    c.root = j.value("root", "");
-    c.encoder_threads = j.value("encoder_threads", 1);
-    c.max_image_queue = j.value("max_image_queue", 0);
-    c.png_compression_level = j.value("png_compression_level", 3);
-    // c.drop_policy = j.value("drop_policy", "DropNewest");
-    c.overwrite_existing = j.value("overwrite_existing", false);
-    c.encode_videos = j.value("encode_videos", false);
-    c.task_name = j.value("task_name", "default_task");
-    c.repository_id = j.value("repository_id", "default_repo");
-    c.dataset_id = j.value("dataset_id", "default_dataset");
-    c.episode_index = j.value("episode_index", 0);
-    c.robot_name = j.value("robot_name", "trossen_ai_generic");
-    c.fps = j.value("fps", 30.0f);
+    LeRobotBackendConfig c;  // All defaults already set by member initializers
+
+    // Only override if present in JSON
+    if (j.contains("root")) j.at("root").get_to(c.root);
+    if (j.contains("encoder_threads")) j.at("encoder_threads").get_to(c.encoder_threads);
+    if (j.contains("max_image_queue")) j.at("max_image_queue").get_to(c.max_image_queue);
+    if (j.contains("png_compression_level"))
+      j.at("png_compression_level").get_to(c.png_compression_level);
+    if (j.contains("overwrite_existing")) j.at("overwrite_existing").get_to(c.overwrite_existing);
+    if (j.contains("encode_videos")) j.at("encode_videos").get_to(c.encode_videos);
+    if (j.contains("task_name")) j.at("task_name").get_to(c.task_name);
+    if (j.contains("repository_id")) j.at("repository_id").get_to(c.repository_id);
+    if (j.contains("dataset_id")) j.at("dataset_id").get_to(c.dataset_id);
+    if (j.contains("episode_index")) j.at("episode_index").get_to(c.episode_index);
+    if (j.contains("robot_name")) j.at("robot_name").get_to(c.robot_name);
+    if (j.contains("fps")) j.at("fps").get_to(c.fps);
 
     return c;
   }

--- a/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
@@ -15,22 +15,25 @@ namespace trossen::configuration {
 
 struct McapBackendConfig : public BaseConfig {
   std::string root{trossen::io::backends::get_default_root_path().string()};
-  std::string robot_name{"/robot/joint_states"};
-  int chunk_size_bytes{4 * 1024 * 1024};
-  std::string compression{""};
-  std::string dataset_id;
+  std::string robot_name{trossen::io::backends::DEFAULT_ROBOT_NAME};
+  int chunk_size_bytes{trossen::io::backends::DEFAULT_CHUNK_SIZE_BYTES};
+  std::string compression{trossen::io::backends::DEFAULT_COMPRESSION};
+  std::string dataset_id{trossen::io::backends::auto_generate_dataset_id()};
+  // TODO(shantanuparab-tr): Remove episode index if not being used
   int episode_index{0};
 
   std::string type() const override { return "mcap_backend"; }
 
   static  McapBackendConfig from_json(const nlohmann::json& j) {
     McapBackendConfig c;
-    c.root = j.value("root", "");
-    c.robot_name = j.value("robot_name", "/robot/joint_states");
-    c.chunk_size_bytes = j.value("chunk_size_bytes", 4 * 1024 * 1024);
-    c.compression = j.value("compression", "");
-    c.dataset_id = j.at("dataset_id").get<std::string>();
-    c.episode_index = j.value("episode_index", 0);
+
+    // Only override if present in JSON
+    if (j.contains("root")) j.at("root").get_to(c.root);
+    if (j.contains("robot_name")) j.at("robot_name").get_to(c.robot_name);
+    if (j.contains("chunk_size_bytes")) j.at("chunk_size_bytes").get_to(c.chunk_size_bytes);
+    if (j.contains("compression")) j.at("compression").get_to(c.compression);
+    if (j.contains("dataset_id")) j.at("dataset_id").get_to(c.dataset_id);
+    if (j.contains("episode_index")) j.at("episode_index").get_to(c.episode_index);
 
     return c;
   }

--- a/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
@@ -14,24 +14,22 @@
 namespace trossen::configuration {
 
 struct TrossenBackendConfig : public BaseConfig {
-  std::string root{"/data/trossen"};
-  int encoder_threads{1};
-  int max_image_queue{0};
-  int png_compression_level{3};
-  std::string drop_policy{"DropNewest"};
+  std::string root{trossen::io::backends::get_default_root_path().string()};
+  int encoder_threads{trossen::io::backends::DEFAULT_ENCODER_THREADS};
+  int max_image_queue{trossen::io::backends::DEFAULT_MAX_IMAGE_QUEUE};
+  int png_compression_level{trossen::io::backends::DEFAULT_PNG_COMPRESSION_LEVEL};
+  std::string drop_policy{trossen::io::backends::DEFAULT_DROP_POLICY};
 
   std::string type() const override { return "trossen_backend"; }
 
   static TrossenBackendConfig from_json(const nlohmann::json& j) {
     TrossenBackendConfig c;
-    c.root = j.value("root", "");
-    if (c.root.empty()) {
-        c.root = trossen::io::backends::get_default_root_path().string();
-    }
-    c.encoder_threads = j.value("encoder_threads", 1);
-    c.max_image_queue = j.value("max_image_queue", 0);
-    c.png_compression_level = j.value("png_compression_level", 3);
-    c.drop_policy = j.value("drop_policy", "DropNewest");
+    if (j.contains("root")) j.at("root").get_to(c.root);
+    if (j.contains("encoder_threads")) j.at("encoder_threads").get_to(c.encoder_threads);
+    if (j.contains("max_image_queue")) j.at("max_image_queue").get_to(c.max_image_queue);
+    if (j.contains("png_compression_level"))
+      j.at("png_compression_level").get_to(c.png_compression_level);
+    if (j.contains("drop_policy")) j.at("drop_policy").get_to(c.drop_policy);
 
     return c;
   }

--- a/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
+++ b/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
@@ -23,14 +23,16 @@ struct SessionManagerConfig : public BaseConfig {
 
   static SessionManagerConfig from_json(const nlohmann::json& j) {
     SessionManagerConfig c;
-    c.max_duration = j.contains("max_duration")
-      ? std::optional<std::chrono::duration<double>>{
-        std::chrono::duration<double>{j.at("max_duration").get<double>()}}
-      : std::nullopt;
-    c.max_episodes = j.contains("max_episodes")
-      ? std::optional<uint32_t>{j.at("max_episodes").get<uint32_t>()}
-      : std::nullopt;
-    c.backend_type = j.value("backend_type", "mcap");
+
+    if (j.contains("max_duration")) {
+      c.max_duration = std::chrono::duration<double>{j.at("max_duration").get<double>()};
+    }
+    if (j.contains("max_episodes")) {
+      c.max_episodes = j.at("max_episodes").get<uint32_t>();
+    }
+    if (j.contains("backend_type")) {
+      j.at("backend_type").get_to(c.backend_type);
+    }
 
     return c;
   }

--- a/include/trossen_sdk/io/backend_utils.hpp
+++ b/include/trossen_sdk/io/backend_utils.hpp
@@ -25,6 +25,7 @@ inline std::filesystem::path get_default_root_path() {
 
 /**
  * @brief Auto-generate a dataset ID based on the current timestamp
+ * @return Generated dataset ID string
  */
 inline std::string auto_generate_dataset_id() {
   // Generate a timestamp-based dataset ID

--- a/include/trossen_sdk/io/backend_utils.hpp
+++ b/include/trossen_sdk/io/backend_utils.hpp
@@ -23,6 +23,34 @@ inline std::filesystem::path get_default_root_path() {
   }
 }
 
+/**
+ * @brief Auto-generate a dataset ID based on the current timestamp
+ */
+inline std::string auto_generate_dataset_id() {
+  // Generate a timestamp-based dataset ID
+  auto now = std::chrono::system_clock::now();
+  auto time_t_now = std::chrono::system_clock::to_time_t(now);
+  std::ostringstream oss;
+  // Format: dataset_YYYYMMDD_HHMMSS in local time
+  oss << "dataset_" << std::put_time(std::localtime(&time_t_now), "%Y%m%d_%H%M%S");
+  return oss.str();
+}
+
+// Constants for default variables
+constexpr int DEFAULT_ENCODER_THREADS = 1;
+constexpr int DEFAULT_MAX_IMAGE_QUEUE = 0;
+constexpr int DEFAULT_PNG_COMPRESSION_LEVEL = 3;
+constexpr bool DEFAULT_OVERWRITE_EXISTING = false;
+constexpr bool DEFAULT_ENCODE_VIDEOS = false;
+constexpr char DEFAULT_TASK_NAME[] = "perform a generic task";
+constexpr char DEFAULT_REPOSITORY_ID[] = "TrossenRoboticsCommunity";
+constexpr char DEFAULT_ROBOT_NAME[] = "trossen_ai_stationary";
+constexpr float DEFAULT_FPS = 30.0f;
+constexpr int DEFAULT_CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
+constexpr char DEFAULT_COMPRESSION[] = "";
+constexpr char DEFAULT_DROP_POLICY[] = "DropNewest";
+constexpr int DEFAULT_EPISODE_INDEX = 0;
+
 }  // namespace trossen::io::backends
 
 #endif  // INCLUDE_TROSSEN_SDK_IO_BACKEND_UTILS_HPP_

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -46,29 +46,6 @@ SessionManager::SessionManager(){
     std::cout << "Backend Type: (none)" << std::endl;
   }
   std::cout << "==========================================================" << std::endl;
-  // TODO(shantanuparab-tr): Move this logic to a backend utility function
-  // Validate required configuration
-  // if (cfg_->base_path.empty()) {
-  //   throw std::invalid_argument("SessionConfig::base_path cannot be empty");
-  // }
-
-  // // Create base directory if it doesn't exist
-  // if (!std::filesystem::exists(cfg_->base_path)) {
-  //   // TODO(lukeschmitt-tr): Handle potential errors
-  //   std::filesystem::create_directories(cfg_->base_path);
-  // }
-
-  // // Auto-generate dataset_id if not provided
-  // if (cfg_->dataset_id.empty()) {
-  //   // TODO(lukeschmitt-tr): Generate UUID (for now, use timestamp-based ID)
-  //   auto now = std::chrono::system_clock::now();
-  //   auto time_t_now = std::chrono::system_clock::to_time_t(now);
-  //   std::ostringstream oss;
-  //   // Format: dataset_YYYYMMDD_HHMMSS in local time
-  //   oss << "dataset_" << std::put_time(std::localtime(&time_t_now), "%Y%m%d_%H%M%S");
-  //   cfg_->dataset_id = oss.str();
-  //   std::cout << "Auto-generated dataset_id: " << cfg_->dataset_id << std::endl;
-  // }
 }
 
 SessionManager::~SessionManager() {


### PR DESCRIPTION
### TL;DR

Commented out RealSense camera code and improved configuration handling with default values.

### What changed?

- Commented out the RealSense camera producer code in `widowxai_lerobot.cpp` with a TODO to add it to configurations later
- Added default constants in `backend_utils.hpp` for all configuration parameters
- Implemented an `auto_generate_dataset_id()` function to create timestamp-based dataset IDs
- Refactored configuration parsing in backend config classes to use the new default values
- Improved JSON parsing to only override values when explicitly present in the JSON

### How to test?

1. Build and run the `widowxai_lerobot` example to verify.
2. Create configurations with partial settings to verify defaults are properly applied
3. Check that dataset IDs are automatically generated with the timestamp format when not specified

### Why make this change?

- Using constants for default values improves maintainability and consistency
- The improved JSON parsing is more robust by only overriding values when explicitly provided
- Auto-generating dataset IDs ensures unique identifiers without requiring manual configuration