### PR TITLE
Update arm producer and demos for hardware components usage

### DIFF
--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -25,14 +25,19 @@
 #include <vector>
 
 #include "libtrossen_arm/trossen_arm.hpp"
-#include "trossen_sdk/runtime/session_manager.hpp"
+#include "nlohmann/json.hpp"
 #include "trossen_sdk/hw/arm/arm_producer.hpp"
-#include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/hw/arm/mock_joint_producer.hpp"
-#include "trossen_sdk/hw/camera/opencv_producer.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
+#include "trossen_sdk/hw/camera/opencv_producer.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
 
-#include "demo_utils.hpp"
+#include "./demo_utils.hpp"
 
 // ────────────────────────────────────────────────────────────
 // Command-line configuration
@@ -160,53 +165,32 @@ int main(int argc, char** argv) {
   // Initialize hardware (if not using mock)
   // ──────────────────────────────────────────────────────────
 
-  std::unique_ptr<trossen_arm::TrossenArmDriver> leader_driver;
-  std::unique_ptr<trossen_arm::TrossenArmDriver> follower_driver;
+  std::shared_ptr<trossen_arm::TrossenArmDriver> leader_driver;  // Managed by component
+  std::shared_ptr<trossen_arm::TrossenArmDriver> follower_driver;  // Managed by component
   const float moving_time_s = 2.0f;
 
   if (!cfg.use_mock) {
     std::cout << "Initializing hardware...\n";
 
-    leader_driver = std::make_unique<trossen_arm::TrossenArmDriver>();
-    follower_driver = std::make_unique<trossen_arm::TrossenArmDriver>();
+    // Create leader arm via registry
+    nlohmann::json leader_hw_cfg = {
+      {"ip_address", cfg.leader_ip},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_leader"}
+    };
 
-    try {
-      leader_driver->configure(
-        trossen_arm::Model::wxai_v0,
-        trossen_arm::StandardEndEffector::wxai_v0_leader,
-        cfg.leader_ip,
-        true);
-      std::cout << "  ✓ Leader arm configured (" << cfg.leader_ip << ")\n";
-    } catch (const std::exception& e) {
-      std::cerr << "Failed to configure leader: " << e.what() << "\n";
-      return 1;
-    }
+    auto leader_component = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", "leader_arm", leader_hw_cfg, true);
+    auto leader_comp_typed = std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(
+      leader_component);
+    leader_driver = leader_comp_typed->get_hardware();
+    std::cout << "  ✓ Leader arm configured (" << cfg.leader_ip << ")\n";
 
-    try {
-      follower_driver->configure(
-        trossen_arm::Model::wxai_v0,
-        trossen_arm::StandardEndEffector::wxai_v0_follower,
-        cfg.follower_ip,
-        true);
-      std::cout << "  ✓ Follower arm configured (" << cfg.follower_ip << ")\n";
-    } catch (const std::exception& e) {
-      std::cerr << "Failed to configure follower: " << e.what() << "\n";
-      return 1;
-    }
-
-    // Adjust follower joint limits for gripper tolerance
-    auto joint_limits = follower_driver->get_joint_limits();
-    joint_limits[follower_driver->get_num_joints() - 1].position_tolerance = 0.01;
-    follower_driver->set_joint_limits(joint_limits);
-
-    // Move arms to staged positions
+    // Stage leader to starting position
     leader_driver->set_all_modes(trossen_arm::Mode::position);
-    follower_driver->set_all_modes(trossen_arm::Mode::position);
     leader_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
-    follower_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
     std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-    std::cout << "  ✓ Arms staged to starting positions\n";
+    std::cout << "  ✓ Leader staged to starting position\n";
   }
 
   trossen::runtime::SessionManager mgr;
@@ -236,24 +220,52 @@ int main(int argc, char** argv) {
     joint_producer = std::make_shared<trossen::hw::arm::MockJointStateProducer>(joint_cfg);
     std::cout << "  ✓ Mock joint state producer (" << cfg.joint_rate_hz << " Hz, 6 joints)\n";
   } else {
-    trossen::hw::arm::TrossenArmProducer::Config joint_cfg;
-    joint_cfg.stream_id = "follower/joint_states";
-    joint_cfg.use_device_time = false;
+    // Create follower arm via registry
+    nlohmann::json hw_cfg = {
+      {"ip_address", cfg.follower_ip},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_follower"}
+    };
 
-    // Wrap follower_driver in shared_ptr (non-owning wrapper since we manage lifetime)
-    auto follower_shared = std::shared_ptr<trossen_arm::TrossenArmDriver>(
-      follower_driver.get(), [](trossen_arm::TrossenArmDriver*){});
+    auto arm_component = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", "follower_arm", hw_cfg, true);
 
-    joint_producer = std::make_shared<trossen::hw::arm::TrossenArmProducer>(
-      follower_shared, joint_cfg);
+    // Get driver from component for control loop
+    auto arm_comp_typed = std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(
+      arm_component);
+    follower_driver = arm_comp_typed->get_hardware();
+
+    std::cout << "  ✓ Follower arm configured (" << cfg.follower_ip << ")\n";
+
+    // Adjust follower joint limits for gripper tolerance
+    auto joint_limits = follower_driver->get_joint_limits();
+    joint_limits[follower_driver->get_num_joints() - 1].position_tolerance = 0.01;
+    follower_driver->set_joint_limits(joint_limits);
+
+    // Move follower to staged position
+    follower_driver->set_all_modes(trossen_arm::Mode::position);
+    follower_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+    std::cout << "  ✓ Follower staged to starting position\n";
+
+    // Create producer via registry
+    nlohmann::json prod_cfg = {
+      {"stream_id", "follower/joint_states"},
+      {"use_device_time", false}
+    };
+
+    joint_producer = trossen::runtime::ProducerRegistry::create(
+      "trossen_arm", arm_component, prod_cfg);
+
     std::cout << "  ✓ Follower arm producer (" << cfg.joint_rate_hz << " Hz)\n";
   }
 
   auto joint_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.joint_rate_hz));
   mgr.add_producer(joint_producer, joint_period);
 
