### PR TITLE
Add RealSense Hardware Component and Real Hardware Support to Registry Demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if(TROSSEN_ENABLE_REALSENSE)
   target_sources(trossen_sdk PRIVATE
     src/hw/camera/realsense_producer.cpp
     src/hw/camera/realsense_depth_producer.cpp
+    src/hw/camera/realsense_camera_component.cpp
   )
   target_compile_definitions(trossen_sdk PRIVATE TROSSEN_ENABLE_REALSENSE)
 

--- a/examples/hardware_registry_demo.cpp
+++ b/examples/hardware_registry_demo.cpp
@@ -9,6 +9,9 @@
 #include "trossen_sdk/hw/active_hardware_registry.hpp"
 #include "trossen_sdk/hw/hardware_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
+#include "trossen_sdk/hw/camera/realsense_camera_component.hpp"
+#include "trossen_sdk/hw/camera/opencv_camera_component.hpp"
 
 // Mock hardware component for demo (doesn't require real devices)
 namespace demo {
@@ -39,12 +42,24 @@ REGISTER_HARDWARE(MockArmComponent, "mock_arm")
 
 }  // namespace demo
 
-int main() {
+int main(int argc, char** argv) {
+  // Parse command line arguments
+  bool use_real_hardware = false;
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--real") {
+      use_real_hardware = true;
+      break;
+    }
+  }
+
   std::cout << "\nHardware Registry Demo\n";
   std::cout << "======================\n\n";
 
-  // 1. Create hardware from config
-  std::cout << "Creating hardware from config:\n";
+  // 1. Create Hardware from configuration
+  std::cout << "Creating hardware components from configuration...\n";
+
+  // 1.1 Mock Arms hardware
+  std::cout << "Mock Arms hardware from config:\n";
   nlohmann::json config = {{"num_joints", 7}};
   // Create left mock arm. It will be auto-registered.
   auto left_arm = trossen::hw::HardwareRegistry::create("mock_arm", "left_arm", config);
