### PR TITLE
Delegate episode termination control to SessionManager and simplify recording demos

### DIFF
--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -10,8 +10,8 @@
  * - Configurable episode count and duration
  *
  * Usage:
- *   ./so101_teleop --episodes 5 --duration 10
- *   ./so101_teleop --episodes 3 --duration 5 --root /data/recordings
+ *   ./so101_teleop
+ *   ./so101_teleop --root /data/recordings
  *   ./so101_teleop --mock  # Use mock producers for testing without hardware
  */
 

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -10,8 +10,8 @@
  * - Configurable episode count and duration
  *
  * Usage:
- *   ./widowxai --episodes 5 --duration 10
- *   ./widowxai --episodes 3 --duration 5 --root /data/recordings
+ *   ./widowxai
+ *   ./widowxai --root /data/recordings
  *   ./widowxai --mock  # Use mock producers for testing without hardware
  */
 
@@ -39,8 +39,6 @@
 // ────────────────────────────────────────────────────────────
 
 struct Config {
-  int duration_s = 10;
-  int episodes = 3;
   std::string dataset_id = "";  // empty = auto-generate
   std::string root = trossen::io::backends::get_default_root_path().string();
   bool use_mock = false;
@@ -65,8 +63,6 @@ void print_usage(const char* prog_name) {
   std::cout
     << "Usage: " << prog_name << " [options]\n\n"
     << "Options:\n"
-    << "  --duration <seconds>     Duration per episode (default: 10)\n"
-    << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
     << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
@@ -80,8 +76,8 @@ void print_usage(const char* prog_name) {
     << "  --backend <type>         Dataset backend type (default: mcap)\n"
     << "  --help                   Show this help message\n\n"
     << "Examples:\n"
-    << "  " << prog_name << " --duration 10 --episodes 5\n"
-    << "  " << prog_name << " --mock --duration 5 --episodes 3\n"
+    << "  " << prog_name << "\n"
+    << "  " << prog_name << " --mock\n"
     << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
 }
 
@@ -92,10 +88,6 @@ Config parse_args(int argc, char** argv) {
     if (arg == "--help" || arg == "-h") {
       cfg.show_help = true;
       return cfg;
-    } else if (arg == "--duration" && i + 1 < argc) {
-      cfg.duration_s = std::max(1, std::atoi(argv[++i]));
-    } else if (arg == "--episodes" && i + 1 < argc) {
-      cfg.episodes = std::max(1, std::atoi(argv[++i]));
     } else if (arg == "--dataset-id" && i + 1 < argc) {
       cfg.dataset_id = argv[++i];
     } else if (arg == "--root" && i + 1 < argc) {
@@ -140,8 +132,6 @@ int main(int argc, char** argv) {
   // Print configuration
   std::vector<std::string> config_lines = {
     "Mode:                 " + std::string(cfg.use_mock ? "Mock (no hardware)" : "Hardware"),
-    "Duration per episode: " + std::to_string(cfg.duration_s) + "s",
-    "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
     "Root directory:       " + cfg.root,
     "Backend:              " + cfg.backend_type
@@ -315,14 +305,14 @@ int main(int argc, char** argv) {
   // Recording loop: record requested number of episodes
   // ──────────────────────────────────────────────────────────
 
-  for (int ep = 0; ep < cfg.episodes; ++ep) {
+  while (true) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\n\nStopping at user request (Ctrl+C).\n";
       break;
     }
 
     // Display episode header
-    trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
+    // trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
 
     // Lock the leader arm, move the follower arm to mirror the leader's current position, and
     // unlock the leader
@@ -408,14 +398,6 @@ int main(int argc, char** argv) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
-    }
-
-    // Pause between episodes (unless this was the last one)
-    if (ep < cfg.episodes - 1) {
-      std::cout << "\nPausing for 1 second before next episode...\n";
-      if (!trossen::demo::interruptible_sleep(std::chrono::seconds(1))) {
-        break;  // Stop requested during pause
-      }
     }
   }
 

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -311,9 +311,6 @@ int main(int argc, char** argv) {
       break;
     }
 
-    // Display episode header
-    // trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
-
     // Lock the leader arm, move the follower arm to mirror the leader's current position, and
     // unlock the leader
     if (!cfg.use_mock) {

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -72,8 +72,6 @@ void print_usage(const char* prog_name) {
   std::cout
     << "Usage: " << prog_name << " [options]\n\n"
     << "Options:\n"
-    << "  --duration <seconds>     Duration per episode (default: 10)\n"
-    << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
     << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
@@ -90,8 +88,8 @@ void print_usage(const char* prog_name) {
     << "  Follower Right: 192.168.1.4 (recorded)\n"
     << "  Cameras:        /dev/video0, /dev/video2, /dev/video4, /dev/video6\n\n"
     << "Examples:\n"
-    << "  " << prog_name << " --duration 10 --episodes 5\n"
-    << "  " << prog_name << " --mock --duration 5 --episodes 3\n"
+    << "  " << prog_name << "\n"
+    << "  " << prog_name << " --mock\n"
     << "  " << prog_name << " --dataset-id stationary_demo_001 --root /data/recordings\n";
 }
 
@@ -140,8 +138,6 @@ int main(int argc, char** argv) {
   // Print configuration
   std::vector<std::string> config_lines = {
     "Mode:                 " + std::string(cfg.use_mock ? "Mock (no hardware)" : "Hardware"),
-    "Duration per episode: " + std::to_string(cfg.duration_s) + "s",
-    "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
     "Root directory:       " + cfg.root,
     "Backend:              " + cfg.backend_type
@@ -391,7 +387,7 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
   std::cout << "  Recording: 2 follower arms + 4 cameras = 6 data streams\n";
 
-  for (int ep = 0; ep < cfg.episodes; ++ep) {
+  while (true) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\n\nStopping at user request (Ctrl+C).\n";
       break;
@@ -507,15 +503,6 @@ int main(int argc, char** argv) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
-    }
-
-    // Pause between episodes (unless this was the last one)
-    if (ep < cfg.episodes - 1) {
-      std::cout << "\nPausing for 1 second before next episode...\n";
-      if (!trossen::demo::interruptible_sleep(std::chrono::seconds(1))) {
-        // Stop requested during pause
-        break;
-      }
     }
   }
 

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -417,9 +417,6 @@ int main(int argc, char** argv) {
       break;
     }
 
-    // Display episode header
-    // trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
-
     // Lock the leader arm, move the follower arm to mirror the leader's current position, and
     // unlock the leader
     if (!cfg.use_mock) {

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -10,8 +10,8 @@
  * - Configurable episode count and duration
  *
  * Usage:
- *   ./widowxai_lerobot --episodes 5 --duration 10
- *   ./widowxai_lerobot --episodes 3 --duration 5 --root-dir /data/recordings
+ *   ./widowxai_lerobot
+ *   ./widowxai_lerobot --root-dir /data/recordings
  *   ./widowxai_lerobot --mock  # Use mock producers for testing without hardware
  */
 
@@ -45,8 +45,6 @@
 // ────────────────────────────────────────────────────────────
 
 struct Config {
-  int duration_s = 10;
-  int episodes = 3;
   std::string dataset_id = "";  // empty = auto-generate
   std::string root = trossen::io::backends::get_default_root_path().string();
   std::string repository_id = "TrossenRoboticsCommunity";  // Valid only for LeRobot backend
@@ -72,8 +70,6 @@ void print_usage(const char* prog_name) {
   std::cout
     << "Usage: " << prog_name << " [options]\n\n"
     << "Options:\n"
-    << "  --duration <seconds>     Duration per episode (default: 10)\n"
-    << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
     << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --repository-id <string> Repository identifier (default: TrossenRoboticsCommunity, "
@@ -89,8 +85,8 @@ void print_usage(const char* prog_name) {
     << "  --backend <type>         Dataset backend type (default: mcap)\n"
     << "  --help                   Show this help message\n\n"
     << "Examples:\n"
-    << "  " << prog_name << " --duration 10 --episodes 5\n"
-    << "  " << prog_name << " --mock --duration 5 --episodes 3\n"
+    << "  " << prog_name << "\n"
+    << "  " << prog_name << " --mock\n"
     << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
 }
 
@@ -101,10 +97,6 @@ Config parse_args(int argc, char** argv) {
     if (arg == "--help" || arg == "-h") {
       cfg.show_help = true;
       return cfg;
-    } else if (arg == "--duration" && i + 1 < argc) {
-      cfg.duration_s = std::max(1, std::atoi(argv[++i]));
-    } else if (arg == "--episodes" && i + 1 < argc) {
-      cfg.episodes = std::max(1, std::atoi(argv[++i]));
     } else if (arg == "--dataset-id" && i + 1 < argc) {
       cfg.dataset_id = argv[++i];
     } else if (arg == "--root" && i + 1 < argc) {
@@ -159,8 +151,6 @@ int main(int argc, char** argv) {
   // Print configuration
   std::vector<std::string> config_lines = {
     "Mode:                 " + std::string(cfg.use_mock ? "Mock (no hardware)" : "Hardware"),
-    "Duration per episode: " + std::to_string(cfg.duration_s) + "s",
-    "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
     "Root directory:       " + cfg.root,
     "Repository ID:        " + cfg.repository_id,
@@ -421,14 +411,14 @@ int main(int argc, char** argv) {
   // Recording loop: record requested number of episodes
   // ──────────────────────────────────────────────────────────
 
-  for (int ep = 0; ep < cfg.episodes; ++ep) {
+  while (true) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\n\nStopping at user request (Ctrl+C).\n";
       break;
     }
 
     // Display episode header
-    trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
+    // trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
 
     // Lock the leader arm, move the follower arm to mirror the leader's current position, and
     // unlock the leader
@@ -514,14 +504,6 @@ int main(int argc, char** argv) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
-    }
-
-    // Pause between episodes (unless this was the last one)
-    if (ep < cfg.episodes - 1) {
-      std::cout << "\nPausing for 1 second before next episode...\n";
-      if (!trossen::demo::interruptible_sleep(std::chrono::seconds(1))) {
-        break;  // Stop requested during pause
-      }
     }
   }
 


### PR DESCRIPTION
### TL;DR

Removed episode count and duration limits from robot recording examples, making them run continuously until stopped by session manager or  manually stopped.

### What changed?

* Updated recording loops to run continuously (`while (true)`), removing fixed episode limits so that **session termination is fully controlled by the SessionManager**.
* Removed `--episodes` and `--duration` command-line arguments from all demos to eliminate **redundant and misleading control paths**.
* Removed demo-level pauses between episodes, as **timing and transitions are responsibilities of the SessionManager**.
* Updated documentation and usage examples to reflect the new session-driven control flow.
* Removed demo-side configuration and logging for episode count and duration to avoid duplicating session-level state.
* Commented out episode header displays related to duration, with the intent to **centralize this logic in the SessionManager** in future updates.

### How to test?

Run any of the examples without parameters to start continuous recording:
```
./widowxai
./widowxai_lerobot
./widowxai_bimanual
./so101_teleop
```

Let the Session Manager stop the recording session or use Ctrl+C to stop recording at any time.

### Why make this change?

This change simplifies both the user experience and the internal control flow by removing demo-level episode limits and delegating all session termination logic to the SessionManager. Recording examples now run continuously, allowing users to start a session and rely on the SessionManager to determine when and how episodes are ended.