### PR TITLE
Added So101 arm component (to use for initalization)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
   rev: v2.4.1
   hooks:
   - id: codespell
+    exclude: '.*\.json$'
     additional_dependencies:
     - tomli
 

--- a/apps/trossen_sdk_ui/backend/src/session_actions.cpp
+++ b/apps/trossen_sdk_ui/backend/src/session_actions.cpp
@@ -456,6 +456,7 @@ bool setup_arm_recording(
     return true;
 }
 
+// Set up full system recording (cameras + arms + teleop if applicable)
 bool setup_full_system_recording(
     std::shared_ptr<ActiveSession> active_session,
     const std::string& system_id,


### PR DESCRIPTION
# Add SO101 Arm Component and Enable RealSense Support

This PR adds a new hardware component wrapper for SO101 arms that provides JSON configuration capabilities. The component wraps the existing SO101ArmDriver and makes it easier to configure and use in applications.

Key changes:
- Created new `SO101ArmComponent` class with JSON configuration support
- Enabled Intel RealSense support by default
- Added install targets for library and headers
- Temporarily disabled benchmarks due to compilation errors

The new component allows configuring the arm with a simple JSON format specifying the end effector type and port.