### PR TITLE
Add producer registry and demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(trossen_sdk SHARED
   src/hw/camera/mock_producer.cpp
   src/hw/camera/mock_synced_producer.cpp
   src/runtime/session_manager.cpp
+  src/runtime/producer_registry.cpp
 )
 
 if(TROSSEN_ENABLE_REALSENSE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,3 +34,7 @@ target_link_libraries(hardware_registry_demo trossen_sdk)
 find_package(libtrossen_arm)
 add_executable(widowxai_lerobot_async widowxai_lerobot_async.cpp)
 target_link_libraries(widowxai_lerobot_async demo_utils trossen_sdk libtrossen_arm)
+
+# Producer registry demo
+add_executable(producer_registry_demo producer_registry_demo.cpp)
+target_link_libraries(producer_registry_demo trossen_sdk)

--- a/examples/producer_registry_demo.cpp
+++ b/examples/producer_registry_demo.cpp
@@ -1,0 +1,203 @@
+/**
+ * @file producer_registry_demo.cpp
+ * @brief Demo of the ProducerRegistry system with hardware and mock producers
+ */
+
+#include <iostream>
+
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+
+// Mock hardware component for demo
+namespace demo {
+
+class MockArmComponent : public trossen::hw::HardwareComponent {
+public:
+  explicit MockArmComponent(const std::string& identifier)
+    : HardwareComponent(identifier) {}
+
+  void configure(const nlohmann::json& config) override {
+    num_joints_ = config.value("num_joints", 6);
+    std::cout << "  ✓ Configured " << get_identifier()
+              << " (" << num_joints_ << " joints)\n";
+  }
+
+  std::string get_type() const override { return "mock_arm"; }
+  nlohmann::json get_info() const override {
+    return {{"type", "mock_arm"}, {"num_joints", num_joints_}};
+  }
+  int get_num_joints() const { return num_joints_; }
+
+private:
+  int num_joints_ = 6;
+};
+
+// Mock producer that requires hardware
+class MockArmProducer : public trossen::hw::PolledProducer {
+public:
+  MockArmProducer(std::shared_ptr<MockArmComponent> hw, const nlohmann::json& config)
+    : hardware_(hw) {
+    stream_id_ = config.value("stream_id", "joint_states");
+    std::cout << "  ✓ Created MockArmProducer for " << hardware_->get_identifier()
+              << " (stream: " << stream_id_ << ")\n";
+  }
+
+  void poll(const std::function<void(std::shared_ptr<trossen::data::RecordBase>)>& emit) override {
+    // Mock implementation - would normally read from hardware
+    auto record = std::make_shared<trossen::data::RecordBase>();
+    record->id = stream_id_;
+    emit(record);
+  }
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    auto meta = std::make_shared<ProducerMetadata>();
+    meta->type = "mock_arm";
+    meta->id = stream_id_;
+    meta->name = hardware_->get_identifier();
+    meta->description = "Mock arm producer";
+    return meta;
+  }
+
+private:
+  std::shared_ptr<MockArmComponent> hardware_;
+  std::string stream_id_;
+};
+
+// Mock producer that doesn't need hardware
+class SyntheticProducer : public trossen::hw::PolledProducer {
+public:
+  explicit SyntheticProducer(const nlohmann::json& config) {
+    stream_id_ = config.value("stream_id", "synthetic");
+    frequency_ = config.value("frequency", 1.0);
+    std::cout << "  ✓ Created SyntheticProducer (stream: " << stream_id_
+              << ", freq: " << frequency_ << " Hz)\n";
+  }
+
+  void poll(const std::function<void(std::shared_ptr<trossen::data::RecordBase>)>& emit) override {
+    // Mock implementation - generates synthetic data
+    auto record = std::make_shared<trossen::data::RecordBase>();
+    record->id = stream_id_;
+    emit(record);
+  }
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    auto meta = std::make_shared<ProducerMetadata>();
+    meta->type = "synthetic";
+    meta->id = stream_id_;
+    meta->name = "Synthetic Producer";
+    meta->description = "Generates synthetic data";
+    return meta;
+  }
+
+private:
+  std::string stream_id_;
+  double frequency_;
+};
+
+// Register hardware and producers
+REGISTER_HARDWARE(MockArmComponent, "mock_arm")
+
+}  // namespace demo
+
+// Register producers with custom factory logic
+namespace demo {
+
+// Hardware-based producer registration
+namespace {
+struct MockArmProducerRegistrar {
+  MockArmProducerRegistrar() {
+    trossen::runtime::ProducerRegistry::register_producer(
+      "mock_arm",
+      [](std::shared_ptr<trossen::hw::HardwareComponent> hw,
+         const nlohmann::json& cfg) -> std::shared_ptr<trossen::hw::PolledProducer> {
+        // Require hardware
+        if (!hw) {
+          throw std::invalid_argument("MockArmProducer requires hardware component");
+        }
+
+        // Type check
+        auto arm_hw = std::dynamic_pointer_cast<MockArmComponent>(hw);
+        if (!arm_hw) {
+          throw std::invalid_argument(
+            "MockArmProducer requires MockArmComponent, got: " + hw->get_type());
+        }
+
+        return std::make_shared<MockArmProducer>(arm_hw, cfg);
+      });
+  }
+};
+static MockArmProducerRegistrar mock_arm_producer_registrar;
+
+// Synthetic producer registration (no hardware needed)
+struct SyntheticProducerRegistrar {
+  SyntheticProducerRegistrar() {
+    trossen::runtime::ProducerRegistry::register_producer(
+      "synthetic",
+      [](std::shared_ptr<trossen::hw::HardwareComponent> hw,
+         const nlohmann::json& cfg) -> std::shared_ptr<trossen::hw::PolledProducer> {
+        // Hardware not required (ignored if provided)
+        return std::make_shared<SyntheticProducer>(cfg);
+      });
+  }
+};
+static SyntheticProducerRegistrar synthetic_producer_registrar;
+
+}  // anonymous namespace
+}  // namespace demo
+
+int main() {
+  std::cout << "\nProducer Registry Demo\n";
+  std::cout << "======================\n\n";
+
+  // 1. Create and register hardware
+  std::cout << "Step 1: Create hardware\n";
+  auto left_arm = trossen::hw::HardwareRegistry::create(
+    "mock_arm", "left_arm", {{"num_joints", 7}});
+  // Note: Hardware auto-registered in ActiveHardwareRegistry by create()
+
+  // 2. Create hardware-based producer
+  std::cout << "\nStep 2: Create hardware-based producer\n";
+  auto hw_left = trossen::hw::ActiveHardwareRegistry::get("left_arm");
+  auto arm_producer = trossen::runtime::ProducerRegistry::create(
+    "mock_arm", hw_left, {{"stream_id", "left_arm/joints"}});
+
+  // 3. Create synthetic producer (no hardware)
+  std::cout << "\nStep 3: Create synthetic producer\n";
+  auto synth_producer = trossen::runtime::ProducerRegistry::create(
+    "synthetic", nullptr, {{"stream_id", "clock"}, {"frequency", 10.0}});
+
+  // 4. List registered types
+  std::cout << "\nStep 4: Registry info\n";
+  std::cout << "  Hardware types: ";
+  for (const auto& type : trossen::hw::HardwareRegistry::get_registered_types()) {
+    std::cout << type << " ";
+  }
+  std::cout << "\n  Producer types: ";
+  for (const auto& type : trossen::runtime::ProducerRegistry::get_registered_types()) {
+    std::cout << type << " ";
+  }
+  std::cout << "\n";
+
+  // 5. Test producers
+  std::cout << "\nStep 5: Test producers\n";
+  int emit_count = 0;
+  auto emit_callback = [&](std::shared_ptr<trossen::data::RecordBase> rec) {
+    emit_count++;
+  };
+
+  arm_producer->poll(emit_callback);
+  synth_producer->poll(emit_callback);
+  std::cout << "  ✓ Emitted " << emit_count << " records\n";
+
+  // Cleanup
+  trossen::hw::ActiveHardwareRegistry::clear();
+
+  std::cout << "\n✓ Demo complete!\n\n";
+  return 0;
+}

