### PR TITLE
Enhance monitor_episode to return full SessionManager stats

### DIFF
--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -173,6 +173,9 @@ runtime::SessionManager::Stats monitor_episode(
         saved_stats = last_stats;
       }
     }
+    // TODO(shantanuparab-tr): We might miss records written in the last sleep interval.
+    // Consider using condition variable or similar mechanism for better accuracy.
+    // Make sure this is fixed with asynchronous episode monitoring implementation.
     std::this_thread::sleep_for(sleep_interval);
   }
   return saved_stats;

--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -151,36 +151,31 @@ bool interruptible_sleep(std::chrono::duration<double> duration) {
   return true;
 }
 
-uint64_t monitor_episode(
+runtime::SessionManager::Stats monitor_episode(
   runtime::SessionManager& mgr,
   std::chrono::duration<double> update_interval,
   std::chrono::duration<double> sleep_interval)
 {
   auto last_update = std::chrono::steady_clock::now();
-  uint64_t last_record_count = 0;
+  runtime::SessionManager::Stats last_stats;
+  runtime::SessionManager::Stats saved_stats;
 
   while (mgr.is_episode_active() && !g_stop_requested) {
     auto now = std::chrono::steady_clock::now();
     if (now - last_update >= update_interval) {
       auto stats = mgr.stats();
       print_stats_line(stats);
-      last_record_count = stats.records_written_current;
+      last_stats = stats;
       last_update = now;
+      if (last_stats.records_written_current != 0 &&
+          last_stats.records_written_current !=
+            saved_stats.records_written_current) {
+        saved_stats = last_stats;
+      }
     }
     std::this_thread::sleep_for(sleep_interval);
   }
-
-  // Get final count
-  if (mgr.is_episode_active()) {
-    last_record_count = mgr.stats().records_written_current;
-  } else {
-    auto final_stats = mgr.stats();
-    if (final_stats.records_written_current > 0) {
-      last_record_count = final_stats.records_written_current;
-    }
-  }
-
-  return last_record_count;
+  return saved_stats;
 }
 
 std::string generate_episode_path(

--- a/examples/demo_utils.hpp
+++ b/examples/demo_utils.hpp
@@ -145,7 +145,7 @@ bool interruptible_sleep(std::chrono::duration<double> duration);
  * @param sleep_interval How long to sleep between checks
  * @return true if completed normally, false if interrupted by stop request
  */
-uint64_t monitor_episode(
+runtime::SessionManager::Stats monitor_episode(
   runtime::SessionManager& mgr,
   std::chrono::duration<double> update_interval = std::chrono::milliseconds(500),
   std::chrono::duration<double> sleep_interval = std::chrono::milliseconds(100));

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -350,7 +350,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    uint64_t last_record_count = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {
@@ -370,21 +370,24 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_record_count);
+    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts
     // ──────────────────────────────────────────────────────────
 
     trossen::demo::SanityCheckConfig sanity_cfg{
-      actual_duration,
+      last_stats.elapsed.count(),
       1,  // 1 joint producer (follower)
       cfg.joint_rate_hz,
       1,  // 1 camera
       cfg.camera_fps,
       5.0  // 5% tolerance
     };
-    trossen::demo::perform_sanity_check(recording_episode_index, last_record_count, sanity_cfg);
+    trossen::demo::perform_sanity_check(
+      recording_episode_index,
+      last_stats.records_written_current,
+      sanity_cfg);
 
     // Check if user requested stop
     if (trossen::demo::g_stop_requested) {

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -365,7 +365,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    uint64_t last_record_count = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {
@@ -385,7 +385,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_record_count);
+    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts
@@ -399,7 +399,10 @@ int main(int argc, char** argv) {
       cfg.camera_fps,
       5.0  // 5% tolerance
     };
-    trossen::demo::perform_sanity_check(recording_episode_index, last_record_count, sanity_cfg);
+    trossen::demo::perform_sanity_check(
+      recording_episode_index,
+      last_stats.records_written_current,
+      sanity_cfg);
 
     // Check if user requested stop
     if (trossen::demo::g_stop_requested) {

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -471,7 +471,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    uint64_t last_record_count = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {
@@ -491,17 +491,17 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_record_count);
+    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
 
     trossen::demo::SanityCheckConfig sanity_cfg{
-      actual_duration,
+      last_stats.elapsed.count(),
       2,  // 2 joint producers (follower left + follower right)
       cfg.joint_rate_hz,
       static_cast<int>(cfg.camera_indices.size()),  // 4 cameras
       cfg.camera_fps,
       5.0  // 5% tolerance
     };
-    perform_sanity_check(recording_episode_index, last_record_count, sanity_cfg);
+    perform_sanity_check(recording_episode_index, last_stats.records_written_current, sanity_cfg);
 
     // Check if user requested stop
     if (trossen::demo::g_stop_requested) {

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -471,7 +471,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    uint64_t last_record_count = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {
@@ -491,21 +491,24 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_record_count);
+    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts
     // ──────────────────────────────────────────────────────────
 
     trossen::demo::SanityCheckConfig sanity_cfg{
-      actual_duration,
+      last_stats.elapsed.count(),
       1,  // 1 joint producer (follower)
       cfg.joint_rate_hz,
       1,  // 1 camera
       cfg.camera_fps,
       5.0  // 5% tolerance
     };
-    trossen::demo::perform_sanity_check(recording_episode_index, last_record_count, sanity_cfg);
+    trossen::demo::perform_sanity_check(
+      recording_episode_index,
+      last_stats.records_written_current,
+      sanity_cfg);
 
     // Check if user requested stop
     if (trossen::demo::g_stop_requested) {


### PR DESCRIPTION
### TL;DR

Enhanced episode monitoring to return full session statistics instead of just record count.

### What changed?

- Modified `monitor_episode()` to return `SessionManager::Stats` instead of just a record count
- Improved record tracking logic to save the last valid stats rather than just the final count
- Updated all example files (so101_lerobot, widowxai, widowxai_bimanual, widowxai_lerobot) to use the full stats object
- Replaced manual duration tracking with the elapsed time from the stats object for sanity checks

### How to test?

1. Run any of the example applications (so101_lerobot, widowxai, widowxai_bimanual, widowxai_lerobot)
2. Verify that episode statistics are correctly displayed during and after recording
3. Confirm that sanity checks still work properly with the new stats-based approach

### Why make this change?

This change improves the robustness of episode monitoring by:
1. Providing access to the full statistics object rather than just record count
2. Using the elapsed time directly from the stats object for more accurate duration tracking
3. Ensuring the last valid stats are preserved even if the final stats are empty or invalid