@@ -52,10 +67,55 @@ int main() {
   auto right_arm = trossen::hw::HardwareRegistry::create(
     "mock_arm", "right_arm", {{"num_joints", 6}}, false);
 
+  std::shared_ptr<trossen::hw::HardwareComponent> real_arm;
+  std::shared_ptr<trossen::hw::HardwareComponent> realsense_camera;
+  std::shared_ptr<trossen::hw::HardwareComponent> opencv_camera;
+
+  if (use_real_hardware) {
+    // 1.2 Real Arms hardware
+    std::cout << "\nReal Trossen Arms hardware from config:\n";
+    nlohmann::json real_arm_config = {
+      {"ip_address", "192.168.1.2"},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_leader"}
+    };
+    real_arm = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", "real_arm", real_arm_config);
+
+    // 1.3 Realsense Camera hardware
+    std::cout << "\nReal Realsense Camera hardware from config:\n";
+    nlohmann::json camera_config = {
+      {"serial_number", "218622274938"},
+      {"width", 640},
+      {"height", 480},
+      {"fps", 30}
+    };
+    realsense_camera = trossen::hw::HardwareRegistry::create(
+      "realsense_camera", "realsense_camera0", camera_config);
+
+    // 1.4 OpenCV Camera hardware
+    std::cout << "\nReal OpenCV Camera hardware from config:\n";
+    nlohmann::json opencv_camera_config = {
+      {"device_index", 0},
+      {"width", 640},
+      {"height", 480},
+      {"fps", 30}
+    };
+
+    opencv_camera = trossen::hw::HardwareRegistry::create(
+      "opencv_camera", "opencv_camera0", opencv_camera_config);
+  }
+
   // 2. Register in active registry
   std::cout << "\nRegistering hardware:\n";
   // We only registered left_arm during creation; now register right_arm
   trossen::hw::ActiveHardwareRegistry::register_active("right_arm", right_arm);
+
+  if (use_real_hardware) {
+    trossen::hw::ActiveHardwareRegistry::register_active("real_arm", real_arm);
+    trossen::hw::ActiveHardwareRegistry::register_active("realsense_camera0", realsense_camera);
+    trossen::hw::ActiveHardwareRegistry::register_active("opencv_camera0", opencv_camera);
+  }
   std::cout << "  ✓ " << trossen::hw::ActiveHardwareRegistry::count()
             << " hardware components active\n";
 

--- a/include/trossen_sdk/hw/camera/realsense_camera_component.hpp
+++ b/include/trossen_sdk/hw/camera/realsense_camera_component.hpp
@@ -1,0 +1,113 @@
+/**
+ * @file realsense_camera_component.hpp
+ * @brief Hardware component wrapper for RealSense-compatible cameras
+ */
+
+#ifndef TROSSEN_SDK__HW__CAMERA__REALSENSE_CAMERA_COMPONENT_HPP_
+#define TROSSEN_SDK__HW__CAMERA__REALSENSE_CAMERA_COMPONENT_HPP_
+
+#include <memory>
+#include <string>
+
+#include "trossen_sdk/hw/camera/realsense_frame_cache.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+
+namespace trossen::hw::camera {
+
+/**
+ * @brief Hardware component for Realsense-compatible cameras
+ *
+ * Owns RealsenseFrameCache instance and provides JSON configuration.
+ */
+class RealsenseCameraComponent : public HardwareComponent {
+public:
+  /**
+   * @brief Constructor
+   *
+   * @param identifier Component identifier (e.g., "camera_0", "wrist_cam")
+   */
+  explicit RealsenseCameraComponent(const std::string& identifier)
+    : HardwareComponent(identifier) {}
+  ~RealsenseCameraComponent() override;
+
+  /**
+   * @brief Configure the camera from JSON
+   *
+   * Expected JSON format:
+   * {
+   *   "serial_number": "012345678",
+   *   "width": 640,
+   *   "height": 480,
+   *   "fps": 30,
+   *   "use_depth": true,
+   *   "force_hardware_reset": false
+   * }
+   *
+   * @param config JSON configuration object
+   * @throws std::runtime_error if configuration fails
+   */
+  void configure(const nlohmann::json& config) override;
+
+  /**
+   * @brief Get the type string for this hardware component
+   *
+   * @return Type identifier
+   */
+  std::string get_type() const override { return "realsense_camera"; }
+
+  /**
+   * @brief Get human-readable component information
+   *
+   * @return JSON object with component details
+   */
+  nlohmann::json get_info() const override;
+
+  /**
+   * @brief Get the camera serial number
+   * @return Serial number of the camera
+   */
+  std::string get_serial_number() const { return serial_number; }
+
+  /**
+   * @brief Get the underlying hardware (RealsenseFrameCache) instance
+   *
+   * @return Shared pointer to RealsenseFrameCache (for producer access)
+   */
+  std::shared_ptr<RealsenseFrameCache> get_hardware() { return frame_cache_; }
+
+  /**
+   * @brief Check if camera is opened and ready
+   * @return true if camera pipeline and frame cache can be accessed
+   */
+  bool is_opened() const;
+
+private:
+  /// @brief Underlying RealsenseFrameCache for Realsense camera
+  std::shared_ptr<RealsenseFrameCache> frame_cache_;
+
+  /// @brief Realsense pipeline profile
+  // Used for getting actual stream parameters after starting the pipeline
+  rs2::pipeline_profile profile;
+
+  /// @brief Camera device index
+  std::string serial_number = "unspecified";
+
+  /// @brief Configured width
+  int width_ = 640;
+
+  /// @brief Configured height
+  int height_ = 480;
+
+  /// @brief Configured frame rate
+  int fps_ = 30;
+
+  /// @brief Configure use_depth flag
+  bool use_depth_ = false;
+
+  /// @brief Configure force_hardware_reset flag
+  bool force_hardware_reset_ = false;
+};
+
+}  // namespace trossen::hw::camera
+
+#endif  // TROSSEN_SDK__HW__CAMERA__REALSENSE_CAMERA_COMPONENT_HPP_

--- a/include/trossen_sdk/hw/camera/realsense_camera_component.hpp
+++ b/include/trossen_sdk/hw/camera/realsense_camera_component.hpp
@@ -89,7 +89,7 @@ private:
   // Used for getting actual stream parameters after starting the pipeline
   rs2::pipeline_profile profile;
 
-  /// @brief Camera device index
+  /// @brief Camera serial number
   std::string serial_number = "unspecified";
 
   /// @brief Configured width

--- a/src/hw/camera/realsense_camera_component.cpp
+++ b/src/hw/camera/realsense_camera_component.cpp
@@ -1,0 +1,145 @@
+/**
+ * @file realsense_camera_component.cpp
+ * @brief Implementation of RealsenseCameraComponent
+ */
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "trossen_sdk/hw/camera/realsense_camera_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+
+namespace trossen::hw::camera {
+
+RealsenseCameraComponent::~RealsenseCameraComponent() {
+  // TODO(shantanuparab-tr): Properly stop and release Realsense resources
+  std::cout << "RealsenseCameraComponent: Destructor called for "
+            << get_identifier() << std::endl;
+}
+
+void RealsenseCameraComponent::configure(const nlohmann::json& config) {
+  // Extract device index (required)
+  if (!config.contains("serial_number")) {
+    throw std::runtime_error("RealsenseCameraComponent: 'serial_number' is required in config");
+  }
+  serial_number = config.at("serial_number").get<std::string>();
+
+  // Extract optional parameters
+  if (config.contains("width")) {
+    width_ = config.at("width").get<int>();
+  }
+  if (config.contains("height")) {
+    height_ = config.at("height").get<int>();
+  }
+  if (config.contains("fps")) {
+    fps_ = config.at("fps").get<int>();
+  }
+  if (config.contains("use_depth")) {
+    use_depth_ = config.at("use_depth").get<bool>();
+  }
+  if (config.contains("force_hardware_reset")) {
+    force_hardware_reset_ = config.at("force_hardware_reset").get<bool>();
+  }
+
+  // TODO(shantanuparab-tr): Improve this logic to avoid iterating all connected devices
+  // Force hardware reset if requested
+  if (force_hardware_reset_) {
+    std::cout << "RealsenseCameraComponent: Forcing hardware reset for camera "
+              << serial_number << std::endl;
+    // Find the devices connected
+    rs2::context ctx;
+    auto devices = ctx.query_devices();
+    // Reset the device with matching serial number
+    for (auto&& dev : devices) {
+      if (dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) == serial_number) {
+        dev.hardware_reset();
+        std::cout << "RealsenseCameraComponent: Hardware reset completed for camera "
+                  << serial_number << std::endl;
+        break;
+      }
+    }
+  }
+
+  // Create Realsense pipeline
+  rs2::pipeline realsense_pipeline;
+  auto camera_ = std::make_shared<rs2::pipeline>(realsense_pipeline);
+
+  // Create Realsense config
+  rs2::config cam_cfg;
+
+  // Enable the device using the serial number
+  cam_cfg.enable_device(serial_number);
+
+  // Enable color stream by default
+  cam_cfg.enable_stream(RS2_STREAM_COLOR, width_, height_, RS2_FORMAT_RGB8, fps_);
+
+  // Enable depth stream if requested
+  if (use_depth_) {
+    cam_cfg.enable_stream(RS2_STREAM_DEPTH, width_, height_, RS2_FORMAT_Z16, fps_);
+  }
+
+  // Start the camera pipeline
+  try {
+    profile = camera_->start(cam_cfg);
+  } catch (const rs2::error& e) {
+    throw std::runtime_error(
+      "RealsenseCameraComponent: Failed to start camera with serial number " +
+      serial_number + ": " + std::string(e.what()));
+  }
+  // TODO(shantanuparab-tr): Determine RealsenseFrameCache consumer
+  // count from use_depth_ (2 for color+depth streams, 1 for color-only).
+  // Pass use_depth flag to RealsenseFrameCache constructor.
+  if (use_depth_) {
+    frame_cache_ = std::make_shared<RealsenseFrameCache>(camera_, 2);
+  } else {
+    frame_cache_ = std::make_shared<RealsenseFrameCache>(camera_, 1);
+  }
+
+  // Read back actual values
+  auto color_stream = profile.get_stream(RS2_STREAM_COLOR);
+  auto color_profile = color_stream.as<rs2::video_stream_profile>();
+  width_ = color_profile.width();
+  height_ = color_profile.height();
+  fps_ = static_cast<int>(color_profile.fps());
+
+  // If depth stream is enabled, confirm its parameters
+  if (use_depth_) {
+    auto depth_stream = profile.get_stream(RS2_STREAM_DEPTH);
+    auto depth_profile = depth_stream.as<rs2::video_stream_profile>();
+    // Just to confirm depth stream is valid
+    (void)depth_profile.width();
+    (void)depth_profile.height();
+    (void)depth_profile.fps();
+  }
+
+  std::cout << "Camera " << get_identifier() << " configured: "
+            << width_ << "x" << height_ << " @ " << fps_
+            << " FPS" << std::endl;
+}
+
+nlohmann::json RealsenseCameraComponent::get_info() const {
+  nlohmann::json info = {
+    {"type", "realsense_camera"},
+    {"serial_number", serial_number},
+    {"width", width_},
+    {"height", height_},
+    {"fps", fps_},
+    {"use_depth", use_depth_},
+    {"force_hardware_reset", force_hardware_reset_}
+  };
+
+  // Add opened status
+  info["is_opened"] = is_opened();
+
+  return info;
+}
+
+bool RealsenseCameraComponent::is_opened() const {
+  // TODO(shantanuparab-tr): Implement proper check for Realsense pipeline and frame cache
+  return frame_cache_ != nullptr;
+}
+
+REGISTER_HARDWARE(RealsenseCameraComponent, "realsense_camera")
+
+}  // namespace trossen::hw::camera


### PR DESCRIPTION
* Added `RealSenseCameraComponent` implementing the `HardwareComponent` interface
* Integrated RealSense cameras into the hardware registry with JSON-based configuration
* Enabled color and depth stream support with optional hardware reset
* Extended hardware registry demo with `--real` flag to use real hardware
* Registers real components (Trossen Arm, RealSense Camera, OpenCV Camera) when enabled
* Default behavior remains mock hardware for testing without physical devices