### PR TITLE
Move episode header printing to SessionManager class

### DIFF
--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -28,17 +28,6 @@ void install_signal_handler() {
   std::signal(SIGINT, signal_handler);
 }
 
-void print_episode_header(uint32_t index, int duration_s) {
-  std::cout << "\n╔════════════════════════════════════════════════════════════╗\n";
-  std::cout << "║  Episode " << index << " | Target Duration: " << duration_s << "s";
-
-  // Calculate padding to align right edge
-  std::string padding(
-    41 - std::to_string(index).length() - std::to_string(duration_s).length(), ' ');
-  std::cout << padding << "║\n";
-  std::cout << "╚════════════════════════════════════════════════════════════╝\n";
-}
-
 void print_stats_line(const runtime::SessionManager::Stats& stats) {
   std::cout << "\r[Episode " << stats.current_episode_index << "] "
             << "Elapsed: " << std::fixed << std::setprecision(1) << stats.elapsed.count() << "s"

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -314,7 +314,7 @@ int main(int argc, char** argv) {
     }
 
     // Display episode header
-    trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
+    mgr.print_episode_header();
 
     // Sync follower to leader's current position before recording
     if (!cfg.use_mock) {

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -432,7 +432,7 @@ int main(int argc, char** argv) {
     }
 
     // Display episode header
-    trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
+    mgr.print_episode_header();
 
     // Start episode
     if (!mgr.start_episode()) {

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -417,6 +417,9 @@ int main(int argc, char** argv) {
       break;
     }
 
+    // Display episode header
+    mgr.print_episode_header();
+
     // Lock the leader arm, move the follower arm to mirror the leader's current position, and
     // unlock the leader
     if (!cfg.use_mock) {

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -162,6 +162,11 @@ public:
    */
   Stats stats() const;
 
+  /**
+   * @brief Print episode header to console
+   */
+  void print_episode_header();
+
 private:
   /// @brief Configuration
   std::shared_ptr<trossen::configuration::SessionManagerConfig> cfg_;

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -361,4 +361,25 @@ void SessionManager::monitor_duration() {
   }
 }
 
+void SessionManager::print_episode_header() {
+  std::cout << "\n╔════════════════════════════════════════════════════════════╗\n";
+  std::cout << "║  Episode " << next_episode_index_ << " | Target Duration: ";
+  if (cfg_->max_duration.has_value()) {
+    std::cout << cfg_->max_duration->count() << "s";
+  } else {
+    std::cout << "unlimited";
+  }
+
+  // Calculate padding to align right edge
+  const std::size_t episode_len = std::to_string(next_episode_index_).length();
+  const std::size_t duration_len = cfg_->max_duration.has_value()
+    ? std::to_string(cfg_->max_duration->count()).length()
+    : static_cast<std::size_t>(9);
+  const std::size_t total_len = episode_len + duration_len;
+  const std::size_t padding_len = (41 > total_len) ? (41 - total_len) : 0;
+  std::string padding(padding_len, ' ');
+  std::cout << padding << "║\n";
+  std::cout << "╚════════════════════════════════════════════════════════════╝\n";
+}
+
 }  // namespace trossen::runtime


### PR DESCRIPTION
### TL;DR

Moved episode header printing functionality from demo_utils to SessionManager class.

### What changed?

- Removed `print_episode_header()` function from demo_utils.cpp
- Added a new `print_episode_header()` method to the SessionManager class
- Updated the implementation to handle unlimited duration cases
- Modified all example files (so101_lerobot.cpp, widowxai_bimanual.cpp, widowxai.cpp, widowxai_lerobot.cpp) to use the new SessionManager method
- Uncommented the episode header printing in widowxai_lerobot.cpp

### How to test?

Run any of the example applications and verify that episode headers are correctly displayed with:
- Proper episode numbering
- Correct duration display (including "unlimited" when no max duration is set)
- Proper formatting and alignment of the header box

### Why make this change?

This change improves encapsulation by moving the episode header printing logic to the SessionManager class, which already manages episode state. The implementation is also enhanced to handle unlimited duration cases, making it more flexible. This creates a more consistent interface for all examples and ensures the header information is always derived directly from the SessionManager's state.