--- a/include/trossen_sdk/runtime/producer_registry.hpp
+++ b/include/trossen_sdk/runtime/producer_registry.hpp
@@ -1,0 +1,130 @@
+/**
+ * @file producer_registry.hpp
+ * @brief Factory registry for producer types
+ */
+
+#ifndef TROSSEN_SDK__RUNTIME__PRODUCER_REGISTRY_HPP_
+#define TROSSEN_SDK__RUNTIME__PRODUCER_REGISTRY_HPP_
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::runtime {
+
+/**
+ * @brief Static registry for producer factory functions
+ *
+ * Producer implementations register themselves at static initialization time.
+ *
+ * Key Design Decision: Factory does NOT take polling period parameter. Period is a scheduling
+ * concern handled by SessionManager, not a creation concern. This maintains separation of concerns
+ * and matches existing SessionManager::add_producer(producer, period) API.
+ */
+class ProducerRegistry {
+public:
+  /**
+   * @brief Factory function signature for creating producer instances
+   *
+   * @param hardware Hardware component pointer (may be nullptr for mock producers)
+   * @param config JSON configuration object specific to the producer type
+   * @return Shared pointer to created producer instance
+   */
+  using FactoryFunc = std::function<std::shared_ptr<hw::PolledProducer>(
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config)>;
+
+  /**
+   * @brief Register a producer factory function
+   *
+   * @param type Producer type string (e.g., "trossen_arm", "opencv_camera")
+   * @param factory Factory function that creates producer instances
+   *
+   * @throws std::runtime_error if type is already registered
+   *
+   * @note This should be called during static initialization, typically using REGISTER_PRODUCER
+   *       macro in the producer implementation file.
+   */
+  static void register_producer(const std::string& type, FactoryFunc factory);
+
+  /**
+   * @brief Create a producer instance by type
+   *
+   * @param type Producer type string
+   * @param hardware Hardware component
+   * @param config Producer-specific configuration
+   *
+   * @return Shared pointer to created producer instance
+   *
+   * @throws std::runtime_error if type is not registered
+   *
+   * @note The hardware parameter may be nullptr for producers that do not require hardware (e.g.
+   * mock producers).
+   */
+  static std::shared_ptr<hw::PolledProducer> create(
+    const std::string& type,
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config);
+
+  /**
+   * @brief Check if a producer type is registered
+   *
+   * @param type Producer type string
+   * @return true if the type is registered, false otherwise
+   */
+  static bool is_registered(const std::string& type);
+
+  /**
+   * @brief Get list of all registered producer types
+   *
+   * @return Vector of registered type strings
+   */
+  static std::vector<std::string> get_registered_types();
+
+private:
+  static std::map<std::string, FactoryFunc>& get_registry();
+};
+
+/**
+ * @brief Macro to register a producer type with the ProducerRegistry
+ *
+ * Creates a static registrar object that registers the producer factory function during static
+ * initialization. Use this in your producer implementation (.cpp) file.
+ *
+ * @param ClassName The producer class name (e.g., TrossenArmProducer)
+ * @param TypeString The type string for this producer (e.g., "trossen_arm")
+ *
+ * Example usage:
+ * @code
+ * // In trossen_arm_producer.cpp namespace trossen::hw::arm {
+ * REGISTER_PRODUCER(TrossenArmProducer, "trossen_arm")
+ * }
+ * @endcode
+ */
+#define REGISTER_PRODUCER(ClassName, TypeString)                                         \
+  namespace {                                                                            \
+  struct ClassName##Registrar {                                                          \
+    ClassName##Registrar() {                                                             \
+      ::trossen::runtime::ProducerRegistry::register_producer(                           \
+        TypeString,                                                                      \
+        [](std::shared_ptr<::trossen::hw::HardwareComponent> hw,                        \
+           const nlohmann::json& cfg)                                                    \
+             -> std::shared_ptr<::trossen::hw::PolledProducer> {                        \
+          return std::make_shared<ClassName>(hw, cfg);                                   \
+        });                                                                              \
+    }                                                                                    \
+  };                                                                                     \
+  static ClassName##Registrar ClassName##_registrar_instance;                           \
+  }  /* anonymous namespace */
+
+}  // namespace trossen::runtime
+
+#endif  // TROSSEN_SDK__RUNTIME__PRODUCER_REGISTRY_HPP_