-  // Camera producer (OpenCV or mock)
+  // Camera producer
   std::shared_ptr<trossen::hw::PolledProducer> camera_producer;
+  auto camera_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.camera_fps));
   if (cfg.use_mock) {
     trossen::hw::camera::MockCameraProducer::Config cam_cfg;
     cam_cfg.width = cfg.camera_width;
@@ -280,7 +292,6 @@ int main(int argc, char** argv) {
               << cfg.camera_width << "x" << cfg.camera_height << ")\n";
   }
 
-  auto camera_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.camera_fps));
   mgr.add_producer(camera_producer, camera_period);
 
   std::cout << "\nProducers registered. Ready to record.\n";

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -34,12 +34,17 @@
 #include <vector>
 
 #include "libtrossen_arm/trossen_arm.hpp"
-#include "trossen_sdk/runtime/session_manager.hpp"
+#include "nlohmann/json.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
 #include "trossen_sdk/hw/arm/arm_producer.hpp"
-#include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/hw/arm/mock_joint_producer.hpp"
-#include "trossen_sdk/hw/camera/opencv_producer.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
+#include "trossen_sdk/hw/camera/opencv_producer.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
 
 #include "./demo_utils.hpp"
 
@@ -176,10 +181,14 @@ int main(int argc, char** argv) {
   // Create root directory
   std::filesystem::create_directories(cfg.root);
 
-  std::unique_ptr<trossen_arm::TrossenArmDriver> leader_left_driver;
-  std::unique_ptr<trossen_arm::TrossenArmDriver> leader_right_driver;
-  std::unique_ptr<trossen_arm::TrossenArmDriver> follower_left_driver;
-  std::unique_ptr<trossen_arm::TrossenArmDriver> follower_right_driver;
+  // ──────────────────────────────────────────────────────────
+  // Initialize hardware (if not using mock)
+  // ──────────────────────────────────────────────────────────
+
+  std::shared_ptr<trossen_arm::TrossenArmDriver> leader_left_driver;
+  std::shared_ptr<trossen_arm::TrossenArmDriver> leader_right_driver;
+  std::shared_ptr<trossen_arm::TrossenArmDriver> follower_left_driver;
+  std::shared_ptr<trossen_arm::TrossenArmDriver> follower_right_driver;
 
   std::vector<double> leader_left_starting_pos;
   std::vector<double> leader_right_starting_pos;
@@ -191,88 +200,39 @@ int main(int argc, char** argv) {
   if (!cfg.use_mock) {
     std::cout << "Initializing hardware...\n";
 
-    // Initialize all 4 arms
-    leader_left_driver = std::make_unique<trossen_arm::TrossenArmDriver>();
-    leader_right_driver = std::make_unique<trossen_arm::TrossenArmDriver>();
-    follower_left_driver = std::make_unique<trossen_arm::TrossenArmDriver>();
-    follower_right_driver = std::make_unique<trossen_arm::TrossenArmDriver>();
+    // Create leader left via registry
+    nlohmann::json leader_left_hw_cfg = {
+      {"ip_address", cfg.leader_left_ip},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_leader"}
+    };
+    auto leader_left_component = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", "leader_left", leader_left_hw_cfg, true);
+    auto leader_left_comp_typed = std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(
+      leader_left_component);
+    leader_left_driver = leader_left_comp_typed->get_hardware();
+    std::cout << "  ✓ Leader Left configured (" << cfg.leader_left_ip << ")\n";
 
-    // Configure Leader Left
-    try {
-      leader_left_driver->configure(
-        trossen_arm::Model::wxai_v0,
-        trossen_arm::StandardEndEffector::wxai_v0_leader,
-        cfg.leader_left_ip,
-        true);
-      std::cout << "  ✓ Leader Left configured (" << cfg.leader_left_ip << ")\n";
-    } catch (const std::exception& e) {
-      std::cerr << "Failed to configure Leader Left: " << e.what() << "\n";
-      return 1;
-    }
+    // Create leader right via registry
+    nlohmann::json leader_right_hw_cfg = {
+      {"ip_address", cfg.leader_right_ip},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_leader"}
+    };
+    auto leader_right_component = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", "leader_right", leader_right_hw_cfg, true);
+    auto leader_right_comp_typed =
+      std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(leader_right_component);
+    leader_right_driver = leader_right_comp_typed->get_hardware();
+    std::cout << "  ✓ Leader Right configured (" << cfg.leader_right_ip << ")\n";
 
-    // Configure Leader Right
-    try {
-      leader_right_driver->configure(
-        trossen_arm::Model::wxai_v0,
-        trossen_arm::StandardEndEffector::wxai_v0_leader,
-        cfg.leader_right_ip,
-        true);
-      std::cout << "  ✓ Leader Right configured (" << cfg.leader_right_ip << ")\n";
-    } catch (const std::exception& e) {
-      std::cerr << "Failed to configure Leader Right: " << e.what() << "\n";
-      return 1;
-    }
-
-    // Configure Follower Left
-    try {
-      follower_left_driver->configure(
-        trossen_arm::Model::wxai_v0,
-        trossen_arm::StandardEndEffector::wxai_v0_follower,
-        cfg.follower_left_ip,
-        true);
-      std::cout << "  ✓ Follower Left configured (" << cfg.follower_left_ip << ")\n";
-    } catch (const std::exception& e) {
-      std::cerr << "Failed to configure Follower Left: " << e.what() << "\n";
-      return 1;
-    }
-
-    // Configure Follower Right
-    try {
-      follower_right_driver->configure(
-        trossen_arm::Model::wxai_v0,
-        trossen_arm::StandardEndEffector::wxai_v0_follower,
-        cfg.follower_right_ip,
-        true);
-      std::cout << "  ✓ Follower Right configured (" << cfg.follower_right_ip << ")\n";
-    } catch (const std::exception& e) {
-      std::cerr << "Failed to configure Follower Right: " << e.what() << "\n";
-      return 1;
-    }
-
-    // Adjust follower joint limits for gripper tolerance
-    auto left_limits = follower_left_driver->get_joint_limits();
-    left_limits[follower_left_driver->get_num_joints() - 1].position_tolerance = 0.01;
-    follower_left_driver->set_joint_limits(left_limits);
-
-    auto right_limits = follower_right_driver->get_joint_limits();
-    right_limits[follower_right_driver->get_num_joints() - 1].position_tolerance = 0.01;
-    follower_right_driver->set_joint_limits(right_limits);
-
-    // Set all arms to position mode and stage them
+    // Stage leader arms to starting positions
     leader_left_driver->set_all_modes(trossen_arm::Mode::position);
     leader_right_driver->set_all_modes(trossen_arm::Mode::position);
-    follower_left_driver->set_all_modes(trossen_arm::Mode::position);
-    follower_right_driver->set_all_modes(trossen_arm::Mode::position);
-
-    // Stage all arms to their starting positions
     leader_left_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
     leader_right_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
-    follower_left_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
-    follower_right_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
-
     std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-    std::cout << "  ✓ All arms staged to starting positions\n";
+    std::cout << "  ✓ Leader arms staged to starting positions\n";
   }
 
   trossen::runtime::SessionManager mgr;
@@ -283,6 +243,10 @@ int main(int argc, char** argv) {
     std::cout << "  (Resuming from existing episodes in directory)\n";
   }
   std::cout << "\n";
+
+  // ──────────────────────────────────────────────────────────
+  // Create and register producers
+  // ──────────────────────────────────────────────────────────
 
   std::cout << "Creating producers...\n";
 
@@ -316,36 +280,72 @@ int main(int argc, char** argv) {
     mgr.add_producer(right_prod, joint_period);
     std::cout << "  ✓ Mock follower right producer (" << cfg.joint_rate_hz << " Hz)\n";
   } else {
-    // Real follower left producer
-    trossen::hw::arm::TrossenArmProducer::Config left_cfg;
-    left_cfg.stream_id = "follower_left/joint_states";
-    left_cfg.use_device_time = false;
+    // Create follower left via registry
+    nlohmann::json left_hw_cfg = {
+      {"ip_address", cfg.follower_left_ip},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_follower"}
+    };
+    auto left_component = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", "follower_left", left_hw_cfg, true);
+    auto left_comp_typed = std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(
+      left_component);
+    follower_left_driver = left_comp_typed->get_hardware();
+    std::cout << "  ✓ Follower Left configured (" << cfg.follower_left_ip << ")\n";
 
-    auto follower_left_shared = std::shared_ptr<trossen_arm::TrossenArmDriver>(
-      follower_left_driver.get(), [](trossen_arm::TrossenArmDriver*){});
+    // Create follower right via registry
+    nlohmann::json right_hw_cfg = {
+      {"ip_address", cfg.follower_right_ip},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_follower"}
+    };
+    auto right_component = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", "follower_right", right_hw_cfg, true);
+    auto right_comp_typed = std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(
+      right_component);
+    follower_right_driver = right_comp_typed->get_hardware();
+    std::cout << "  ✓ Follower Right configured (" << cfg.follower_right_ip << ")\n";
 
-    auto left_prod = std::make_shared<trossen::hw::arm::TrossenArmProducer>(
-      follower_left_shared, left_cfg);
+    // Adjust follower joint limits for gripper tolerance and stage
+    auto left_limits = follower_left_driver->get_joint_limits();
+    left_limits[follower_left_driver->get_num_joints() - 1].position_tolerance = 0.01;
+    follower_left_driver->set_joint_limits(left_limits);
+    follower_left_driver->set_all_modes(trossen_arm::Mode::position);
+    follower_left_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
+
+    auto right_limits = follower_right_driver->get_joint_limits();
+    right_limits[follower_right_driver->get_num_joints() - 1].position_tolerance = 0.01;
+    follower_right_driver->set_joint_limits(right_limits);
+    follower_right_driver->set_all_modes(trossen_arm::Mode::position);
+    follower_right_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
+
+    // Wait for both followers to reach position
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+    std::cout << "  ✓ Followers staged to starting positions\n";
+
+    // Create producers via registry
+    nlohmann::json left_prod_cfg = {
+      {"stream_id", "follower_left/joint_states"},
+      {"use_device_time", false}
+    };
+    auto left_prod = trossen::runtime::ProducerRegistry::create(
+      "trossen_arm", left_component, left_prod_cfg);
     joint_producers.push_back(left_prod);
     mgr.add_producer(left_prod, joint_period);
     std::cout << "  ✓ Follower Left producer (" << cfg.joint_rate_hz << " Hz)\n";
 
-    // Real follower right producer
-    trossen::hw::arm::TrossenArmProducer::Config right_cfg;
-    right_cfg.stream_id = "follower_right/joint_states";
-    right_cfg.use_device_time = false;
-
-    auto follower_right_shared = std::shared_ptr<trossen_arm::TrossenArmDriver>(
-      follower_right_driver.get(), [](trossen_arm::TrossenArmDriver*){});
-
-    auto right_prod = std::make_shared<trossen::hw::arm::TrossenArmProducer>(
-      follower_right_shared, right_cfg);
+    nlohmann::json right_prod_cfg = {
+      {"stream_id", "follower_right/joint_states"},
+      {"use_device_time", false}
+    };
+    auto right_prod = trossen::runtime::ProducerRegistry::create(
+      "trossen_arm", right_component, right_prod_cfg);
     joint_producers.push_back(right_prod);
     mgr.add_producer(right_prod, joint_period);
     std::cout << "  ✓ Follower Right producer (" << cfg.joint_rate_hz << " Hz)\n";
   }
 
-  // Camera producers (4 cameras)
+  // Camera producers
   std::vector<std::shared_ptr<trossen::hw::PolledProducer>> camera_producers;
   auto camera_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.camera_fps));
 

