### PR TITLE
Move backend-specific constants from common utils to respective config files

### DIFF
--- a/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
@@ -13,20 +13,28 @@
 
 namespace trossen::configuration {
 
+// LeRobot backend specific constants
+inline constexpr bool LEROBOT_DEFAULT_OVERWRITE_EXISTING = false;
+inline constexpr bool LEROBOT_DEFAULT_ENCODE_VIDEOS = false;
+inline constexpr char LEROBOT_DEFAULT_TASK_NAME[] = "perform a generic task";
+inline constexpr char LEROBOT_DEFAULT_REPOSITORY_ID[] = "TrossenRoboticsCommunity";
+inline constexpr float LEROBOT_DEFAULT_FPS = 30.0f;
+inline constexpr int LEROBOT_DEFAULT_EPISODE_INDEX = 0;
+
 struct LeRobotBackendConfig : public BaseConfig {
   int encoder_threads{trossen::io::backends::DEFAULT_ENCODER_THREADS};
   int max_image_queue{trossen::io::backends::DEFAULT_MAX_IMAGE_QUEUE};
   int png_compression_level{trossen::io::backends::DEFAULT_PNG_COMPRESSION_LEVEL};
-  bool overwrite_existing{trossen::io::backends::DEFAULT_OVERWRITE_EXISTING};
-  bool encode_videos{trossen::io::backends::DEFAULT_ENCODE_VIDEOS};
-  std::string task_name{trossen::io::backends::DEFAULT_TASK_NAME};
-  std::string repository_id{trossen::io::backends::DEFAULT_REPOSITORY_ID};
+  bool overwrite_existing{LEROBOT_DEFAULT_OVERWRITE_EXISTING};
+  bool encode_videos{LEROBOT_DEFAULT_ENCODE_VIDEOS};
+  std::string task_name{LEROBOT_DEFAULT_TASK_NAME};
+  std::string repository_id{LEROBOT_DEFAULT_REPOSITORY_ID};
   std::string dataset_id{trossen::io::backends::auto_generate_dataset_id()};
   std::string root{trossen::io::backends::get_default_root_path().string()};
   // TODO(shantanuparab-tr): DRemove episode index if not being used
-  int episode_index{trossen::io::backends::DEFAULT_EPISODE_INDEX};
+  int episode_index{LEROBOT_DEFAULT_EPISODE_INDEX};
   std::string robot_name{trossen::io::backends::DEFAULT_ROBOT_NAME};
-  float fps{trossen::io::backends::DEFAULT_FPS};
+  float fps{LEROBOT_DEFAULT_FPS};
 
   std::string type() const override { return "lerobot_backend"; }
 

--- a/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
@@ -13,11 +13,15 @@
 
 namespace trossen::configuration {
 
+// MCAP backend specific constants
+inline constexpr int MCAP_DEFAULT_CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
+inline constexpr char MCAP_DEFAULT_COMPRESSION[] = "";
+
 struct McapBackendConfig : public BaseConfig {
   std::string root{trossen::io::backends::get_default_root_path().string()};
   std::string robot_name{trossen::io::backends::DEFAULT_ROBOT_NAME};
-  int chunk_size_bytes{trossen::io::backends::DEFAULT_CHUNK_SIZE_BYTES};
-  std::string compression{trossen::io::backends::DEFAULT_COMPRESSION};
+  int chunk_size_bytes{MCAP_DEFAULT_CHUNK_SIZE_BYTES};
+  std::string compression{MCAP_DEFAULT_COMPRESSION};
   std::string dataset_id{trossen::io::backends::auto_generate_dataset_id()};
   // TODO(shantanuparab-tr): Remove episode index if not being used
   int episode_index{0};

--- a/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
@@ -13,12 +13,15 @@
 
 namespace trossen::configuration {
 
+// Trossen backend specific constants
+inline constexpr char TROSSEN_DEFAULT_DROP_POLICY[] = "DropNewest";
+
 struct TrossenBackendConfig : public BaseConfig {
   std::string root{trossen::io::backends::get_default_root_path().string()};
   int encoder_threads{trossen::io::backends::DEFAULT_ENCODER_THREADS};
   int max_image_queue{trossen::io::backends::DEFAULT_MAX_IMAGE_QUEUE};
   int png_compression_level{trossen::io::backends::DEFAULT_PNG_COMPRESSION_LEVEL};
-  std::string drop_policy{trossen::io::backends::DEFAULT_DROP_POLICY};
+  std::string drop_policy{TROSSEN_DEFAULT_DROP_POLICY};
 
   std::string type() const override { return "trossen_backend"; }
 

--- a/include/trossen_sdk/io/backend_utils.hpp
+++ b/include/trossen_sdk/io/backend_utils.hpp
@@ -37,20 +37,11 @@ inline std::string auto_generate_dataset_id() {
   return oss.str();
 }
 
-// Constants for default variables
-constexpr int DEFAULT_ENCODER_THREADS = 1;
-constexpr int DEFAULT_MAX_IMAGE_QUEUE = 0;
-constexpr int DEFAULT_PNG_COMPRESSION_LEVEL = 3;
-constexpr bool DEFAULT_OVERWRITE_EXISTING = false;
-constexpr bool DEFAULT_ENCODE_VIDEOS = false;
-constexpr char DEFAULT_TASK_NAME[] = "perform a generic task";
-constexpr char DEFAULT_REPOSITORY_ID[] = "TrossenRoboticsCommunity";
-constexpr char DEFAULT_ROBOT_NAME[] = "trossen_ai_stationary";
-constexpr float DEFAULT_FPS = 30.0f;
-constexpr int DEFAULT_CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
-constexpr char DEFAULT_COMPRESSION[] = "";
-constexpr char DEFAULT_DROP_POLICY[] = "DropNewest";
-constexpr int DEFAULT_EPISODE_INDEX = 0;
+// Common constants used across multiple backends
+inline constexpr int DEFAULT_ENCODER_THREADS = 1;
+inline constexpr int DEFAULT_MAX_IMAGE_QUEUE = 0;
+inline constexpr int DEFAULT_PNG_COMPRESSION_LEVEL = 3;
+inline constexpr char DEFAULT_ROBOT_NAME[] = "trossen_ai_stationary";
 
 }  // namespace trossen::io::backends
 


### PR DESCRIPTION
### TL;DR

Refactored backend configuration constants to improve organization and maintainability.

### What changed?

- Removed the unused `monitor_episode` function from `demo_utils.cpp` (Artifact from Graphite Restacking)
- Moved backend-specific constants from the common `backend_utils.hpp` to their respective backend config files:
  - Created `LEROBOT_DEFAULT_*` constants in `lerobot_backend_config.hpp`
  - Created `MCAP_DEFAULT_*` constants in `mcap_backend_config.hpp`
  - Created `TROSSEN_DEFAULT_*` constants in `trossen_backend_config.hpp`
- Kept only common constants in `backend_utils.hpp` that are shared across multiple backends
- Changed constants from `constexpr` to `inline constexpr` for better header inclusion behavior

### How to test?

- Verify that all examples and applications using these backend configurations still compile and run correctly
- Check that the default values for each backend configuration remain unchanged in behavior

### Why make this change?

This change improves code organization by placing backend-specific constants with their respective configuration files rather than keeping them all in a common utility file. This makes the code more maintainable as each backend's default values are now co-located with their configuration structures, making it easier to understand and modify backend-specific settings.