### PR TITLE
Enhance episode summary with detailed statistics display

### DIFF
--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -43,9 +43,123 @@ void print_stats_line(const runtime::SessionManager::Stats& stats) {
   std::cout << std::flush;
 }
 
-void print_episode_summary(const std::string& file_path, uint64_t records) {
-  std::cout << "\n✓ Episode complete: " << records << " records written\n";
-  std::cout << "  File: " << file_path << "\n";
+void print_episode_summary(const std::string& file_path, runtime::SessionManager::Stats stats) {
+  // Helper to repeat a string n times
+  auto repeat_str = [](const std::string& s, size_t n) {
+    std::string result;
+    result.reserve(s.length() * n);
+    for (size_t i = 0; i < n; ++i) {
+      result += s;
+    }
+    return result;
+  };
+
+  // Prepare all the values as strings
+  std::string records_str = std::to_string(stats.records_written_current);
+
+  std::string duration_str =
+      std::to_string(static_cast<int>(stats.elapsed.count())) + "s";
+
+  std::string setup_str =
+      stats.preprocessing_duration_s.has_value()
+          ? std::to_string(
+                stats.preprocessing_duration_s.value()) + "s"
+          : "";
+
+  std::string shutdown_str =
+      stats.postprocess_duration_s.has_value()
+          ? std::to_string(
+                stats.postprocess_duration_s.value()) + "s"
+          : "";
+
+  std::string rate_str =
+      stats.elapsed.count() > 0
+          ? std::to_string(static_cast<int>(
+                stats.records_written_current / stats.elapsed.count())) +
+                " records/s"
+          : "";
+
+  // Calculate the maximum value length needed
+  size_t max_value_len = records_str.length();
+  max_value_len = std::max(max_value_len, duration_str.length());
+  if (!setup_str.empty()) max_value_len = std::max(max_value_len, setup_str.length());
+  if (!shutdown_str.empty()) max_value_len = std::max(max_value_len, shutdown_str.length());
+  if (!rate_str.empty()) max_value_len = std::max(max_value_len, rate_str.length());
+  // Label column width (longest label + padding)
+  const size_t label_width = 21;  // "Records Written:     " is 21 chars
+  // Calculate minimum box width based on content
+  size_t min_box_width = 2 + label_width + max_value_len + 2;
+  // Include file path length in calculation
+  size_t file_path_width = 9 + file_path.length();  // "│ File: " (7) + path + " │" (2)
+  // Title width
+  std::string title = " ✓ Episode " + std::to_string(stats.current_episode_index) + " Summary";
+  size_t title_width = 2 + title.length();  // "│" + title + "│"
+  // Use the maximum of all width requirements
+  const size_t box_width = std::max({min_box_width, file_path_width, title_width});
+  // Top border
+  std::cout << "\n┌" << repeat_str("─", box_width - 2) << "┐\n";
+  // Title line
+  std::cout << "│" << title << std::string(box_width - 2 - title.length(), ' ') << "│\n";
+  // Separator
+  std::cout << "├" << repeat_str("─", box_width - 2) << "┤\n";
+  // Helper lambda to print a row
+  auto print_row = [&](const std::string& label, const std::string& value) {
+    std::cout << "│ " << std::setw(label_width) << std::left << label
+              << std::setw(max_value_len) << std::left << value << " │\n";
+  };
+
+  // Data rows
+  print_row("Records Written:", records_str);
+  print_row("Duration:", duration_str);
+
+  if (!setup_str.empty()) {
+    print_row("Pre-Processing Time:", setup_str);
+  }
+
+  if (!shutdown_str.empty()) {
+    print_row("Post-Processing Time:", shutdown_str);
+  }
+
+  if (!rate_str.empty()) {
+    print_row("Average Rate:", rate_str);
+  }
+
+  // Separator before file path
+  std::cout << "├" << repeat_str("─", box_width - 2) << "┤\n";
+
+  // File path (display full path)
+  // Limit the "File" line to at most 100 characters (including borders)
+  const size_t max_line_len = 100;
+  const std::string prefix = "│ File: ";
+  const std::string suffix = "│";
+
+  // Compute max length available for the file path
+  size_t max_path_len = (max_line_len > prefix.size() + suffix.size())
+                          ? (max_line_len - prefix.size() - suffix.size())
+                          : 0;
+
+  std::string display_path = file_path;
+  if (display_path.size() > max_path_len) {
+    if (max_path_len <= 3) {
+      display_path = display_path.substr(0, max_path_len);
+    } else {
+      size_t keep = max_path_len - 3;
+      size_t front = keep / 2;
+      size_t back = keep - front;
+      display_path = display_path.substr(0, front) + "..." +
+                     display_path.substr(display_path.size() - back);
+    }
+  }
+
+  // Pad up to the smaller of box_width or 100 to keep alignment where possible
+  size_t target_len = std::min(box_width, max_line_len);
+  size_t current_len = prefix.size() + display_path.size() + suffix.size();
+  size_t pad = (current_len < target_len) ? (target_len - current_len) : 0;
+
+  std::cout << prefix << display_path << std::string(pad, ' ') << suffix << "\n";
+
+  // Bottom border
+  std::cout << "└" << repeat_str("─", box_width - 2) << "┘\n";
 }
 
 void print_config_banner(

--- a/examples/demo_utils.hpp
+++ b/examples/demo_utils.hpp
@@ -72,7 +72,7 @@ void print_stats_line(const runtime::SessionManager::Stats& stats);
  * @param file_path Path to the recorded episode
  * @param records Number of records written
  */
-void print_episode_summary(const std::string& file_path, uint64_t records);
+void print_episode_summary(const std::string& file_path, runtime::SessionManager::Stats stats);
 
 /**
  * @brief Print application configuration banner

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -370,7 +370,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
+    trossen::demo::print_episode_summary(file_path, last_stats);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -372,7 +372,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
+    trossen::demo::print_episode_summary(file_path, last_stats);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -487,7 +487,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
+    trossen::demo::print_episode_summary(file_path, last_stats);
 
     trossen::demo::SanityCheckConfig sanity_cfg{
       last_stats.elapsed.count(),

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -481,7 +481,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
+    trossen::demo::print_episode_summary(file_path, last_stats);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -155,6 +155,12 @@ public:
 
     /// @brief Episodes finished this session
     uint64_t total_episodes_completed;
+
+    /// @brief Duration of episode preprocessing (seconds)
+    std::optional<double> preprocessing_duration_s;
+
+    /// @brief Duration of episode shutdown (seconds)
+    std::optional<double> postprocess_duration_s;
   };
 
   /**
@@ -185,6 +191,12 @@ private:
 
   /// @brief Sink's processed_count() at the start of current episode (for delta tracking)
   uint64_t episode_start_record_count_{0};
+
+  /// @brief Duration of last preprocessing phase (seconds)
+  double preprocessing_duration_s_{0.0};
+
+  /// @brief Duration of last shutdown phase (seconds)
+  double postprocess_duration_s_{0.0};
 
   /// @brief Monitoring thread for duration-based auto-stop
   std::thread monitor_thread_;

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -89,6 +89,8 @@ bool SessionManager::start_episode() {
     std::cerr << "Episode already active. Call stop_episode() first." << std::endl;
     return false;
   }
+  // Start a timer to measure pre-processing duration
+  auto prep_start_time = std::chrono::steady_clock::now();
 
   ProducerMetadataList producer_metadata;
 
@@ -182,13 +184,19 @@ bool SessionManager::start_episode() {
     monitoring_active_ = true;
     monitor_thread_ = std::thread([this]() { monitor_duration(); });
   }
-
+  // Measure and report pre-processing duration
+  auto prep_end_time = std::chrono::steady_clock::now();
+  preprocessing_duration_s_ =
+    std::chrono::duration<double>(prep_end_time - prep_start_time).count();
   std::cout << "Episode " << next_episode_index_ << " started." << std::endl;
 
   return true;
 }
 
 void SessionManager::stop_episode() {
+  // Start timer to measure shutdown duration
+  auto shutdown_start_time = std::chrono::steady_clock::now();
+
   // First, signal monitoring thread to stop (if any)
   monitoring_active_ = false;
 
@@ -232,6 +240,10 @@ void SessionManager::stop_episode() {
   ++total_episodes_completed_;
   ++next_episode_index_;
 
+  // Measure and report shutdown duration
+  auto shutdown_end_time = std::chrono::steady_clock::now();
+  auto shutdown_duration = shutdown_end_time - shutdown_start_time;
+  postprocess_duration_s_ = std::chrono::duration<double>(shutdown_duration).count();
   std::cout << "\nEpisode stopped. Total completed: " << total_episodes_completed_
             << ", Next index: " << next_episode_index_ << std::endl;
 
@@ -306,6 +318,12 @@ SessionManager::Stats SessionManager::stats() const {
     } else {
       s.records_written_current = 0;
     }
+    if (preprocessing_duration_s_ > 0.0) {
+      s.preprocessing_duration_s = preprocessing_duration_s_;
+    }
+    if (postprocess_duration_s_ > 0.0) {
+      s.postprocess_duration_s = postprocess_duration_s_;
+    }
   } else {
     s.elapsed = std::chrono::duration<double>(0);
     s.remaining = std::nullopt;
@@ -313,6 +331,7 @@ SessionManager::Stats SessionManager::stats() const {
   }
 
   s.total_episodes_completed = total_episodes_completed_;
+
 
   return s;
 }


### PR DESCRIPTION
# Enhanced Episode Summary Display with Detailed Statistics

### TL;DR
Improved the episode summary display with a formatted box layout that shows detailed statistics including processing times and recording rates.

### What changed?
- Updated the function signature to accept full `SessionManager::Stats` instead of just record count
- Added tracking for pre-processing and post-processing durations in `SessionManager`
- Added new fields to the `Stats` struct to store these durations
- Enhanced `print_episode_summary()` to display information in a formatted box with borders
- Updated all example applications to pass the full stats object to the summary function

### How to test?
Run any of the example applications that record episodes. When an episode completes, you'll see a nicely formatted summary box showing:
- Records written
- Total duration
- Pre-processing time
- Post-processing time
- Average recording rate
- File path

### Why make this change?
This change provides users with more detailed information about episode recording performance in a visually appealing format. The additional metrics help users understand the efficiency of their recording sessions and identify potential bottlenecks in the pre-processing or post-processing phases.