### PR TITLE
Move episode monitoring functionality from demo_utils to SessionManager

### DIFF
--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -28,21 +28,6 @@ void install_signal_handler() {
   std::signal(SIGINT, signal_handler);
 }
 
-void print_stats_line(const runtime::SessionManager::Stats& stats) {
-  std::cout << "\r[Episode " << stats.current_episode_index << "] "
-            << "Elapsed: " << std::fixed << std::setprecision(1) << stats.elapsed.count() << "s"
-            << " | Records: " << stats.records_written_current;
-
-  if (stats.remaining.has_value() && stats.remaining->count() > 0) {
-    std::cout << " | Remaining: " << std::fixed << std::setprecision(1)
-              << stats.remaining->count() << "s";
-  } else {
-    std::cout << " | Duration: unlimited";
-  }
-
-  std::cout << std::flush;
-}
-
 void print_episode_summary(const std::string& file_path, runtime::SessionManager::Stats stats) {
   // Helper to repeat a string n times
   auto repeat_str = [](const std::string& s, size_t n) {

--- a/examples/demo_utils.hpp
+++ b/examples/demo_utils.hpp
@@ -58,15 +58,6 @@ void install_signal_handler();
 void print_episode_header(uint32_t index, int duration_s);
 
 /**
- * @brief Print a single line of episode statistics (updates in place)
- *
- * Uses carriage return to overwrite the previous line for smooth updates.
- *
- * @param stats Session manager statistics
- */
-void print_stats_line(const runtime::SessionManager::Stats& stats);
-
-/**
  * @brief Print episode completion summary
  *
  * @param file_path Path to the recorded episode
@@ -134,21 +125,6 @@ bool perform_sanity_check(
  * @return true if completed normally, false if interrupted by stop request
  */
 bool interruptible_sleep(std::chrono::duration<double> duration);
-
-/**
- * @brief Pausable sleep that respects stop requests
- *
- * Sleeps for the specified duration but checks g_stop_requested
- * periodically and returns early if stop is requested.
- *
- * @param update_interval How often to print stats
- * @param sleep_interval How long to sleep between checks
- * @return true if completed normally, false if interrupted by stop request
- */
-runtime::SessionManager::Stats monitor_episode(
-  runtime::SessionManager& mgr,
-  std::chrono::duration<double> update_interval = std::chrono::milliseconds(500),
-  std::chrono::duration<double> sleep_interval = std::chrono::milliseconds(100));
 
 /**
  * @brief Generate episode file path

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -349,7 +349,8 @@ int main(int argc, char** argv) {
       });
     }
 
-    // Monitor loop: display stats while episode is active
+    // Blocking monitor call: keeps the main thread alive while the episode is recording,
+    // prevents threads from joining before data is collected, and updates/prints status logs.
     trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -350,7 +350,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -352,7 +352,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -351,7 +351,8 @@ int main(int argc, char** argv) {
       });
     }
 
-    // Monitor loop: display stats while episode is active
+    // Blocking monitor call: keeps the main thread alive while the episode is recording,
+    // prevents threads from joining before data is collected, and updates/prints status logs.
     trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -466,7 +466,8 @@ int main(int argc, char** argv) {
       });
     }
 
-    // Monitor loop: display stats while episode is active
+    // Blocking monitor call: keeps the main thread alive while the episode is recording,
+    // prevents threads from joining before data is collected, and updates/prints status logs.
     trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -467,7 +467,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -460,7 +460,8 @@ int main(int argc, char** argv) {
       });
     }
 
-    // Monitor loop: display stats while episode is active
+    // Blocking monitor call: keeps the main thread alive while the episode is recording,
+    // prevents threads from joining before data is collected, and updates/prints status logs.
     trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -461,7 +461,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -183,6 +183,30 @@ public:
    */
   void print_episode_header();
 
+  /**
+  * @brief Print a single line of episode statistics (updates in place)
+  *
+  * Uses carriage return to overwrite the previous line for smooth updates.
+  *
+  * @param stats Session manager statistics
+  */
+  void print_stats_line(const Stats& stats);
+
+  /**
+  * @brief Pausable sleep that respects stop requests
+  *
+  * Sleeps for the specified duration but checks g_stop_requested
+  * periodically and returns early if stop is requested.
+  * Also, keeps a track of stats while monitoring the episode.
+  *
+  * @param update_interval How often to print stats
+  * @param sleep_interval How long to sleep between checks
+  * @return true if completed normally, false if interrupted by stop request
+  */
+  Stats monitor_episode(
+    std::chrono::duration<double> update_interval = std::chrono::milliseconds(500),
+    std::chrono::duration<double> sleep_interval = std::chrono::milliseconds(100));
+
 private:
   /// @brief Configuration
   std::shared_ptr<trossen::configuration::SessionManagerConfig> cfg_;

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -414,4 +414,39 @@ void SessionManager::print_episode_header() {
   std::cout << "╚════════════════════════════════════════════════════════════╝\n";
 }
 
+void SessionManager::print_stats_line(const SessionManager::Stats& stats) {
+  std::cout << "\r[Episode " << stats.current_episode_index << "] "
+            << "Elapsed: " << std::fixed << std::setprecision(1) << stats.elapsed.count() << "s"
+            << " | Records: " << stats.records_written_current;
+
+  if (stats.remaining.has_value() && stats.remaining->count() > 0) {
+    std::cout << " | Remaining: " << std::fixed << std::setprecision(1)
+              << stats.remaining->count() << "s";
+  } else {
+    std::cout << " | Duration: unlimited";
+  }
+
+  std::cout << std::flush;
+}
+
+SessionManager::Stats SessionManager::monitor_episode(
+  std::chrono::duration<double> update_interval,
+  std::chrono::duration<double> sleep_interval)
+{
+  auto last_update = std::chrono::steady_clock::now();
+  SessionManager::Stats last_stats;
+
+  while (!are_final_stats_emitted()) {
+    auto now = std::chrono::steady_clock::now();
+    if (now - last_update >= update_interval) {
+      SessionManager::Stats stats_ = stats();
+      print_stats_line(stats_);
+      last_stats = stats_;
+      last_update = now;
+    }
+    std::this_thread::sleep_for(sleep_interval);
+  }
+  return last_stats;
+}
+
 }  // namespace trossen::runtime


### PR DESCRIPTION
### TL;DR

Moved episode monitoring functionality from demo utilities into the SessionManager class.

### What changed?

- Moved `print_stats_line()` and `monitor_episode()` functions from `demo_utils` to the `SessionManager` class
- Updated all example files to use the new `mgr.monitor_episode()` method instead of the standalone utility function
- Added appropriate documentation for the newly added methods in the SessionManager class
- Removed the now-redundant function declarations from demo_utils.hpp

### How to test?

1. Build and run any of the example applications (so101_lerobot, widowxai, widowxai_bimanual, or widowxai_lerobot)
2. Verify that episode monitoring still works correctly with the same output format
3. Check that episode statistics are displayed properly during runtime

### Why make this change?

This refactoring improves code organization by moving the monitoring functionality directly into the SessionManager class where it logically belongs. Since the monitoring functionality is closely tied to the SessionManager's state and statistics, having these methods as part of the class creates a more cohesive design and reduces dependencies on external utility functions.  The` monitor_episode()` method also serves as a blocking call to prevent script termination.

### Future
Rename the `monitor_episode` method and move `print_stats_line` to a logging utility class.