--- a/include/trossen_sdk/hw/arm/arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/arm_producer.hpp
@@ -13,9 +13,10 @@
 
 #include "libtrossen_arm/trossen_arm.hpp"
 
-#include "trossen_sdk/hw/producer_base.hpp"
 #include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
 
 namespace trossen::hw::arm {
 
@@ -62,12 +63,15 @@ public:
   };
 
   /**
-   * @brief Construct a TrossenArmProducer
+   * @brief Construct a TrossenArmProducer from hardware component
    *
-   * @param driver Shared pointer to an initialized TrossenArmDriver instance
-   * @param cfg Configuration parameters
+   * @param hardware Hardware component (must be TrossenArmComponent)
+   * @param config JSON configuration with fields: stream_id, use_device_time
+   * @throws std::invalid_argument if hardware is null or wrong type
    */
-  TrossenArmProducer(std::shared_ptr<trossen_arm::TrossenArmDriver> driver, Config cfg);
+  TrossenArmProducer(
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config);
 
   /**
    * @brief Destructor

--- a/src/hw/arm/arm_producer.cpp
+++ b/src/hw/arm/arm_producer.cpp
@@ -7,23 +7,46 @@
 #include <algorithm>
 #include <memory>
 #include <utility>
+#include <stdexcept>
 
 #include "trossen_sdk/hw/arm/arm_producer.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
 
 namespace trossen::hw::arm {
 
 TrossenArmProducer::TrossenArmProducer(
-  std::shared_ptr<trossen_arm::TrossenArmDriver> driver,
-  Config cfg)
-  : driver_(std::move(driver)), cfg_(std::move(cfg)) {
-  if (driver_) {
-    // Preallocate buffers based on number of joints
-    pos_d_.resize(driver_->get_num_joints());
-    vel_d_.resize(driver_->get_num_joints());
-    eff_d_.resize(driver_->get_num_joints());
-    // Initial read to populate robot_output state
-    robot_output_ = driver_->get_robot_output();
+  std::shared_ptr<hw::HardwareComponent> hardware,
+  const nlohmann::json& config) {
+  // Validate hardware component
+  if (!hardware) {
+    throw std::invalid_argument("TrossenArmProducer: hardware component cannot be null");
   }
+
+  // Dynamic cast to TrossenArmComponent
+  auto arm_component = std::dynamic_pointer_cast<TrossenArmComponent>(hardware);
+  if (!arm_component) {
+    throw std::invalid_argument(
+      "TrossenArmProducer: hardware must be TrossenArmComponent, got: " + hardware->get_type());
+  }
+
+  // Extract driver
+  driver_ = arm_component->get_hardware();
+  if (!driver_) {
+    throw std::invalid_argument("TrossenArmProducer: TrossenArmComponent has null driver");
+  }
+
+  // Parse JSON config into Config struct
+  cfg_.stream_id = config.value("stream_id", "joint_states");
+  cfg_.use_device_time = config.value("use_device_time", false);
+
+  // Preallocate buffers based on number of joints
+  pos_d_.resize(driver_->get_num_joints());
+  vel_d_.resize(driver_->get_num_joints());
+  eff_d_.resize(driver_->get_num_joints());
+
+  // Initial read to populate robot_output state
+  robot_output_ = driver_->get_robot_output();
 
   // Populate metadata
   metadata_.type = "arm";
@@ -84,5 +107,8 @@ void TrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::Rec
   emit(rec);
   ++stats_.produced;
 }
+
+// Register producer with registry
+REGISTER_PRODUCER(TrossenArmProducer, "trossen_arm");
 
 }  // namespace trossen::hw::arm


### PR DESCRIPTION
### TL;DR

Refactored the WidowX AI examples to use the hardware and producer registries for more consistent component management.

### What changed?

- Updated `widowxai.cpp` and `widowxai_bimanual.cpp` to use the hardware registry system for creating and managing arm components
- Refactored `TrossenArmProducer` to be created through the producer registry with JSON configuration
- Changed arm driver management from raw pointers to shared pointers managed by components
- Simplified hardware initialization code by using the registry pattern
- Updated include statements to properly organize dependencies
- Modified the producer constructor to accept a hardware component and JSON config

### How to test?

1. Build the examples:
   ```
   mkdir build && cd build
   cmake .. && make
   ```
2. Run the single-arm example:
   ```
   ./examples/widowxai
   ```
3. Run the bimanual example:
   ```
   ./examples/widowxai_bimanual
   ```
4. Verify that both examples work with the `--use-mock` flag for testing without hardware

### Why make this change?

This refactoring improves code organization and maintainability by:
- Using a consistent pattern for hardware and producer creation
- Leveraging the registry system for better component lifecycle management
- Reducing code duplication in hardware initialization
- Making the examples more consistent with the rest of the codebase
- Simplifying future extensions by using a standardized component creation approach