--- a/src/runtime/producer_registry.cpp
+++ b/src/runtime/producer_registry.cpp
@@ -1,0 +1,63 @@
+/**
+ * @file producer_registry.cpp
+ * @brief Implementation of ProducerRegistry
+ */
+
+#include <iostream>
+
+#include "trossen_sdk/runtime/producer_registry.hpp"
+
+namespace trossen::runtime {
+
+std::map<std::string, ProducerRegistry::FactoryFunc>&
+ProducerRegistry::get_registry() {
+  static std::map<std::string, FactoryFunc> registry;
+  return registry;
+}
+
+void ProducerRegistry::register_producer(const std::string& type, FactoryFunc factory) {
+  auto& registry = get_registry();
+
+  if (registry.find(type) != registry.end()) {
+    throw std::runtime_error("Producer type already registered: " + type);
+  }
+
+  registry[type] = factory;
+  std::cout << "Registered producer type: " << type << std::endl;
+}
+
+std::shared_ptr<hw::PolledProducer> ProducerRegistry::create(
+  const std::string& type,
+  std::shared_ptr<hw::HardwareComponent> hardware,
+  const nlohmann::json& config)
+{
+  auto& registry = get_registry();
+  auto it = registry.find(type);
+
+  if (it == registry.end()) {
+    throw std::runtime_error("Producer type not registered: " + type);
+  }
+
+  // Call factory function
+  auto producer = it->second(hardware, config);
+
+  if (!producer) {
+    throw std::runtime_error("Failed to create producer of type: " + type);
+  }
+
+  return producer;
+}
+
+bool ProducerRegistry::is_registered(const std::string& type) {
+  return get_registry().find(type) != get_registry().end();
+}
+
+std::vector<std::string> ProducerRegistry::get_registered_types() {
+  std::vector<std::string> types;
+  for (const auto& [type, _] : get_registry()) {
+    types.push_back(type);
+  }
+  return types;
+}
+
+}  // namespace trossen::runtime


