### PR TITLE
Add real hardware support to hardware registry demo

### DIFF
--- a/examples/hardware_registry_demo.cpp
+++ b/examples/hardware_registry_demo.cpp
@@ -9,6 +9,9 @@
 #include "trossen_sdk/hw/active_hardware_registry.hpp"
 #include "trossen_sdk/hw/hardware_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
+#include "trossen_sdk/hw/camera/realsense_camera_component.hpp"
+#include "trossen_sdk/hw/camera/opencv_camera_component.hpp"
 
 // Mock hardware component for demo (doesn't require real devices)
 namespace demo {
@@ -39,12 +42,24 @@ REGISTER_HARDWARE(MockArmComponent, "mock_arm")
 
 }  // namespace demo
 
-int main() {
+int main(int argc, char** argv) {
+  // Parse command line arguments
+  bool use_real_hardware = false;
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--real") {
+      use_real_hardware = true;
+      break;
+    }
+  }
+
   std::cout << "\nHardware Registry Demo\n";
   std::cout << "======================\n\n";
 
-  // 1. Create hardware from config
-  std::cout << "Creating hardware from config:\n";
+  // 1. Create Hardware from configuration
+  std::cout << "Creating hardware components from configuration...\n";
+
+  // 1.1 Mock Arms hardware
+  std::cout << "Mock Arms hardware from config:\n";
   nlohmann::json config = {{"num_joints", 7}};
   // Create left mock arm. It will be auto-registered.
   auto left_arm = trossen::hw::HardwareRegistry::create("mock_arm", "left_arm", config);
@@ -52,10 +67,55 @@ int main() {
   auto right_arm = trossen::hw::HardwareRegistry::create(
     "mock_arm", "right_arm", {{"num_joints", 6}}, false);
 
+  std::shared_ptr<trossen::hw::HardwareComponent> real_arm;
+  std::shared_ptr<trossen::hw::HardwareComponent> realsense_camera;
+  std::shared_ptr<trossen::hw::HardwareComponent> opencv_camera;
+
+  if (use_real_hardware) {
+    // 1.2 Real Arms hardware
+    std::cout << "\nReal Trossen Arms hardware from config:\n";
+    nlohmann::json real_arm_config = {
+      {"ip_address", "192.168.1.2"},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_leader"}
+    };
+    real_arm = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", "real_arm", real_arm_config);
+
+    // 1.3 Realsense Camera hardware
+    std::cout << "\nReal Realsense Camera hardware from config:\n";
+    nlohmann::json camera_config = {
+      {"serial_number", "218622274938"},
+      {"width", 640},
+      {"height", 480},
+      {"fps", 30}
+    };
+    realsense_camera = trossen::hw::HardwareRegistry::create(
+      "realsense_camera", "realsense_camera0", camera_config);
+
+    // 1.4 OpenCV Camera hardware
+    std::cout << "\nReal OpenCV Camera hardware from config:\n";
+    nlohmann::json opencv_camera_config = {
+      {"device_index", 0},
+      {"width", 640},
+      {"height", 480},
+      {"fps", 30}
+    };
+
+    opencv_camera = trossen::hw::HardwareRegistry::create(
+      "opencv_camera", "opencv_camera0", opencv_camera_config);
+  }
+
   // 2. Register in active registry
   std::cout << "\nRegistering hardware:\n";
   // We only registered left_arm during creation; now register right_arm
   trossen::hw::ActiveHardwareRegistry::register_active("right_arm", right_arm);
+
+  if (use_real_hardware) {
+    trossen::hw::ActiveHardwareRegistry::register_active("real_arm", real_arm);
+    trossen::hw::ActiveHardwareRegistry::register_active("realsense_camera0", realsense_camera);
+    trossen::hw::ActiveHardwareRegistry::register_active("opencv_camera0", opencv_camera);
+  }
   std::cout << "  ✓ " << trossen::hw::ActiveHardwareRegistry::count()
             << " hardware components active\n";
 


### PR DESCRIPTION
### TL;DR

Added support for real hardware components in the hardware registry demo.

### What changed?

- Modified the hardware registry demo to accept a `--real` command line flag
- Added support for three real hardware components when the flag is used:
  - Trossen Arm component with configuration for IP address, model, and end effector
  - RealSense Camera component with configuration for serial number, resolution, and FPS
  - OpenCV Camera component with configuration for device index, resolution, and FPS
- Added necessary include statements for the new hardware components
- Updated the main function to register these real components in the active registry when enabled

### How to test?

1. Build the hardware registry demo
2. Run without arguments to see the mock hardware behavior:
   ```
   ./hardware_registry_demo
   ```
3. Run with the `--real` flag to test with real hardware components:
   ```
   ./hardware_registry_demo --real
   ```
4. Verify that the appropriate hardware components are created and registered based on the command line argument

### Why make this change?

This enhancement allows the demo to showcase both mock hardware for testing without physical devices and real hardware components when available. This provides a more complete demonstration of the hardware registry's capabilities and makes the demo more useful for real-world testing scenarios.