### PR TITLE
Improve episode statistics with accurate recording duration tracking

### DIFF
--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -57,8 +57,9 @@ void print_episode_summary(const std::string& file_path, runtime::SessionManager
   // Prepare all the values as strings
   std::string records_str = std::to_string(stats.records_written_current);
 
-  std::string duration_str =
-      std::to_string(static_cast<int>(stats.elapsed.count())) + "s";
+  std::ostringstream duration_ss;
+  duration_ss << std::fixed << std::setprecision(1) << stats.elapsed.count() << "s";
+  std::string duration_str = duration_ss.str();
 
   std::string setup_str =
       stats.preprocessing_duration_s.has_value()
@@ -72,10 +73,13 @@ void print_episode_summary(const std::string& file_path, runtime::SessionManager
                 stats.postprocess_duration_s.value()) + "s"
           : "";
 
+  std::string actual_duration_str =
+      std::to_string(stats.recording_duration_s.value_or(0.0)) + "s";
+
   std::string rate_str =
       stats.elapsed.count() > 0
           ? std::to_string(static_cast<int>(
-                stats.records_written_current / stats.elapsed.count())) +
+                stats.records_written_current / stats.recording_duration_s.value_or(0.0))) +
                 " records/s"
           : "";
 
@@ -111,6 +115,8 @@ void print_episode_summary(const std::string& file_path, runtime::SessionManager
   // Data rows
   print_row("Records Written:", records_str);
   print_row("Duration:", duration_str);
+
+  print_row("Actual Duration:", actual_duration_str);
 
   if (!setup_str.empty()) {
     print_row("Pre-Processing Time:", setup_str);
@@ -261,27 +267,21 @@ runtime::SessionManager::Stats monitor_episode(
 {
   auto last_update = std::chrono::steady_clock::now();
   runtime::SessionManager::Stats last_stats;
-  runtime::SessionManager::Stats saved_stats;
 
-  while (mgr.is_episode_active() && !g_stop_requested) {
+  while (!mgr.are_final_stats_emitted()) {
     auto now = std::chrono::steady_clock::now();
     if (now - last_update >= update_interval) {
       auto stats = mgr.stats();
       print_stats_line(stats);
       last_stats = stats;
       last_update = now;
-      if (last_stats.records_written_current != 0 &&
-          last_stats.records_written_current !=
-            saved_stats.records_written_current) {
-        saved_stats = last_stats;
-      }
     }
     // TODO(shantanuparab-tr): We might miss records written in the last sleep interval.
     // Consider using condition variable or similar mechanism for better accuracy.
     // Make sure this is fixed with asynchronous episode monitoring implementation.
     std::this_thread::sleep_for(sleep_interval);
   }
-  return saved_stats;
+  return last_stats;
 }
 
 std::string generate_episode_path(

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -488,7 +488,7 @@ int main(int argc, char** argv) {
     // ──────────────────────────────────────────────────────────
 
     trossen::demo::SanityCheckConfig sanity_cfg{
-      last_stats.elapsed.count(),
+      last_stats.recording_duration_s.value_or(0.0),
       1,  // 1 joint producer (follower)
       cfg.joint_rate_hz,
       1,  // 1 camera

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -108,6 +108,13 @@ public:
   bool is_episode_active() const;
 
   /**
+    * @brief Check if the final stats are emitted
+    *
+    * @return true if final stats have been emitted, false otherwise
+    */
+  bool are_final_stats_emitted() const;
+
+  /**
    * @brief Wait for auto-stop signal (if max_duration is set)
    *
    * @param timeout Maximum time to wait (default: wait indefinitely)
@@ -156,6 +163,9 @@ public:
     /// @brief Episodes finished this session
     uint64_t total_episodes_completed;
 
+    /// @brief Duration of episode recording
+    std::optional<double> recording_duration_s;
+
     /// @brief Duration of episode preprocessing (seconds)
     std::optional<double> preprocessing_duration_s;
 
@@ -198,6 +208,12 @@ private:
   /// @brief Duration of last shutdown phase (seconds)
   double postprocess_duration_s_{0.0};
 
+  /// @brief Final elapsed time when episode stopped
+  std::chrono::duration<double> final_elapsed_{0};
+
+  /// @brief Final record count when episode stopped
+  uint64_t final_records_written_{0};
+
   /// @brief Monitoring thread for duration-based auto-stop
   std::thread monitor_thread_;
 
@@ -206,6 +222,9 @@ private:
 
   /// @brief Flag indicating that auto-stop was triggered by monitor thread
   std::atomic<bool> auto_stop_triggered_{false};
+
+  /// @brief Flag indicating that episode final statistics were emitted
+  mutable std::atomic<bool> stats_emitted_{false};
 
   /// @brief Condition variable for auto-stop signaling
   std::condition_variable auto_stop_cv_;

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -89,6 +89,9 @@ bool SessionManager::start_episode() {
     std::cerr << "Episode already active. Call stop_episode() first." << std::endl;
     return false;
   }
+  // Make sure stats_emitted_ is reset for new episode
+  stats_emitted_.store(false);
+
   // Start a timer to measure pre-processing duration
   auto prep_start_time = std::chrono::steady_clock::now();
 
@@ -222,6 +225,12 @@ void SessionManager::stop_episode() {
     scheduler_.reset();
   }
 
+  // Get the final record count before stopping sink
+  if (current_sink_) {
+    final_records_written_ = current_sink_->processed_count() - episode_start_record_count_;
+  } else {
+    final_records_written_ = 0;
+  }
   // Stop sink - drain queue and write all pending records
   if (current_sink_) {
     current_sink_->stop();
@@ -263,6 +272,10 @@ bool SessionManager::is_episode_active() const {
   return episode_active_;
 }
 
+bool SessionManager::are_final_stats_emitted() const {
+  return stats_emitted_.load();
+}
+
 bool SessionManager::wait_for_auto_stop(std::chrono::milliseconds timeout) {
   std::unique_lock<std::mutex> lock(auto_stop_mutex_);
 
@@ -296,7 +309,7 @@ SessionManager::Stats SessionManager::stats() const {
   s.current_episode_index = next_episode_index_;
   s.episode_active = episode_active_;
 
-  if (episode_active_) {
+  if (episode_active_ || !stats_emitted_.load()) {
     auto now = std::chrono::steady_clock::now();
     s.elapsed = std::chrono::duration<double>(now - episode_start_time_);
 
@@ -316,13 +329,18 @@ SessionManager::Stats SessionManager::stats() const {
       uint64_t current_count = current_sink_->processed_count();
       s.records_written_current = current_count - episode_start_record_count_;
     } else {
-      s.records_written_current = 0;
+      s.records_written_current = final_records_written_;
     }
     if (preprocessing_duration_s_ > 0.0) {
       s.preprocessing_duration_s = preprocessing_duration_s_;
     }
     if (postprocess_duration_s_ > 0.0) {
       s.postprocess_duration_s = postprocess_duration_s_;
+    }
+    if (!stats_emitted_.load() && !episode_active_) {
+      s.recording_duration_s = s.elapsed.count() -
+        (preprocessing_duration_s_ + postprocess_duration_s_);
+      stats_emitted_.store(true);
     }
   } else {
     s.elapsed = std::chrono::duration<double>(0);
@@ -367,11 +385,6 @@ void SessionManager::monitor_duration() {
 
       // Stop monitoring first
       monitoring_active_ = false;
-
-      // Detach this thread so it can clean itself up
-      if (monitor_thread_.joinable()) {
-        monitor_thread_.detach();
-      }
 
       // Call stop_episode() directly from this thread
       stop_episode();


### PR DESCRIPTION
### TL;DR

Improved episode statistics tracking and display with more accurate duration measurements and better final stats handling.

### What changed?

- Added `recording_duration_s` to track the actual recording time (excluding pre/post-processing)
- Improved duration display with decimal precision (1 decimal place)
- Added "Actual Duration" to the episode summary output
- Fixed record rate calculation to use actual recording time instead of total elapsed time
- Added `are_final_stats_emitted()` method to properly track when final statistics are available
- Implemented proper tracking of final record counts and elapsed time when an episode stops
- Fixed the monitoring logic to continue until final stats are emitted rather than just checking if the episode is active

### How to test?

1. Run any demo application that uses the SessionManager
2. Verify that the episode summary now shows "Actual Duration" separate from total duration
3. Check that the records/second rate is calculated based on actual recording time
4. Confirm that final statistics are properly displayed after an episode completes

### Why make this change?

The previous implementation didn't accurately track or display the actual recording duration separate from setup and teardown times. This made it difficult to get accurate performance metrics, especially for the records/second calculation. The changes provide more precise timing information and ensure that final statistics are properly captured and displayed, even after an episode has completed.