### PR DESCRIPTION
### TL;DR

Added a `ProducerRegistry` system to provide a factory pattern for creating producer instances.

### What changed?

- Created a new `ProducerRegistry` class that manages factory functions for producer types
- Added header file `include/trossen_sdk/runtime/producer_registry.hpp` with registry interface
- Implemented registry functionality in `src/runtime/producer_registry.cpp`
- Added a `REGISTER_PRODUCER` macro to simplify producer registration
- Created a comprehensive demo in `examples/producer_registry_demo.cpp` showing:
  - Registration of hardware and producer types
  - Creation of hardware-based producers
  - Creation of synthetic producers (no hardware)
  - Listing registered types
  - Testing producer functionality

### How to test?

Run the new producer registry demo:
```bash
# Build the project
cmake --build .

# Run the demo
./examples/producer_registry_demo
```

The demo shows the complete workflow of registering, creating, and using producers with and without hardware dependencies.

### Why make this change?

This change introduces a factory pattern for producers that:
1. Standardizes producer creation across the SDK
2. Decouples producer implementations from consumer code
3. Allows runtime discovery of available producer types
4. Supports both hardware-dependent and standalone producers
5. Provides a clean registration mechanism for new producer implementations

The registry pattern makes the system more extensible and maintainable as new producer types are added.