### PR TITLE
refactored configure for opencv to include warmup period

### DIFF
--- a/apps/soma/src/soma.cpp
+++ b/apps/soma/src/soma.cpp
@@ -219,17 +219,9 @@ int SomaApp::run() {
     cam_cfg.height = config_.camera_height;
     cam_cfg.fps = config_.camera_fps;
     cam_cfg.use_device_time = false;
-    cam_cfg.warmup_seconds = 2.0;
+    cam_cfg.warmup_frames = 30;
 
     auto cam_prod = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
-
-    std::cout << "Warming up camera " << i << " (/dev/video"
-              << config_.camera_indices[i] << ")...\n";
-    if (!cam_prod->warmup()) {
-      std::cerr << "Failed to warmup camera " << i << "\n";
-      return 1;
-    }
-
     mgr.add_producer(cam_prod, camera_period);
     std::cout << "Camera " << i << " producer (" << config_.camera_fps << " Hz, "
               << config_.camera_width << "x" << config_.camera_height << ")\n";

--- a/apps/soma/src/soma.cpp
+++ b/apps/soma/src/soma.cpp
@@ -219,7 +219,6 @@ int SomaApp::run() {
     cam_cfg.height = config_.camera_height;
     cam_cfg.fps = config_.camera_fps;
     cam_cfg.use_device_time = false;
-    cam_cfg.warmup_frames = 30;
 
     auto cam_prod = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
     mgr.add_producer(cam_prod, camera_period);

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -283,7 +283,6 @@ int main(int argc, char** argv) {
     cam_cfg.height = cfg.camera_height;
     cam_cfg.fps = cfg.camera_fps;
     cam_cfg.use_device_time = false;
-    cam_cfg.warmup_frames = 30;
     camera_producer = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
     std::cout << "  ✓ OpenCV camera producer (" << cfg.camera_fps << " Hz, "
               << cfg.camera_width << "x" << cfg.camera_height << ")\n";

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -283,17 +283,8 @@ int main(int argc, char** argv) {
     cam_cfg.height = cfg.camera_height;
     cam_cfg.fps = cfg.camera_fps;
     cam_cfg.use_device_time = false;
-    cam_cfg.warmup_seconds = 2.0;
+    cam_cfg.warmup_frames = 30;
     camera_producer = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
-
-    // Warmup camera before registering
-    std::cout << "    Warming up camera...\n";
-    auto opencv_cam =
-      std::static_pointer_cast<trossen::hw::camera::OpenCvCameraProducer>(camera_producer);
-    if (!opencv_cam->warmup()) {
-      std::cerr << "Failed to warmup camera\n";
-      return 1;
-    }
     std::cout << "  ✓ OpenCV camera producer (" << cfg.camera_fps << " Hz, "
               << cfg.camera_width << "x" << cfg.camera_height << ")\n";
   }

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -285,7 +285,6 @@ int main(int argc, char** argv) {
     cam_cfg.height = cfg.camera_height;
     cam_cfg.fps = cfg.camera_fps;
     cam_cfg.use_device_time = false;
-    cam_cfg.warmup_frames = 30;
     camera_producer = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
     std::cout << "  ✓ OpenCV camera producer (" << cfg.camera_fps << " Hz, "
               << cfg.camera_width << "x" << cfg.camera_height << ")\n";

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -285,17 +285,8 @@ int main(int argc, char** argv) {
     cam_cfg.height = cfg.camera_height;
     cam_cfg.fps = cfg.camera_fps;
     cam_cfg.use_device_time = false;
-    cam_cfg.warmup_seconds = 2.0;
+    cam_cfg.warmup_frames = 30;
     camera_producer = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
-
-    // Warmup camera before registering
-    std::cout << "    Warming up camera...\n";
-    auto opencv_cam =
-      std::static_pointer_cast<trossen::hw::camera::OpenCvCameraProducer>(camera_producer);
-    if (!opencv_cam->warmup()) {
-      std::cerr << "Failed to warmup camera\n";
-      return 1;
-    }
     std::cout << "  ✓ OpenCV camera producer (" << cfg.camera_fps << " Hz, "
               << cfg.camera_width << "x" << cfg.camera_height << ")\n";
   }

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -379,7 +379,6 @@ int main(int argc, char** argv) {
       cam_cfg.height = cfg.camera_height;
       cam_cfg.fps = cfg.camera_fps;
       cam_cfg.use_device_time = false;
-      cam_cfg.warmup_frames = 30;
 
       auto cam_prod = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
       camera_producers.push_back(cam_prod);

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -379,18 +379,9 @@ int main(int argc, char** argv) {
       cam_cfg.height = cfg.camera_height;
       cam_cfg.fps = cfg.camera_fps;
       cam_cfg.use_device_time = false;
-      cam_cfg.warmup_seconds = 2.0;
+      cam_cfg.warmup_frames = 30;
 
       auto cam_prod = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
-
-      // Warmup camera before registering
-      std::cout << "    Warming up camera " << i
-                << " (/dev/video" << cfg.camera_indices[i] << ")...\n";
-      if (!cam_prod->warmup()) {
-        std::cerr << "Failed to warmup camera " << i << "\n";
-        return 1;
-      }
-
       camera_producers.push_back(cam_prod);
       mgr.add_producer(cam_prod, camera_period);
       std::cout << "  ✓ Camera " << i << " producer (" << cfg.camera_fps << " Hz, "

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -308,17 +308,8 @@ int main(int argc, char** argv) {
     cam_cfg.height = cfg.camera_height;
     cam_cfg.fps = cfg.camera_fps;
     cam_cfg.use_device_time = false;
-    cam_cfg.warmup_seconds = 2.0;
+    cam_cfg.warmup_frames = 30;
     camera_producer = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
-
-    // Warmup camera before registering
-    std::cout << "    Warming up camera...\n";
-    auto opencv_cam =
-      std::static_pointer_cast<trossen::hw::camera::OpenCvCameraProducer>(camera_producer);
-    if (!opencv_cam->warmup()) {
-      std::cerr << "Failed to warmup camera\n";
-      return 1;
-    }
     std::cout << "  ✓ OpenCV camera producer (" << cfg.camera_fps << " Hz, "
               << cfg.camera_width << "x" << cfg.camera_height << ")\n";
   }

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -308,7 +308,6 @@ int main(int argc, char** argv) {
     cam_cfg.height = cfg.camera_height;
     cam_cfg.fps = cfg.camera_fps;
     cam_cfg.use_device_time = false;
-    cam_cfg.warmup_frames = 30;
     camera_producer = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
     std::cout << "  ✓ OpenCV camera producer (" << cfg.camera_fps << " Hz, "
               << cfg.camera_width << "x" << cfg.camera_height << ")\n";

--- a/include/trossen_sdk/hw/camera/opencv_camera_component.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_camera_component.hpp
@@ -41,7 +41,8 @@ public:
    *   "width": 640,
    *   "height": 480,
    *   "fps": 30,
-   *   "backend": "v4l2"  // optional, defaults to auto
+   *   "backend": "v4l2",      // optional, defaults to auto
+   *   "warmup_frames": 10     // optional, number of frames to discard after opening
    * }
    *
    * @param config JSON configuration object
@@ -100,6 +101,9 @@ private:
 
   /// @brief OpenCV backend API (e.g., CAP_V4L2, CAP_ANY)
   int backend_ = cv::CAP_ANY;
+
+  /// @brief Number of warmup frames to discard after opening
+  int warmup_frames_ = 0;
 };
 
 }  // namespace trossen::hw::camera

--- a/include/trossen_sdk/hw/camera/opencv_producer.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_producer.hpp
@@ -51,8 +51,8 @@ public:
     /// @brief Prefer device timestamp if available
     bool use_device_time{true};
 
-    /// @brief Seconds to warm up (discard frames) after device open before emitting
-    double warmup_seconds{0.0};
+    /// @brief Number of warmup frames to discard after device open before emitting
+    int warmup_frames{30};
 
     /// @brief Preferred FOURCC pixel formats (in order). Default: MJPG, YUYV
     std::vector<int32_t> preferred_fourcc = {
@@ -130,13 +130,6 @@ public:
    * @brief Destructor
    */
   ~OpenCvCameraProducer() override;
-
-  /**
-   * @brief Perform a blocking warmup (open device if needed, discard frames for warmup_seconds)
-   *
-   * @return true on success
-   */
-  bool warmup();
 
   /**
    * @brief Poll the producer for new data and emit records via the callback

--- a/include/trossen_sdk/hw/camera/opencv_producer.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_producer.hpp
@@ -51,9 +51,6 @@ public:
     /// @brief Prefer device timestamp if available
     bool use_device_time{true};
 
-    /// @brief Number of warmup frames to discard after device open before emitting
-    int warmup_frames{30};
-
     /// @brief Preferred FOURCC pixel formats (in order). Default: MJPG, YUYV
     std::vector<int32_t> preferred_fourcc = {
       cv::VideoWriter::fourcc('M', 'J', 'P', 'G'),

--- a/src/hw/camera/opencv_camera_component.cpp
+++ b/src/hw/camera/opencv_camera_component.cpp
@@ -93,6 +93,27 @@ void OpenCvCameraComponent::configure(const nlohmann::json& config) {
   std::cout << "Camera " << get_identifier() << " configured: "
             << width_ << "x" << height_ << " @ " << fps_
             << " FPS, FOURCC=" << fourcc_chars << std::endl;
+
+  // Parse optional warmup_frames parameter
+  if (config.contains("warmup_frames")) {
+    warmup_frames_ = config.at("warmup_frames").get<int>();
+  }
+
+  // Perform warmup: discard initial frames to allow camera to stabilize
+  if (warmup_frames_ > 0) {
+    std::cout << "Warming up camera " << get_identifier() << ": discarding "
+              << warmup_frames_ << " frames..." << std::endl;
+    cv::Mat warmup_frame;
+    int discarded = 0;
+    for (int i = 0; i < warmup_frames_; ++i) {
+      if (capture_->read(warmup_frame)) {
+        ++discarded;
+      } else {
+        std::cerr << "Warning: Failed to read warmup frame " << i << std::endl;
+      }
+    }
+    std::cout << "Warmup complete: discarded " << discarded << " frames" << std::endl;
+  }
 }
 
 nlohmann::json OpenCvCameraComponent::get_info() const {

--- a/src/hw/camera/opencv_producer.cpp
+++ b/src/hw/camera/opencv_producer.cpp
@@ -100,21 +100,6 @@ bool OpenCvCameraProducer::open_if_needed() {
   }
   opened_ = true;
 
-  // Perform warmup: discard initial frames to allow camera to stabilize
-  if (cfg_.warmup_frames > 0) {
-    std::cout << "Warming up camera (device " << cfg_.device_index
-              << "): discarding " << cfg_.warmup_frames << " frames..." << std::endl;
-    cv::Mat warmup_frame;
-    for (int i = 0; i < cfg_.warmup_frames; ++i) {
-      if (cap_.read(warmup_frame)) {
-        ++stats_.warmup_discarded;
-      } else {
-        std::cerr << "Warning: Failed to read warmup frame " << i << std::endl;
-      }
-    }
-    std::cout << "Warmup complete: discarded " << stats_.warmup_discarded << " frames" << std::endl;
-  }
-
   return true;
 }
 

--- a/src/hw/camera/opencv_producer.cpp
+++ b/src/hw/camera/opencv_producer.cpp
@@ -99,29 +99,22 @@ bool OpenCvCameraProducer::open_if_needed() {
               << cfg_.fps << " but device reports " << eff_fps << std::endl;
   }
   opened_ = true;
-  return true;
-}
 
-bool OpenCvCameraProducer::warmup() {
-  // TODO(lukeschmitt-tr): check that received frames are valid and match requested configuration
-  if (!open_if_needed()) {
-    return false;
-  }
-  if (cfg_.warmup_seconds <= 0.0) {
-    return true;
-  }
-  auto warmup_end =
-    std::chrono::steady_clock::now() + std::chrono::duration<double>(cfg_.warmup_seconds);
-  cv::Mat frame;
-  while (std::chrono::steady_clock::now() < warmup_end) {
-    if (!cap_.read(frame)) {
-      ++stats_.dropped;
-      continue;
+  // Perform warmup: discard initial frames to allow camera to stabilize
+  if (cfg_.warmup_frames > 0) {
+    std::cout << "Warming up camera (device " << cfg_.device_index
+              << "): discarding " << cfg_.warmup_frames << " frames..." << std::endl;
+    cv::Mat warmup_frame;
+    for (int i = 0; i < cfg_.warmup_frames; ++i) {
+      if (cap_.read(warmup_frame)) {
+        ++stats_.warmup_discarded;
+      } else {
+        std::cerr << "Warning: Failed to read warmup frame " << i << std::endl;
+      }
     }
-    ++stats_.warmup_discarded;
-    // Sleep a bit to avoid tight busy loop
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::cout << "Warmup complete: discarded " << stats_.warmup_discarded << " frames" << std::endl;
   }
+
   return true;
 }
 


### PR DESCRIPTION
This PR changes the camera warmup mechanism from a time-based approach to a frame-count approach:

1. Replaced `warmup_seconds` with `warmup_frames` in the camera configuration
2. Moved warmup logic from manual calls in application code to the component initialization
3. Integrated warmup directly into the `OpenCvCameraComponent::configure()` method
4. Added support for warmup_frames as a JSON configuration parameter
5. Improved logging during the warmup process
