### PR TITLE
Refactor SessionManager to Centralize Episode Lifecycle, Monitoring, and Configuration

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,3 +29,8 @@ target_link_libraries(backend_registry_demo trossen_sdk)
 # Hardware registry demo
 add_executable(hardware_registry_demo hardware_registry_demo.cpp)
 target_link_libraries(hardware_registry_demo trossen_sdk)
+
+# Trossen AI Solo demo Async
+find_package(libtrossen_arm)
+add_executable(widowxai_lerobot_async widowxai_lerobot_async.cpp)
+target_link_libraries(widowxai_lerobot_async demo_utils trossen_sdk libtrossen_arm)

--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -28,21 +28,6 @@ void install_signal_handler() {
   std::signal(SIGINT, signal_handler);
 }
 
-void print_stats_line(const runtime::SessionManager::Stats& stats) {
-  std::cout << "\r[Episode " << stats.current_episode_index << "] "
-            << "Elapsed: " << std::fixed << std::setprecision(1) << stats.elapsed.count() << "s"
-            << " | Records: " << stats.records_written_current;
-
-  if (stats.remaining.has_value() && stats.remaining->count() > 0) {
-    std::cout << " | Remaining: " << std::fixed << std::setprecision(1)
-              << stats.remaining->count() << "s";
-  } else {
-    std::cout << " | Duration: unlimited";
-  }
-
-  std::cout << std::flush;
-}
-
 void print_episode_summary(const std::string& file_path, runtime::SessionManager::Stats stats) {
   // Helper to repeat a string n times
   auto repeat_str = [](const std::string& s, size_t n) {

--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -43,9 +43,123 @@ void print_stats_line(const runtime::SessionManager::Stats& stats) {
   std::cout << std::flush;
 }
 
-void print_episode_summary(const std::string& file_path, uint64_t records) {
-  std::cout << "\n✓ Episode complete: " << records << " records written\n";
-  std::cout << "  File: " << file_path << "\n";
+void print_episode_summary(const std::string& file_path, runtime::SessionManager::Stats stats) {
+  // Helper to repeat a string n times
+  auto repeat_str = [](const std::string& s, size_t n) {
+    std::string result;
+    result.reserve(s.length() * n);
+    for (size_t i = 0; i < n; ++i) {
+      result += s;
+    }
+    return result;
+  };
+
+  // Prepare all the values as strings
+  std::string records_str = std::to_string(stats.records_written_current);
+
+  std::string duration_str =
+      std::to_string(static_cast<int>(stats.elapsed.count())) + "s";
+
+  std::string setup_str =
+      stats.preprocessing_duration_s.has_value()
+          ? std::to_string(
+                stats.preprocessing_duration_s.value()) + "s"
+          : "";
+
+  std::string shutdown_str =
+      stats.postprocess_duration_s.has_value()
+          ? std::to_string(
+                stats.postprocess_duration_s.value()) + "s"
+          : "";
+
+  std::string rate_str =
+      stats.elapsed.count() > 0
+          ? std::to_string(static_cast<int>(
+                stats.records_written_current / stats.elapsed.count())) +
+                " records/s"
+          : "";
+
+  // Calculate the maximum value length needed
+  size_t max_value_len = records_str.length();
+  max_value_len = std::max(max_value_len, duration_str.length());
+  if (!setup_str.empty()) max_value_len = std::max(max_value_len, setup_str.length());
+  if (!shutdown_str.empty()) max_value_len = std::max(max_value_len, shutdown_str.length());
+  if (!rate_str.empty()) max_value_len = std::max(max_value_len, rate_str.length());
+  // Label column width (longest label + padding)
+  const size_t label_width = 21;  // "Records Written:     " is 21 chars
+  // Calculate minimum box width based on content
+  size_t min_box_width = 2 + label_width + max_value_len + 2;
+  // Include file path length in calculation
+  size_t file_path_width = 9 + file_path.length();  // "│ File: " (7) + path + " │" (2)
+  // Title width
+  std::string title = " ✓ Episode " + std::to_string(stats.current_episode_index) + " Summary";
+  size_t title_width = 2 + title.length();  // "│" + title + "│"
+  // Use the maximum of all width requirements
+  const size_t box_width = std::max({min_box_width, file_path_width, title_width});
+  // Top border
+  std::cout << "\n┌" << repeat_str("─", box_width - 2) << "┐\n";
+  // Title line
+  std::cout << "│" << title << std::string(box_width - 2 - title.length(), ' ') << "│\n";
+  // Separator
+  std::cout << "├" << repeat_str("─", box_width - 2) << "┤\n";
+  // Helper lambda to print a row
+  auto print_row = [&](const std::string& label, const std::string& value) {
+    std::cout << "│ " << std::setw(label_width) << std::left << label
+              << std::setw(max_value_len) << std::left << value << " │\n";
+  };
+
+  // Data rows
+  print_row("Records Written:", records_str);
+  print_row("Duration:", duration_str);
+
+  if (!setup_str.empty()) {
+    print_row("Pre-Processing Time:", setup_str);
+  }
+
+  if (!shutdown_str.empty()) {
+    print_row("Post-Processing Time:", shutdown_str);
+  }
+
+  if (!rate_str.empty()) {
+    print_row("Average Rate:", rate_str);
+  }
+
+  // Separator before file path
+  std::cout << "├" << repeat_str("─", box_width - 2) << "┤\n";
+
+  // File path (display full path)
+  // Limit the "File" line to at most 100 characters (including borders)
+  const size_t max_line_len = 100;
+  const std::string prefix = "│ File: ";
+  const std::string suffix = "│";
+
+  // Compute max length available for the file path
+  size_t max_path_len = (max_line_len > prefix.size() + suffix.size())
+                          ? (max_line_len - prefix.size() - suffix.size())
+                          : 0;
+
+  std::string display_path = file_path;
+  if (display_path.size() > max_path_len) {
+    if (max_path_len <= 3) {
+      display_path = display_path.substr(0, max_path_len);
+    } else {
+      size_t keep = max_path_len - 3;
+      size_t front = keep / 2;
+      size_t back = keep - front;
+      display_path = display_path.substr(0, front) + "..." +
+                     display_path.substr(display_path.size() - back);
+    }
+  }
+
+  // Pad up to the smaller of box_width or 100 to keep alignment where possible
+  size_t target_len = std::min(box_width, max_line_len);
+  size_t current_len = prefix.size() + display_path.size() + suffix.size();
+  size_t pad = (current_len < target_len) ? (target_len - current_len) : 0;
+
+  std::cout << prefix << display_path << std::string(pad, ' ') << suffix << "\n";
+
+  // Bottom border
+  std::cout << "└" << repeat_str("─", box_width - 2) << "┘\n";
 }
 
 void print_config_banner(

--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -57,8 +57,9 @@ void print_episode_summary(const std::string& file_path, runtime::SessionManager
   // Prepare all the values as strings
   std::string records_str = std::to_string(stats.records_written_current);
 
-  std::string duration_str =
-      std::to_string(static_cast<int>(stats.elapsed.count())) + "s";
+  std::ostringstream duration_ss;
+  duration_ss << std::fixed << std::setprecision(1) << stats.elapsed.count() << "s";
+  std::string duration_str = duration_ss.str();
 
   std::string setup_str =
       stats.preprocessing_duration_s.has_value()
@@ -72,10 +73,13 @@ void print_episode_summary(const std::string& file_path, runtime::SessionManager
                 stats.postprocess_duration_s.value()) + "s"
           : "";
 
+  std::string actual_duration_str =
+      std::to_string(stats.recording_duration_s.value_or(0.0)) + "s";
+
   std::string rate_str =
       stats.elapsed.count() > 0
           ? std::to_string(static_cast<int>(
-                stats.records_written_current / stats.elapsed.count())) +
+                stats.records_written_current / stats.recording_duration_s.value_or(0.0))) +
                 " records/s"
           : "";
 
@@ -111,6 +115,8 @@ void print_episode_summary(const std::string& file_path, runtime::SessionManager
   // Data rows
   print_row("Records Written:", records_str);
   print_row("Duration:", duration_str);
+
+  print_row("Actual Duration:", actual_duration_str);
 
   if (!setup_str.empty()) {
     print_row("Pre-Processing Time:", setup_str);
@@ -261,27 +267,21 @@ runtime::SessionManager::Stats monitor_episode(
 {
   auto last_update = std::chrono::steady_clock::now();
   runtime::SessionManager::Stats last_stats;
-  runtime::SessionManager::Stats saved_stats;
 
-  while (mgr.is_episode_active() && !g_stop_requested) {
+  while (!mgr.are_final_stats_emitted()) {
     auto now = std::chrono::steady_clock::now();
     if (now - last_update >= update_interval) {
       auto stats = mgr.stats();
       print_stats_line(stats);
       last_stats = stats;
       last_update = now;
-      if (last_stats.records_written_current != 0 &&
-          last_stats.records_written_current !=
-            saved_stats.records_written_current) {
-        saved_stats = last_stats;
-      }
     }
     // TODO(shantanuparab-tr): We might miss records written in the last sleep interval.
     // Consider using condition variable or similar mechanism for better accuracy.
     // Make sure this is fixed with asynchronous episode monitoring implementation.
     std::this_thread::sleep_for(sleep_interval);
   }
-  return saved_stats;
+  return last_stats;
 }
 
 std::string generate_episode_path(

--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -151,36 +151,34 @@ bool interruptible_sleep(std::chrono::duration<double> duration) {
   return true;
 }
 
-uint64_t monitor_episode(
+runtime::SessionManager::Stats monitor_episode(
   runtime::SessionManager& mgr,
   std::chrono::duration<double> update_interval,
   std::chrono::duration<double> sleep_interval)
 {
   auto last_update = std::chrono::steady_clock::now();
-  uint64_t last_record_count = 0;
+  runtime::SessionManager::Stats last_stats;
+  runtime::SessionManager::Stats saved_stats;
 
   while (mgr.is_episode_active() && !g_stop_requested) {
     auto now = std::chrono::steady_clock::now();
     if (now - last_update >= update_interval) {
       auto stats = mgr.stats();
       print_stats_line(stats);
-      last_record_count = stats.records_written_current;
+      last_stats = stats;
       last_update = now;
+      if (last_stats.records_written_current != 0 &&
+          last_stats.records_written_current !=
+            saved_stats.records_written_current) {
+        saved_stats = last_stats;
+      }
     }
+    // TODO(shantanuparab-tr): We might miss records written in the last sleep interval.
+    // Consider using condition variable or similar mechanism for better accuracy.
+    // Make sure this is fixed with asynchronous episode monitoring implementation.
     std::this_thread::sleep_for(sleep_interval);
   }
-
-  // Get final count
-  if (mgr.is_episode_active()) {
-    last_record_count = mgr.stats().records_written_current;
-  } else {
-    auto final_stats = mgr.stats();
-    if (final_stats.records_written_current > 0) {
-      last_record_count = final_stats.records_written_current;
-    }
-  }
-
-  return last_record_count;
+  return saved_stats;
 }
 
 std::string generate_episode_path(

--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -28,17 +28,6 @@ void install_signal_handler() {
   std::signal(SIGINT, signal_handler);
 }
 
-void print_episode_header(uint32_t index, int duration_s) {
-  std::cout << "\n╔════════════════════════════════════════════════════════════╗\n";
-  std::cout << "║  Episode " << index << " | Target Duration: " << duration_s << "s";
-
-  // Calculate padding to align right edge
-  std::string padding(
-    41 - std::to_string(index).length() - std::to_string(duration_s).length(), ' ');
-  std::cout << padding << "║\n";
-  std::cout << "╚════════════════════════════════════════════════════════════╝\n";
-}
-
 void print_stats_line(const runtime::SessionManager::Stats& stats) {
   std::cout << "\r[Episode " << stats.current_episode_index << "] "
             << "Elapsed: " << std::fixed << std::setprecision(1) << stats.elapsed.count() << "s"

--- a/examples/demo_utils.cpp
+++ b/examples/demo_utils.cpp
@@ -245,30 +245,6 @@ bool interruptible_sleep(std::chrono::duration<double> duration) {
   return true;
 }
 
-runtime::SessionManager::Stats monitor_episode(
-  runtime::SessionManager& mgr,
-  std::chrono::duration<double> update_interval,
-  std::chrono::duration<double> sleep_interval)
-{
-  auto last_update = std::chrono::steady_clock::now();
-  runtime::SessionManager::Stats last_stats;
-
-  while (!mgr.are_final_stats_emitted()) {
-    auto now = std::chrono::steady_clock::now();
-    if (now - last_update >= update_interval) {
-      auto stats = mgr.stats();
-      print_stats_line(stats);
-      last_stats = stats;
-      last_update = now;
-    }
-    // TODO(shantanuparab-tr): We might miss records written in the last sleep interval.
-    // Consider using condition variable or similar mechanism for better accuracy.
-    // Make sure this is fixed with asynchronous episode monitoring implementation.
-    std::this_thread::sleep_for(sleep_interval);
-  }
-  return last_stats;
-}
-
 std::string generate_episode_path(
   const std::string& output_dir,
   uint32_t episode_index,

--- a/examples/demo_utils.hpp
+++ b/examples/demo_utils.hpp
@@ -58,15 +58,6 @@ void install_signal_handler();
 void print_episode_header(uint32_t index, int duration_s);
 
 /**
- * @brief Print a single line of episode statistics (updates in place)
- *
- * Uses carriage return to overwrite the previous line for smooth updates.
- *
- * @param stats Session manager statistics
- */
-void print_stats_line(const runtime::SessionManager::Stats& stats);
-
-/**
  * @brief Print episode completion summary
  *
  * @param file_path Path to the recorded episode
@@ -134,21 +125,6 @@ bool perform_sanity_check(
  * @return true if completed normally, false if interrupted by stop request
  */
 bool interruptible_sleep(std::chrono::duration<double> duration);
-
-/**
- * @brief Pausable sleep that respects stop requests
- *
- * Sleeps for the specified duration but checks g_stop_requested
- * periodically and returns early if stop is requested.
- *
- * @param update_interval How often to print stats
- * @param sleep_interval How long to sleep between checks
- * @return true if completed normally, false if interrupted by stop request
- */
-runtime::SessionManager::Stats monitor_episode(
-  runtime::SessionManager& mgr,
-  std::chrono::duration<double> update_interval = std::chrono::milliseconds(500),
-  std::chrono::duration<double> sleep_interval = std::chrono::milliseconds(100));
 
 /**
  * @brief Generate episode file path

--- a/examples/demo_utils.hpp
+++ b/examples/demo_utils.hpp
@@ -72,7 +72,7 @@ void print_stats_line(const runtime::SessionManager::Stats& stats);
  * @param file_path Path to the recorded episode
  * @param records Number of records written
  */
-void print_episode_summary(const std::string& file_path, uint64_t records);
+void print_episode_summary(const std::string& file_path, runtime::SessionManager::Stats stats);
 
 /**
  * @brief Print application configuration banner

--- a/examples/demo_utils.hpp
+++ b/examples/demo_utils.hpp
@@ -145,7 +145,7 @@ bool interruptible_sleep(std::chrono::duration<double> duration);
  * @param sleep_interval How long to sleep between checks
  * @return true if completed normally, false if interrupted by stop request
  */
-uint64_t monitor_episode(
+runtime::SessionManager::Stats monitor_episode(
   runtime::SessionManager& mgr,
   std::chrono::duration<double> update_interval = std::chrono::milliseconds(500),
   std::chrono::duration<double> sleep_interval = std::chrono::milliseconds(100));

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -350,7 +350,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    uint64_t last_record_count = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {
@@ -370,21 +370,24 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_record_count);
+    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts
     // ──────────────────────────────────────────────────────────
 
     trossen::demo::SanityCheckConfig sanity_cfg{
-      actual_duration,
+      last_stats.elapsed.count(),
       1,  // 1 joint producer (follower)
       cfg.joint_rate_hz,
       1,  // 1 camera
       cfg.camera_fps,
       5.0  // 5% tolerance
     };
-    trossen::demo::perform_sanity_check(recording_episode_index, last_record_count, sanity_cfg);
+    trossen::demo::perform_sanity_check(
+      recording_episode_index,
+      last_stats.records_written_current,
+      sanity_cfg);
 
     // Check if user requested stop
     if (trossen::demo::g_stop_requested) {

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -370,7 +370,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
+    trossen::demo::print_episode_summary(file_path, last_stats);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -314,7 +314,7 @@ int main(int argc, char** argv) {
     }
 
     // Display episode header
-    trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
+    mgr.print_episode_header();
 
     // Sync follower to leader's current position before recording
     if (!cfg.use_mock) {

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -349,8 +349,9 @@ int main(int argc, char** argv) {
       });
     }
 
-    // Monitor loop: display stats while episode is active
-    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
+    // Blocking monitor call: keeps the main thread alive while the episode is recording,
+    // prevents threads from joining before data is collected, and updates/prints status logs.
+    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {

--- a/examples/so101_lerobot.cpp
+++ b/examples/so101_lerobot.cpp
@@ -10,8 +10,8 @@
  * - Configurable episode count and duration
  *
  * Usage:
- *   ./so101_teleop --episodes 5 --duration 10
- *   ./so101_teleop --episodes 3 --duration 5 --root /data/recordings
+ *   ./so101_teleop
+ *   ./so101_teleop --root /data/recordings
  *   ./so101_teleop --mock  # Use mock producers for testing without hardware
  */
 

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -10,8 +10,8 @@
  * - Configurable episode count and duration
  *
  * Usage:
- *   ./widowxai --episodes 5 --duration 10
- *   ./widowxai --episodes 3 --duration 5 --root /data/recordings
+ *   ./widowxai
+ *   ./widowxai --root /data/recordings
  *   ./widowxai --mock  # Use mock producers for testing without hardware
  */
 
@@ -39,8 +39,6 @@
 // ────────────────────────────────────────────────────────────
 
 struct Config {
-  int duration_s = 10;
-  int episodes = 3;
   std::string dataset_id = "";  // empty = auto-generate
   std::string root = trossen::io::backends::get_default_root_path().string();
   bool use_mock = false;
@@ -65,8 +63,6 @@ void print_usage(const char* prog_name) {
   std::cout
     << "Usage: " << prog_name << " [options]\n\n"
     << "Options:\n"
-    << "  --duration <seconds>     Duration per episode (default: 10)\n"
-    << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
     << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
@@ -80,8 +76,8 @@ void print_usage(const char* prog_name) {
     << "  --backend <type>         Dataset backend type (default: mcap)\n"
     << "  --help                   Show this help message\n\n"
     << "Examples:\n"
-    << "  " << prog_name << " --duration 10 --episodes 5\n"
-    << "  " << prog_name << " --mock --duration 5 --episodes 3\n"
+    << "  " << prog_name << "\n"
+    << "  " << prog_name << " --mock\n"
     << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
 }
 
@@ -92,10 +88,6 @@ Config parse_args(int argc, char** argv) {
     if (arg == "--help" || arg == "-h") {
       cfg.show_help = true;
       return cfg;
-    } else if (arg == "--duration" && i + 1 < argc) {
-      cfg.duration_s = std::max(1, std::atoi(argv[++i]));
-    } else if (arg == "--episodes" && i + 1 < argc) {
-      cfg.episodes = std::max(1, std::atoi(argv[++i]));
     } else if (arg == "--dataset-id" && i + 1 < argc) {
       cfg.dataset_id = argv[++i];
     } else if (arg == "--root" && i + 1 < argc) {
@@ -140,8 +132,6 @@ int main(int argc, char** argv) {
   // Print configuration
   std::vector<std::string> config_lines = {
     "Mode:                 " + std::string(cfg.use_mock ? "Mock (no hardware)" : "Hardware"),
-    "Duration per episode: " + std::to_string(cfg.duration_s) + "s",
-    "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
     "Root directory:       " + cfg.root,
     "Backend:              " + cfg.backend_type
@@ -315,14 +305,11 @@ int main(int argc, char** argv) {
   // Recording loop: record requested number of episodes
   // ──────────────────────────────────────────────────────────
 
-  for (int ep = 0; ep < cfg.episodes; ++ep) {
+  while (true) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\n\nStopping at user request (Ctrl+C).\n";
       break;
     }
-
-    // Display episode header
-    trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
 
     // Lock the leader arm, move the follower arm to mirror the leader's current position, and
     // unlock the leader
@@ -408,14 +395,6 @@ int main(int argc, char** argv) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
-    }
-
-    // Pause between episodes (unless this was the last one)
-    if (ep < cfg.episodes - 1) {
-      std::cout << "\nPausing for 1 second before next episode...\n";
-      if (!trossen::demo::interruptible_sleep(std::chrono::seconds(1))) {
-        break;  // Stop requested during pause
-      }
     }
   }
 

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -351,8 +351,9 @@ int main(int argc, char** argv) {
       });
     }
 
-    // Monitor loop: display stats while episode is active
-    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
+    // Blocking monitor call: keeps the main thread alive while the episode is recording,
+    // prevents threads from joining before data is collected, and updates/prints status logs.
+    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -372,7 +372,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
+    trossen::demo::print_episode_summary(file_path, last_stats);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts

--- a/examples/widowxai.cpp
+++ b/examples/widowxai.cpp
@@ -365,7 +365,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    uint64_t last_record_count = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {
@@ -385,7 +385,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_record_count);
+    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts
@@ -399,7 +399,10 @@ int main(int argc, char** argv) {
       cfg.camera_fps,
       5.0  // 5% tolerance
     };
-    trossen::demo::perform_sanity_check(recording_episode_index, last_record_count, sanity_cfg);
+    trossen::demo::perform_sanity_check(
+      recording_episode_index,
+      last_stats.records_written_current,
+      sanity_cfg);
 
     // Check if user requested stop
     if (trossen::demo::g_stop_requested) {

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -72,8 +72,6 @@ void print_usage(const char* prog_name) {
   std::cout
     << "Usage: " << prog_name << " [options]\n\n"
     << "Options:\n"
-    << "  --duration <seconds>     Duration per episode (default: 10)\n"
-    << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
     << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
@@ -90,8 +88,8 @@ void print_usage(const char* prog_name) {
     << "  Follower Right: 192.168.1.4 (recorded)\n"
     << "  Cameras:        /dev/video0, /dev/video2, /dev/video4, /dev/video6\n\n"
     << "Examples:\n"
-    << "  " << prog_name << " --duration 10 --episodes 5\n"
-    << "  " << prog_name << " --mock --duration 5 --episodes 3\n"
+    << "  " << prog_name << "\n"
+    << "  " << prog_name << " --mock\n"
     << "  " << prog_name << " --dataset-id stationary_demo_001 --root /data/recordings\n";
 }
 
@@ -140,8 +138,6 @@ int main(int argc, char** argv) {
   // Print configuration
   std::vector<std::string> config_lines = {
     "Mode:                 " + std::string(cfg.use_mock ? "Mock (no hardware)" : "Hardware"),
-    "Duration per episode: " + std::to_string(cfg.duration_s) + "s",
-    "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
     "Root directory:       " + cfg.root,
     "Backend:              " + cfg.backend_type
@@ -391,7 +387,7 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
   std::cout << "  Recording: 2 follower arms + 4 cameras = 6 data streams\n";
 
-  for (int ep = 0; ep < cfg.episodes; ++ep) {
+  while (true) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\n\nStopping at user request (Ctrl+C).\n";
       break;
@@ -507,15 +503,6 @@ int main(int argc, char** argv) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
-    }
-
-    // Pause between episodes (unless this was the last one)
-    if (ep < cfg.episodes - 1) {
-      std::cout << "\nPausing for 1 second before next episode...\n";
-      if (!trossen::demo::interruptible_sleep(std::chrono::seconds(1))) {
-        // Stop requested during pause
-        break;
-      }
     }
   }
 

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -466,8 +466,9 @@ int main(int argc, char** argv) {
       });
     }
 
-    // Monitor loop: display stats while episode is active
-    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
+    // Blocking monitor call: keeps the main thread alive while the episode is recording,
+    // prevents threads from joining before data is collected, and updates/prints status logs.
+    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -487,7 +487,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
+    trossen::demo::print_episode_summary(file_path, last_stats);
 
     trossen::demo::SanityCheckConfig sanity_cfg{
       last_stats.elapsed.count(),

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -432,7 +432,7 @@ int main(int argc, char** argv) {
     }
 
     // Display episode header
-    trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
+    mgr.print_episode_header();
 
     // Start episode
     if (!mgr.start_episode()) {

--- a/examples/widowxai_bimanual.cpp
+++ b/examples/widowxai_bimanual.cpp
@@ -471,7 +471,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    uint64_t last_record_count = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {
@@ -491,17 +491,17 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_record_count);
+    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
 
     trossen::demo::SanityCheckConfig sanity_cfg{
-      actual_duration,
+      last_stats.elapsed.count(),
       2,  // 2 joint producers (follower left + follower right)
       cfg.joint_rate_hz,
       static_cast<int>(cfg.camera_indices.size()),  // 4 cameras
       cfg.camera_fps,
       5.0  // 5% tolerance
     };
-    perform_sanity_check(recording_episode_index, last_record_count, sanity_cfg);
+    perform_sanity_check(recording_episode_index, last_stats.records_written_current, sanity_cfg);
 
     // Check if user requested stop
     if (trossen::demo::g_stop_requested) {

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -460,8 +460,9 @@ int main(int argc, char** argv) {
       });
     }
 
-    // Monitor loop: display stats while episode is active
-    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
+    // Blocking monitor call: keeps the main thread alive while the episode is recording,
+    // prevents threads from joining before data is collected, and updates/prints status logs.
+    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -471,7 +471,7 @@ int main(int argc, char** argv) {
     }
 
     // Monitor loop: display stats while episode is active
-    uint64_t last_record_count = trossen::demo::monitor_episode(mgr);
+    trossen::runtime::SessionManager::Stats last_stats = trossen::demo::monitor_episode(mgr);
 
     // Stop episode and wait for teleop thread
     if (mgr.is_episode_active()) {
@@ -491,21 +491,24 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_record_count);
+    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts
     // ──────────────────────────────────────────────────────────
 
     trossen::demo::SanityCheckConfig sanity_cfg{
-      actual_duration,
+      last_stats.elapsed.count(),
       1,  // 1 joint producer (follower)
       cfg.joint_rate_hz,
       1,  // 1 camera
       cfg.camera_fps,
       5.0  // 5% tolerance
     };
-    trossen::demo::perform_sanity_check(recording_episode_index, last_record_count, sanity_cfg);
+    trossen::demo::perform_sanity_check(
+      recording_episode_index,
+      last_stats.records_written_current,
+      sanity_cfg);
 
     // Check if user requested stop
     if (trossen::demo::g_stop_requested) {

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -481,7 +481,7 @@ int main(int argc, char** argv) {
     std::string file_path = trossen::demo::generate_episode_path(
       cfg.root,
       recording_episode_index);
-    trossen::demo::print_episode_summary(file_path, last_stats.records_written_current);
+    trossen::demo::print_episode_summary(file_path, last_stats);
 
     // ──────────────────────────────────────────────────────────
     // Sanity check: verify expected record counts

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -488,7 +488,7 @@ int main(int argc, char** argv) {
     // ──────────────────────────────────────────────────────────
 
     trossen::demo::SanityCheckConfig sanity_cfg{
-      last_stats.elapsed.count(),
+      last_stats.recording_duration_s.value_or(0.0),
       1,  // 1 joint producer (follower)
       cfg.joint_rate_hz,
       1,  // 1 camera

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -316,82 +316,83 @@ int main(int argc, char** argv) {
   auto camera_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.camera_fps));
   mgr.add_producer(camera_producer, camera_period);
 
-  // Create a Realsense Camera Producer (Hardcoded configuration for demo purposes)
+  // TODO(shantanuparab-tr): Add this to configurations after main executable is created
+  // // Create a Realsense Camera Producer (Hardcoded configuration for demo purposes)
 
-  trossen::hw::camera::RealsenseCameraProducer::Config realsense_cfg;
-  realsense_cfg.serial_number = "218622274938";  // Replace with your camera's serial number
-  realsense_cfg.stream_id = "realsense_camera0";
-  realsense_cfg.encoding = "bgr8";
-  realsense_cfg.width = 640;
-  realsense_cfg.height = 480;
-  realsense_cfg.fps = 30;
-  realsense_cfg.use_device_time = true;
-  realsense_cfg.warmup_seconds = 2.0;
+  // trossen::hw::camera::RealsenseCameraProducer::Config realsense_cfg;
+  // realsense_cfg.serial_number = "218622274938";  // Replace with your camera's serial number
+  // realsense_cfg.stream_id = "realsense_camera0";
+  // realsense_cfg.encoding = "bgr8";
+  // realsense_cfg.width = 640;
+  // realsense_cfg.height = 480;
+  // realsense_cfg.fps = 30;
+  // realsense_cfg.use_device_time = true;
+  // realsense_cfg.warmup_seconds = 2.0;
 
-  // Create Realsense config
-  rs2::config cam_cfg;
+  // // Create Realsense config
+  // rs2::config cam_cfg;
 
-  // Create a realsense pipeline
-  rs2::pipeline realsense_pipeline;
-  auto camera_ = std::make_shared<rs2::pipeline>(realsense_pipeline);
+  // // Create a realsense pipeline
+  // rs2::pipeline realsense_pipeline;
+  // auto camera_ = std::make_shared<rs2::pipeline>(realsense_pipeline);
 
-  // Enable the device using the unique ID
-  if (!realsense_cfg.serial_number.empty()) {
-    cam_cfg.enable_device(realsense_cfg.serial_number);
-  } else {
-    std::cout << "Unique ID is empty. Cannot connect to RealSense camera: "
-      << realsense_cfg.stream_id << std::endl;
-    throw std::runtime_error("Unique ID is empty for camera: " + realsense_cfg.stream_id);
-  }
+  // // Enable the device using the unique ID
+  // if (!realsense_cfg.serial_number.empty()) {
+  //   cam_cfg.enable_device(realsense_cfg.serial_number);
+  // } else {
+  //   std::cout << "Unique ID is empty. Cannot connect to RealSense camera: "
+  //     << realsense_cfg.stream_id << std::endl;
+  //   throw std::runtime_error("Unique ID is empty for camera: " + realsense_cfg.stream_id);
+  // }
 
-  // Enable the color stream as default
-  cam_cfg.enable_stream(RS2_STREAM_COLOR, realsense_cfg.width, realsense_cfg.height,
-                    RS2_FORMAT_RGB8, realsense_cfg.fps);
+  // // Enable the color stream as default
+  // cam_cfg.enable_stream(RS2_STREAM_COLOR, realsense_cfg.width, realsense_cfg.height,
+  //                   RS2_FORMAT_RGB8, realsense_cfg.fps);
 
-  // Make this conditional to enable depth stream
-  cam_cfg.enable_stream(RS2_STREAM_DEPTH, realsense_cfg.width, realsense_cfg.height,
-                    RS2_FORMAT_Z16, realsense_cfg.fps);
-  try {
-    // Start the camera pipeline
-    rs2::pipeline_profile profile = camera_->start(cam_cfg);
-  } catch (const rs2::error& e) {
-    std::cout << "Failed to enable device with Unique ID: " << realsense_cfg.serial_number
-              << ". Error: " << e.what() << ". Listing all available cameras." << std::endl;
-    std::cout << "Available cameras listed above. Please check outputs folder to get "
-        "Available cameras listed above. Please check outputs folder to get "
-        "images associated "
-        "with each camera." << std::endl;
-    throw std::runtime_error(
-        "Unique ID (serial number) is required to connect to RealSense camera");
-  }
+  // // Make this conditional to enable depth stream
+  // cam_cfg.enable_stream(RS2_STREAM_DEPTH, realsense_cfg.width, realsense_cfg.height,
+  //                   RS2_FORMAT_Z16, realsense_cfg.fps);
+  // try {
+  //   // Start the camera pipeline
+  //   rs2::pipeline_profile profile = camera_->start(cam_cfg);
+  // } catch (const rs2::error& e) {
+  //   std::cout << "Failed to enable device with Unique ID: " << realsense_cfg.serial_number
+  //             << ". Error: " << e.what() << ". Listing all available cameras." << std::endl;
+  //   std::cout << "Available cameras listed above. Please check outputs folder to get "
+  //       "Available cameras listed above. Please check outputs folder to get "
+  //       "images associated "
+  //       "with each camera." << std::endl;
+  //   throw std::runtime_error(
+  //       "Unique ID (serial number) is required to connect to RealSense camera");
+  // }
 
-  auto frame_cache = std::make_shared<trossen::hw::camera::RealsenseFrameCache>(camera_, 2);
+  // auto frame_cache = std::make_shared<trossen::hw::camera::RealsenseFrameCache>(camera_, 2);
 
-  auto realsense_producer =
-    std::make_shared<trossen::hw::camera::RealsenseCameraProducer>(frame_cache, realsense_cfg);
+  // auto realsense_producer =
+  //   std::make_shared<trossen::hw::camera::RealsenseCameraProducer>(frame_cache, realsense_cfg);
 
-  auto realsense_period = std::chrono::milliseconds(static_cast<int>(1000.0f / 30.0f));
+  // auto realsense_period = std::chrono::milliseconds(static_cast<int>(1000.0f / 30.0f));
 
-  mgr.add_producer(realsense_producer, realsense_period);
-  std::cout << "  ✓ Realsense camera producer (30 Hz, 640x480)\n";
+  // mgr.add_producer(realsense_producer, realsense_period);
+  // std::cout << "  ✓ Realsense camera producer (30 Hz, 640x480)\n";
 
-  trossen::hw::camera::RealsenseDepthCameraProducer::Config realsense_depth_cfg;
+  // trossen::hw::camera::RealsenseDepthCameraProducer::Config realsense_depth_cfg;
+  // // Replace with your camera's serial number
+  // realsense_depth_cfg.serial_number = "218622274938";
+  // realsense_depth_cfg.stream_id = "realsense_depth_camera0";
+  // realsense_depth_cfg.encoding = "16UC1";
+  // realsense_depth_cfg.width = 640;
+  // realsense_depth_cfg.height = 480;
+  // realsense_depth_cfg.fps = 30;
+  // realsense_depth_cfg.use_device_time = true;
+  // realsense_depth_cfg.warmup_seconds = 2.0;
 
-  realsense_depth_cfg.serial_number = "218622274938";  // Replace with your camera's serial number
-  realsense_depth_cfg.stream_id = "realsense_depth_camera0";
-  realsense_depth_cfg.encoding = "16UC1";
-  realsense_depth_cfg.width = 640;
-  realsense_depth_cfg.height = 480;
-  realsense_depth_cfg.fps = 30;
-  realsense_depth_cfg.use_device_time = true;
-  realsense_depth_cfg.warmup_seconds = 2.0;
-
-  auto realsense_depth_producer =
-    std::make_shared<trossen::hw::camera::RealsenseDepthCameraProducer>(
-      frame_cache,
-      realsense_depth_cfg);
-  mgr.add_producer(realsense_depth_producer, realsense_period);
-  std::cout << "  ✓ Realsense depth camera producer (30 Hz, 640x480)\n";
+  // auto realsense_depth_producer =
+  //   std::make_shared<trossen::hw::camera::RealsenseDepthCameraProducer>(
+  //     frame_cache,
+  //     realsense_depth_cfg);
+  // mgr.add_producer(realsense_depth_producer, realsense_period);
+  // std::cout << "  ✓ Realsense depth camera producer (30 Hz, 640x480)\n";
 
   std::cout << "\nProducers registered. Ready to record.\n";
 

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -10,8 +10,8 @@
  * - Configurable episode count and duration
  *
  * Usage:
- *   ./widowxai_lerobot --episodes 5 --duration 10
- *   ./widowxai_lerobot --episodes 3 --duration 5 --root-dir /data/recordings
+ *   ./widowxai_lerobot
+ *   ./widowxai_lerobot --root-dir /data/recordings
  *   ./widowxai_lerobot --mock  # Use mock producers for testing without hardware
  */
 
@@ -45,8 +45,6 @@
 // ────────────────────────────────────────────────────────────
 
 struct Config {
-  int duration_s = 10;
-  int episodes = 3;
   std::string dataset_id = "";  // empty = auto-generate
   std::string root = trossen::io::backends::get_default_root_path().string();
   std::string repository_id = "TrossenRoboticsCommunity";  // Valid only for LeRobot backend
@@ -72,8 +70,6 @@ void print_usage(const char* prog_name) {
   std::cout
     << "Usage: " << prog_name << " [options]\n\n"
     << "Options:\n"
-    << "  --duration <seconds>     Duration per episode (default: 10)\n"
-    << "  --episodes <count>       Number of episodes to record (default: 3)\n"
     << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
     << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
     << "  --repository-id <string> Repository identifier (default: TrossenRoboticsCommunity, "
@@ -89,8 +85,8 @@ void print_usage(const char* prog_name) {
     << "  --backend <type>         Dataset backend type (default: mcap)\n"
     << "  --help                   Show this help message\n\n"
     << "Examples:\n"
-    << "  " << prog_name << " --duration 10 --episodes 5\n"
-    << "  " << prog_name << " --mock --duration 5 --episodes 3\n"
+    << "  " << prog_name << "\n"
+    << "  " << prog_name << " --mock\n"
     << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
 }
 
@@ -101,10 +97,6 @@ Config parse_args(int argc, char** argv) {
     if (arg == "--help" || arg == "-h") {
       cfg.show_help = true;
       return cfg;
-    } else if (arg == "--duration" && i + 1 < argc) {
-      cfg.duration_s = std::max(1, std::atoi(argv[++i]));
-    } else if (arg == "--episodes" && i + 1 < argc) {
-      cfg.episodes = std::max(1, std::atoi(argv[++i]));
     } else if (arg == "--dataset-id" && i + 1 < argc) {
       cfg.dataset_id = argv[++i];
     } else if (arg == "--root" && i + 1 < argc) {
@@ -159,8 +151,6 @@ int main(int argc, char** argv) {
   // Print configuration
   std::vector<std::string> config_lines = {
     "Mode:                 " + std::string(cfg.use_mock ? "Mock (no hardware)" : "Hardware"),
-    "Duration per episode: " + std::to_string(cfg.duration_s) + "s",
-    "Number of episodes:   " + std::to_string(cfg.episodes),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
     "Root directory:       " + cfg.root,
     "Repository ID:        " + cfg.repository_id,
@@ -421,14 +411,11 @@ int main(int argc, char** argv) {
   // Recording loop: record requested number of episodes
   // ──────────────────────────────────────────────────────────
 
-  for (int ep = 0; ep < cfg.episodes; ++ep) {
+  while (true) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\n\nStopping at user request (Ctrl+C).\n";
       break;
     }
-
-    // Display episode header
-    trossen::demo::print_episode_header(mgr.stats().current_episode_index, cfg.duration_s);
 
     // Lock the leader arm, move the follower arm to mirror the leader's current position, and
     // unlock the leader
@@ -514,14 +501,6 @@ int main(int argc, char** argv) {
     if (trossen::demo::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
-    }
-
-    // Pause between episodes (unless this was the last one)
-    if (ep < cfg.episodes - 1) {
-      std::cout << "\nPausing for 1 second before next episode...\n";
-      if (!trossen::demo::interruptible_sleep(std::chrono::seconds(1))) {
-        break;  // Stop requested during pause
-      }
     }
   }
 

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -417,6 +417,9 @@ int main(int argc, char** argv) {
       break;
     }
 
+    // Display episode header
+    mgr.print_episode_header();
+
     // Lock the leader arm, move the follower arm to mirror the leader's current position, and
     // unlock the leader
     if (!cfg.use_mock) {

--- a/examples/widowxai_lerobot_async.cpp
+++ b/examples/widowxai_lerobot_async.cpp
@@ -1,0 +1,548 @@
+/**
+ * @file widowxai_lerobot_async.cpp
+ * @brief Demo for Trossen AI Solo with Mock/Hardware arms, Session Manager, LeRobot backend, and OpenCV camera (asynchronous monitoring)
+ *
+ * This demo combines:
+ * - Trossen AI Solo hardware (leader + follower arms)
+ * - Session Manager for multi-episode recording
+ * - LeRobot backend for data storage
+ * - OpenCV camera producer for image capture
+ * - Configurable episode count and duration
+ *
+ * Usage:
+ *   ./widowxai_lerobot_async
+ *   ./widowxai_lerobot_async --root-dir /data/recordings
+ *   ./widowxai_lerobot_async --mock  # Use mock producers for testing without hardware
+ */
+
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "libtrossen_arm/trossen_arm.hpp"
+#include "trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
+#include "trossen_sdk/hw/arm/teleop_arm_producer.hpp"
+#include "trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp"
+#include "trossen_sdk/hw/camera/opencv_producer.hpp"
+#include "trossen_sdk/hw/camera/mock_producer.hpp"
+#include "trossen_sdk/hw/camera/realsense_depth_producer.hpp"
+#include "trossen_sdk/hw/camera/realsense_frame_cache.hpp"
+#include "trossen_sdk/hw/camera/realsense_producer.hpp"
+#include "trossen_sdk/io/backend_utils.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+
+#include "./demo_utils.hpp"
+
+
+// ────────────────────────────────────────────────────────────
+// Command-line configuration
+// ────────────────────────────────────────────────────────────
+
+struct Config {
+  std::string dataset_id = "";  // empty = auto-generate
+  std::string root = trossen::io::backends::get_default_root_path().string();
+  std::string repository_id = "TrossenRoboticsCommunity";  // Valid only for LeRobot backend
+  bool use_mock = false;
+  bool show_help = false;
+
+  // Camera settings
+  int camera_index = 2;
+  int camera_width = 1920;
+  int camera_height = 1080;
+  int camera_fps = 30;
+
+  // Arm settings
+  float joint_rate_hz = 30.0f;
+  std::string leader_ip = "192.168.1.2";
+  std::string follower_ip = "192.168.1.4";
+
+  // Dataset backend type
+  std::string backend_type = "mcap";
+};
+
+void print_usage(const char* prog_name) {
+  std::cout
+    << "Usage: " << prog_name << " [options]\n\n"
+    << "Options:\n"
+    << "  --dataset-id <string>    Dataset identifier (default: auto-generate UUID)\n"
+    << "  --root <path>            Root directory for episodes (default: ~/.cache/trossen_sdk/)\n"
+    << "  --repository-id <string> Repository identifier (default: TrossenRoboticsCommunity, "
+    << "only for LeRobot backend)\n"
+    << "  --mock                   Use mock producers instead of real hardware\n"
+    << "  --camera-index <num>     Camera device index (default: 2, i.e., /dev/video2)\n"
+    << "  --camera-width <pixels>  Camera width (default: 1920)\n"
+    << "  --camera-height <pixels> Camera height (default: 1080)\n"
+    << "  --camera-fps <fps>       Camera frame rate (default: 30)\n"
+    << "  --joint-rate <hz>        Joint state capture rate (default: 30)\n"
+    << "  --leader-ip <ip>         Leader arm IP (default: 192.168.1.2)\n"
+    << "  --follower-ip <ip>       Follower arm IP (default: 192.168.1.4)\n"
+    << "  --backend <type>         Dataset backend type (default: mcap)\n"
+    << "  --help                   Show this help message\n\n"
+    << "Examples:\n"
+    << "  " << prog_name << "\n"
+    << "  " << prog_name << " --mock\n"
+    << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
+}
+
+Config parse_args(int argc, char** argv) {
+  Config cfg;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    if (arg == "--help" || arg == "-h") {
+      cfg.show_help = true;
+      return cfg;
+    } else if (arg == "--dataset-id" && i + 1 < argc) {
+      cfg.dataset_id = argv[++i];
+    } else if (arg == "--root" && i + 1 < argc) {
+      cfg.root = argv[++i];
+    } else if (arg == "--repository-id" && i + 1 < argc) {
+      cfg.repository_id = argv[++i];
+    } else if (arg == "--mock") {
+      cfg.use_mock = true;
+    } else if (arg == "--camera-index" && i + 1 < argc) {
+      cfg.camera_index = std::atoi(argv[++i]);
+    } else if (arg == "--camera-width" && i + 1 < argc) {
+      cfg.camera_width = std::max(1, std::atoi(argv[++i]));
+    } else if (arg == "--camera-height" && i + 1 < argc) {
+      cfg.camera_height = std::max(1, std::atoi(argv[++i]));
+    } else if (arg == "--camera-fps" && i + 1 < argc) {
+      cfg.camera_fps = std::max(1, std::atoi(argv[++i]));
+    } else if (arg == "--joint-rate" && i + 1 < argc) {
+      cfg.joint_rate_hz = std::max(1.0f, static_cast<float>(std::atof(argv[++i])));
+    } else if (arg == "--leader-ip" && i + 1 < argc) {
+      cfg.leader_ip = argv[++i];
+    } else if (arg == "--follower-ip" && i + 1 < argc) {
+      cfg.follower_ip = argv[++i];
+    } else if (arg == "--backend" && i + 1 < argc) {
+      cfg.backend_type = argv[++i];
+    } else {
+      std::cerr << "Warning: Unknown argument '" << arg << "' (use --help for usage)\n";
+    }
+  }
+  return cfg;
+}
+
+// ────────────────────────────────────────────────────────────
+// Main
+// ────────────────────────────────────────────────────────────
+
+int main(int argc, char** argv) {
+  // Parse command-line arguments
+  auto cfg = parse_args(argc, argv);
+  if (cfg.show_help) {
+    print_usage(argv[0]);
+    return 0;
+  }
+  if (!std::filesystem::exists("config/sdk_config.json")) {
+    std::cerr << "Error: config/sdk_config.json not found!" << std::endl;
+    return 1;
+  }
+
+  // Create and load global configuration
+  auto j = trossen::configuration::JsonLoader::load("config/sdk_config.json");
+  trossen::configuration::GlobalConfig::instance().load_from_json(j);
+
+  // Print configuration
+  std::vector<std::string> config_lines = {
+    "Mode:                 " + std::string(cfg.use_mock ? "Mock (no hardware)" : "Hardware"),
+    "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
+    "Root directory:       " + cfg.root,
+    "Repository ID:        " + cfg.repository_id,
+    "Backend:              " + cfg.backend_type
+  };
+
+  if (!cfg.use_mock) {
+    config_lines.push_back("Leader IP:            " + cfg.leader_ip);
+    config_lines.push_back("Follower IP:          " + cfg.follower_ip);
+  }
+
+  config_lines.push_back("Joint rate:           " + std::to_string(cfg.joint_rate_hz) + " Hz");
+  config_lines.push_back(
+    "Camera:               /dev/video" + std::to_string(cfg.camera_index) +
+    " @ " + std::to_string(cfg.camera_width) + "x" + std::to_string(cfg.camera_height) +
+    " @ " + std::to_string(cfg.camera_fps) + " fps");
+
+  trossen::demo::print_config_banner("Trossen AI LeRobot Solo Complete Demo", config_lines);
+
+  // Install signal handler for graceful shutdown
+  trossen::demo::install_signal_handler();
+
+  // Create root directory
+  std::filesystem::create_directories(cfg.root);
+
+  // ──────────────────────────────────────────────────────────
+  // Initialize hardware (if not using mock)
+  // ──────────────────────────────────────────────────────────
+
+  std::unique_ptr<trossen_arm::TrossenArmDriver> leader_driver;
+  std::unique_ptr<trossen_arm::TrossenArmDriver> follower_driver;
+  const float moving_time_s = 2.0f;
+
+  if (!cfg.use_mock) {
+    std::cout << "Initializing hardware...\n";
+
+    leader_driver = std::make_unique<trossen_arm::TrossenArmDriver>();
+    follower_driver = std::make_unique<trossen_arm::TrossenArmDriver>();
+
+    try {
+      leader_driver->configure(
+        trossen_arm::Model::wxai_v0,
+        trossen_arm::StandardEndEffector::wxai_v0_leader,
+        cfg.leader_ip,
+        true);
+      std::cout << "  ✓ Leader arm configured (" << cfg.leader_ip << ")\n";
+    } catch (const std::exception& e) {
+      std::cerr << "Failed to configure leader: " << e.what() << "\n";
+      return 1;
+    }
+
+    try {
+      follower_driver->configure(
+        trossen_arm::Model::wxai_v0,
+        trossen_arm::StandardEndEffector::wxai_v0_follower,
+        cfg.follower_ip,
+        true);
+      std::cout << "  ✓ Follower arm configured (" << cfg.follower_ip << ")\n";
+    } catch (const std::exception& e) {
+      std::cerr << "Failed to configure follower: " << e.what() << "\n";
+      return 1;
+    }
+
+    // Adjust follower joint limits for gripper tolerance
+    auto joint_limits = follower_driver->get_joint_limits();
+    joint_limits[follower_driver->get_num_joints() - 1].position_tolerance = 0.01;
+    follower_driver->set_joint_limits(joint_limits);
+
+    // Move arms to staged positions
+    leader_driver->set_all_modes(trossen_arm::Mode::position);
+    follower_driver->set_all_modes(trossen_arm::Mode::position);
+    leader_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
+    follower_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+
+    std::cout << "  ✓ Arms staged to starting positions\n";
+  }
+
+  trossen::runtime::SessionManager mgr;
+
+  std::cout << "\nInitialized Session Manager\n";
+  std::cout << "  Starting episode index: " << mgr.stats().current_episode_index << "\n";
+  if (mgr.stats().current_episode_index > 0) {
+    std::cout << "  (Resuming from existing episodes in directory)\n";
+  }
+  std::cout << "\n";
+
+  // ──────────────────────────────────────────────────────────
+  // Create and register producers
+  // ──────────────────────────────────────────────────────────
+
+  std::cout << "Creating producers...\n";
+
+  // Joint state producer (arm or mock)
+  std::shared_ptr<trossen::hw::PolledProducer> joint_producer;
+  if (cfg.use_mock) {
+    trossen::hw::arm::TeleopMockJointStateProducer::Config joint_cfg{
+      6,                              // num_joints
+      cfg.joint_rate_hz,              // rate_hz
+      "teleop_robot/joint_states",        // stream_id
+      1.0                             // motion_scale
+    };
+    joint_producer = std::make_shared<trossen::hw::arm::TeleopMockJointStateProducer>(joint_cfg);
+    std::cout << "  ✓ Mock joint state producer (" << cfg.joint_rate_hz << " Hz, 6 joints)\n";
+  } else {
+    trossen::hw::arm::TeleopTrossenArmProducer::Config joint_cfg;
+    joint_cfg.stream_id = "teleop_robot/joint_states";
+    joint_cfg.use_device_time = false;
+
+    // Wrap follower_driver in shared_ptr (non-owning wrapper since we manage lifetime)
+    auto follower_shared = std::shared_ptr<trossen_arm::TrossenArmDriver>(
+      follower_driver.get(), [](trossen_arm::TrossenArmDriver*){});
+
+    auto leader_shared = std::shared_ptr<trossen_arm::TrossenArmDriver>(
+      leader_driver.get(), [](trossen_arm::TrossenArmDriver*){});
+
+    joint_producer = std::make_shared<trossen::hw::arm::TeleopTrossenArmProducer>(
+      leader_shared, follower_shared, joint_cfg);
+    std::cout << "  ✓ Follower arm producer (" << cfg.joint_rate_hz << " Hz)\n";
+  }
+
+  auto joint_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.joint_rate_hz));
+  mgr.add_producer(joint_producer, joint_period);
+
+  // Camera producer (OpenCV or mock)
+  std::shared_ptr<trossen::hw::PolledProducer> camera_producer;
+  if (cfg.use_mock) {
+    trossen::hw::camera::MockCameraProducer::Config cam_cfg;
+    cam_cfg.width = cfg.camera_width;
+    cam_cfg.height = cfg.camera_height;
+    cam_cfg.fps = cfg.camera_fps;
+    cam_cfg.stream_id = "camera_main";
+    cam_cfg.encoding = "bgr8";
+    cam_cfg.pattern = trossen::hw::camera::MockCameraProducer::Pattern::Gradient;
+    cam_cfg.warmup_frames = 3;
+    camera_producer = std::make_shared<trossen::hw::camera::MockCameraProducer>(cam_cfg);
+    std::cout << "  ✓ Mock camera producer (" << cfg.camera_fps << " Hz, "
+              << cfg.camera_width << "x" << cfg.camera_height << ")\n";
+  } else {
+    trossen::hw::camera::OpenCvCameraProducer::Config cam_cfg;
+    cam_cfg.device_index = cfg.camera_index;
+    cam_cfg.stream_id = "camera_main";
+    cam_cfg.encoding = "bgr8";
+    cam_cfg.width = cfg.camera_width;
+    cam_cfg.height = cfg.camera_height;
+    cam_cfg.fps = cfg.camera_fps;
+    cam_cfg.use_device_time = false;
+    camera_producer = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
+    std::cout << "  ✓ OpenCV camera producer (" << cfg.camera_fps << " Hz, "
+              << cfg.camera_width << "x" << cfg.camera_height << ")\n";
+  }
+
+  auto camera_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.camera_fps));
+  mgr.add_producer(camera_producer, camera_period);
+
+  // TODO(shantanuparab-tr): Add this to configurations after main executable is created
+  // // Create a Realsense Camera Producer (Hardcoded configuration for demo purposes)
+
+  // trossen::hw::camera::RealsenseCameraProducer::Config realsense_cfg;
+  // realsense_cfg.serial_number = "218622274938";  // Replace with your camera's serial number
+  // realsense_cfg.stream_id = "realsense_camera0";
+  // realsense_cfg.encoding = "bgr8";
+  // realsense_cfg.width = 640;
+  // realsense_cfg.height = 480;
+  // realsense_cfg.fps = 30;
+  // realsense_cfg.use_device_time = true;
+  // realsense_cfg.warmup_seconds = 2.0;
+
+  // // Create Realsense config
+  // rs2::config cam_cfg;
+
+  // // Create a realsense pipeline
+  // rs2::pipeline realsense_pipeline;
+  // auto camera_ = std::make_shared<rs2::pipeline>(realsense_pipeline);
+
+  // // Enable the device using the unique ID
+  // if (!realsense_cfg.serial_number.empty()) {
+  //   cam_cfg.enable_device(realsense_cfg.serial_number);
+  // } else {
+  //   std::cout << "Unique ID is empty. Cannot connect to RealSense camera: "
+  //     << realsense_cfg.stream_id << std::endl;
+  //   throw std::runtime_error("Unique ID is empty for camera: " + realsense_cfg.stream_id);
+  // }
+
+  // // Enable the color stream as default
+  // cam_cfg.enable_stream(RS2_STREAM_COLOR, realsense_cfg.width, realsense_cfg.height,
+  //                   RS2_FORMAT_RGB8, realsense_cfg.fps);
+
+  // // Make this conditional to enable depth stream
+  // cam_cfg.enable_stream(RS2_STREAM_DEPTH, realsense_cfg.width, realsense_cfg.height,
+  //                   RS2_FORMAT_Z16, realsense_cfg.fps);
+  // try {
+  //   // Start the camera pipeline
+  //   rs2::pipeline_profile profile = camera_->start(cam_cfg);
+  // } catch (const rs2::error& e) {
+  //   std::cout << "Failed to enable device with Unique ID: " << realsense_cfg.serial_number
+  //             << ". Error: " << e.what() << ". Listing all available cameras." << std::endl;
+  //   std::cout << "Available cameras listed above. Please check outputs folder to get "
+  //       "Available cameras listed above. Please check outputs folder to get "
+  //       "images associated "
+  //       "with each camera." << std::endl;
+  //   throw std::runtime_error(
+  //       "Unique ID (serial number) is required to connect to RealSense camera");
+  // }
+
+  // auto frame_cache = std::make_shared<trossen::hw::camera::RealsenseFrameCache>(camera_, 2);
+
+  // auto realsense_producer =
+  //   std::make_shared<trossen::hw::camera::RealsenseCameraProducer>(frame_cache, realsense_cfg);
+
+  // auto realsense_period = std::chrono::milliseconds(static_cast<int>(1000.0f / 30.0f));
+
+  // mgr.add_producer(realsense_producer, realsense_period);
+  // std::cout << "  ✓ Realsense camera producer (30 Hz, 640x480)\n";
+
+  // trossen::hw::camera::RealsenseDepthCameraProducer::Config realsense_depth_cfg;
+  // // Replace with your camera's serial number
+  // realsense_depth_cfg.serial_number = "218622274938";
+  // realsense_depth_cfg.stream_id = "realsense_depth_camera0";
+  // realsense_depth_cfg.encoding = "16UC1";
+  // realsense_depth_cfg.width = 640;
+  // realsense_depth_cfg.height = 480;
+  // realsense_depth_cfg.fps = 30;
+  // realsense_depth_cfg.use_device_time = true;
+  // realsense_depth_cfg.warmup_seconds = 2.0;
+
+  // auto realsense_depth_producer =
+  //   std::make_shared<trossen::hw::camera::RealsenseDepthCameraProducer>(
+  //     frame_cache,
+  //     realsense_depth_cfg);
+  // mgr.add_producer(realsense_depth_producer, realsense_period);
+  // std::cout << "  ✓ Realsense depth camera producer (30 Hz, 640x480)\n";
+
+  std::cout << "\nProducers registered. Ready to record.\n";
+
+  // ──────────────────────────────────────────────────────────
+  // Enable teleop mode (if using hardware)
+  // ──────────────────────────────────────────────────────────
+
+  if (!cfg.use_mock) {
+    std::cout << "\n!! Enabling teleop mode !!\n";
+    std::cout << "   Leader: gravity compensation (external_effort mode)\n";
+    std::cout << "   Follower: will mirror leader positions\n\n";
+
+    leader_driver->set_all_modes(trossen_arm::Mode::external_effort);
+    leader_driver->set_all_external_efforts(
+      std::vector<double>(leader_driver->get_num_joints(), 0.0),
+      0.0,
+      false);
+  }
+
+  // TODO(shantanuparab-tr): Create a method for checking if all the hardware
+  // producers are ready before starting the recording. For now, adding a sleep.
+  // Sleep briefly to ensure everything is settled
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+
+  // ──────────────────────────────────────────────────────────
+  // Recording loop: record requested number of episodes
+  // ──────────────────────────────────────────────────────────
+
+  while (true) {
+    if (trossen::demo::g_stop_requested) {
+      std::cout << "\n\nStopping at user request (Ctrl+C).\n";
+      break;
+    }
+
+    // Display episode header
+    mgr.print_episode_header();
+
+    // Lock the leader arm, move the follower arm to mirror the leader's current position, and
+    // unlock the leader
+    if (!cfg.use_mock) {
+      leader_driver->set_all_modes(trossen_arm::Mode::position);
+      auto leader_positions = leader_driver->get_all_positions();
+      follower_driver->set_all_positions(leader_positions, moving_time_s, false);
+      std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+      leader_driver->set_all_modes(trossen_arm::Mode::external_effort);
+      leader_driver->set_all_external_efforts(
+        std::vector<double>(leader_driver->get_num_joints(), 0.0),
+        0.0,
+        false);
+    }
+
+    // Start episode
+    if (!mgr.start_episode()) {
+      std::cerr << "✗ Failed to start episode " << mgr.stats().current_episode_index << "\n";
+      break;
+    }
+
+    // Capture the episode index that's currently recording
+    uint32_t recording_episode_index = mgr.stats().current_episode_index;
+
+    // Track episode start time for actual duration calculation
+    auto episode_start_time = std::chrono::steady_clock::now();
+
+    std::cout << "Recording...\n";
+
+    // Start async stats monitoring in SessionManager (runs in background thread)
+    mgr.start_async_monitoring();
+
+    // Teleop loop (if using hardware)
+    std::thread teleop_thread;
+    if (!cfg.use_mock) {
+      teleop_thread = std::thread([&]() {
+        while (mgr.is_episode_active() && !trossen::demo::g_stop_requested) {
+          auto leader_js = leader_driver->get_all_positions();
+          follower_driver->set_all_positions(leader_js, 0.0f, false);
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+      });
+    }
+
+    // Main thread can now do other work or just wait for completion
+    // Use wait_for_auto_stop() to detect when episode completes (auto or manual)
+    // This respects the max_duration setting from config and returns when episode ends
+    mgr.wait_for_auto_stop();
+
+    // If Ctrl+C was pressed, ensure episode is stopped
+    if (trossen::demo::g_stop_requested && mgr.is_episode_active()) {
+      mgr.stop_episode();
+    }
+
+    // Get final stats from async monitoring (this will join the thread)
+    trossen::runtime::SessionManager::Stats last_stats = mgr.get_async_monitor_stats();
+
+    // Wait for teleop thread to finish
+    if (!cfg.use_mock && teleop_thread.joinable()) {
+      teleop_thread.join();
+    }
+
+    // Calculate actual episode duration
+    auto episode_end_time = std::chrono::steady_clock::now();
+    double actual_duration =
+      std::chrono::duration<double>(episode_end_time - episode_start_time).count();
+
+    // Build the file path and print summary
+    std::string file_path = trossen::demo::generate_episode_path(
+      cfg.root,
+      recording_episode_index);
+    trossen::demo::print_episode_summary(file_path, last_stats);
+
+    // ──────────────────────────────────────────────────────────
+    // Sanity check: verify expected record counts
+    // ──────────────────────────────────────────────────────────
+
+    trossen::demo::SanityCheckConfig sanity_cfg{
+      last_stats.recording_duration_s.value_or(0.0),
+      1,  // 1 joint producer (follower)
+      cfg.joint_rate_hz,
+      1,  // 1 camera
+      cfg.camera_fps,
+      5.0  // 5% tolerance
+    };
+    trossen::demo::perform_sanity_check(
+      recording_episode_index,
+      last_stats.records_written_current,
+      sanity_cfg);
+
+    // Check if user requested stop
+    if (trossen::demo::g_stop_requested) {
+      std::cout << "\nStopping at user request (Ctrl+C).\n";
+      break;
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────
+  // Shutdown and final summary
+  // ──────────────────────────────────────────────────────────
+
+  mgr.shutdown();
+
+  // Return arms to staging and then sleep position (if using hardware)
+  if (!cfg.use_mock && leader_driver && follower_driver) {
+    std::cout << "\nReturning arms to starting positions...\n";
+    leader_driver->set_all_modes(trossen_arm::Mode::position);
+    leader_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
+    follower_driver->set_all_positions(trossen::demo::STAGED_POSITIONS, moving_time_s, false);
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+    leader_driver->set_all_positions(
+      std::vector<double>(leader_driver->get_num_joints(), 0.0),
+      moving_time_s,
+      false);
+    follower_driver->set_all_positions(
+      std::vector<double>(follower_driver->get_num_joints(), 0.0),
+      moving_time_s,
+      false);
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+    std::cout << "Arms returned to sleep position.\n";
+  }
+
+  auto final_stats = mgr.stats();
+  trossen::demo::print_final_summary(final_stats.total_episodes_completed, cfg.root);
+
+  return 0;
+}

--- a/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
@@ -13,20 +13,28 @@
 
 namespace trossen::configuration {
 
+// LeRobot backend specific constants
+inline constexpr bool LEROBOT_DEFAULT_OVERWRITE_EXISTING = false;
+inline constexpr bool LEROBOT_DEFAULT_ENCODE_VIDEOS = false;
+inline constexpr char LEROBOT_DEFAULT_TASK_NAME[] = "perform a generic task";
+inline constexpr char LEROBOT_DEFAULT_REPOSITORY_ID[] = "TrossenRoboticsCommunity";
+inline constexpr float LEROBOT_DEFAULT_FPS = 30.0f;
+inline constexpr int LEROBOT_DEFAULT_EPISODE_INDEX = 0;
+
 struct LeRobotBackendConfig : public BaseConfig {
   int encoder_threads{trossen::io::backends::DEFAULT_ENCODER_THREADS};
   int max_image_queue{trossen::io::backends::DEFAULT_MAX_IMAGE_QUEUE};
   int png_compression_level{trossen::io::backends::DEFAULT_PNG_COMPRESSION_LEVEL};
-  bool overwrite_existing{trossen::io::backends::DEFAULT_OVERWRITE_EXISTING};
-  bool encode_videos{trossen::io::backends::DEFAULT_ENCODE_VIDEOS};
-  std::string task_name{trossen::io::backends::DEFAULT_TASK_NAME};
-  std::string repository_id{trossen::io::backends::DEFAULT_REPOSITORY_ID};
+  bool overwrite_existing{LEROBOT_DEFAULT_OVERWRITE_EXISTING};
+  bool encode_videos{LEROBOT_DEFAULT_ENCODE_VIDEOS};
+  std::string task_name{LEROBOT_DEFAULT_TASK_NAME};
+  std::string repository_id{LEROBOT_DEFAULT_REPOSITORY_ID};
   std::string dataset_id{trossen::io::backends::auto_generate_dataset_id()};
   std::string root{trossen::io::backends::get_default_root_path().string()};
   // TODO(shantanuparab-tr): DRemove episode index if not being used
-  int episode_index{trossen::io::backends::DEFAULT_EPISODE_INDEX};
+  int episode_index{LEROBOT_DEFAULT_EPISODE_INDEX};
   std::string robot_name{trossen::io::backends::DEFAULT_ROBOT_NAME};
-  float fps{trossen::io::backends::DEFAULT_FPS};
+  float fps{LEROBOT_DEFAULT_FPS};
 
   std::string type() const override { return "lerobot_backend"; }
 

--- a/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
@@ -14,36 +14,39 @@
 namespace trossen::configuration {
 
 struct LeRobotBackendConfig : public BaseConfig {
-  int encoder_threads{1};
-  int max_image_queue{0};
-  int png_compression_level{3};
-  bool overwrite_existing{false};
-  bool encode_videos{false};
-  std::string task_name{"default_task"};
-  std::string repository_id{"default_repo"};
-  std::string dataset_id{"default_dataset"};
+  int encoder_threads{trossen::io::backends::DEFAULT_ENCODER_THREADS};
+  int max_image_queue{trossen::io::backends::DEFAULT_MAX_IMAGE_QUEUE};
+  int png_compression_level{trossen::io::backends::DEFAULT_PNG_COMPRESSION_LEVEL};
+  bool overwrite_existing{trossen::io::backends::DEFAULT_OVERWRITE_EXISTING};
+  bool encode_videos{trossen::io::backends::DEFAULT_ENCODE_VIDEOS};
+  std::string task_name{trossen::io::backends::DEFAULT_TASK_NAME};
+  std::string repository_id{trossen::io::backends::DEFAULT_REPOSITORY_ID};
+  std::string dataset_id{trossen::io::backends::auto_generate_dataset_id()};
   std::string root{trossen::io::backends::get_default_root_path().string()};
-  int episode_index{0};
-  std::string robot_name{"trossen_ai_generic"};
-  float fps{30.0f};
+  // TODO(shantanuparab-tr): DRemove episode index if not being used
+  int episode_index{trossen::io::backends::DEFAULT_EPISODE_INDEX};
+  std::string robot_name{trossen::io::backends::DEFAULT_ROBOT_NAME};
+  float fps{trossen::io::backends::DEFAULT_FPS};
 
   std::string type() const override { return "lerobot_backend"; }
 
   static LeRobotBackendConfig from_json(const nlohmann::json& j) {
-    LeRobotBackendConfig c;
-    c.root = j.value("root", "");
-    c.encoder_threads = j.value("encoder_threads", 1);
-    c.max_image_queue = j.value("max_image_queue", 0);
-    c.png_compression_level = j.value("png_compression_level", 3);
-    // c.drop_policy = j.value("drop_policy", "DropNewest");
-    c.overwrite_existing = j.value("overwrite_existing", false);
-    c.encode_videos = j.value("encode_videos", false);
-    c.task_name = j.value("task_name", "default_task");
-    c.repository_id = j.value("repository_id", "default_repo");
-    c.dataset_id = j.value("dataset_id", "default_dataset");
-    c.episode_index = j.value("episode_index", 0);
-    c.robot_name = j.value("robot_name", "trossen_ai_generic");
-    c.fps = j.value("fps", 30.0f);
+    LeRobotBackendConfig c;  // All defaults already set by member initializers
+
+    // Only override if present in JSON
+    if (j.contains("root")) j.at("root").get_to(c.root);
+    if (j.contains("encoder_threads")) j.at("encoder_threads").get_to(c.encoder_threads);
+    if (j.contains("max_image_queue")) j.at("max_image_queue").get_to(c.max_image_queue);
+    if (j.contains("png_compression_level"))
+      j.at("png_compression_level").get_to(c.png_compression_level);
+    if (j.contains("overwrite_existing")) j.at("overwrite_existing").get_to(c.overwrite_existing);
+    if (j.contains("encode_videos")) j.at("encode_videos").get_to(c.encode_videos);
+    if (j.contains("task_name")) j.at("task_name").get_to(c.task_name);
+    if (j.contains("repository_id")) j.at("repository_id").get_to(c.repository_id);
+    if (j.contains("dataset_id")) j.at("dataset_id").get_to(c.dataset_id);
+    if (j.contains("episode_index")) j.at("episode_index").get_to(c.episode_index);
+    if (j.contains("robot_name")) j.at("robot_name").get_to(c.robot_name);
+    if (j.contains("fps")) j.at("fps").get_to(c.fps);
 
     return c;
   }

--- a/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
@@ -15,22 +15,25 @@ namespace trossen::configuration {
 
 struct McapBackendConfig : public BaseConfig {
   std::string root{trossen::io::backends::get_default_root_path().string()};
-  std::string robot_name{"/robot/joint_states"};
-  int chunk_size_bytes{4 * 1024 * 1024};
-  std::string compression{""};
-  std::string dataset_id;
+  std::string robot_name{trossen::io::backends::DEFAULT_ROBOT_NAME};
+  int chunk_size_bytes{trossen::io::backends::DEFAULT_CHUNK_SIZE_BYTES};
+  std::string compression{trossen::io::backends::DEFAULT_COMPRESSION};
+  std::string dataset_id{trossen::io::backends::auto_generate_dataset_id()};
+  // TODO(shantanuparab-tr): Remove episode index if not being used
   int episode_index{0};
 
   std::string type() const override { return "mcap_backend"; }
 
   static  McapBackendConfig from_json(const nlohmann::json& j) {
     McapBackendConfig c;
-    c.root = j.value("root", "");
-    c.robot_name = j.value("robot_name", "/robot/joint_states");
-    c.chunk_size_bytes = j.value("chunk_size_bytes", 4 * 1024 * 1024);
-    c.compression = j.value("compression", "");
-    c.dataset_id = j.at("dataset_id").get<std::string>();
-    c.episode_index = j.value("episode_index", 0);
+
+    // Only override if present in JSON
+    if (j.contains("root")) j.at("root").get_to(c.root);
+    if (j.contains("robot_name")) j.at("robot_name").get_to(c.robot_name);
+    if (j.contains("chunk_size_bytes")) j.at("chunk_size_bytes").get_to(c.chunk_size_bytes);
+    if (j.contains("compression")) j.at("compression").get_to(c.compression);
+    if (j.contains("dataset_id")) j.at("dataset_id").get_to(c.dataset_id);
+    if (j.contains("episode_index")) j.at("episode_index").get_to(c.episode_index);
 
     return c;
   }

--- a/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
@@ -13,11 +13,15 @@
 
 namespace trossen::configuration {
 
+// MCAP backend specific constants
+inline constexpr int MCAP_DEFAULT_CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
+inline constexpr char MCAP_DEFAULT_COMPRESSION[] = "";
+
 struct McapBackendConfig : public BaseConfig {
   std::string root{trossen::io::backends::get_default_root_path().string()};
   std::string robot_name{trossen::io::backends::DEFAULT_ROBOT_NAME};
-  int chunk_size_bytes{trossen::io::backends::DEFAULT_CHUNK_SIZE_BYTES};
-  std::string compression{trossen::io::backends::DEFAULT_COMPRESSION};
+  int chunk_size_bytes{MCAP_DEFAULT_CHUNK_SIZE_BYTES};
+  std::string compression{MCAP_DEFAULT_COMPRESSION};
   std::string dataset_id{trossen::io::backends::auto_generate_dataset_id()};
   // TODO(shantanuparab-tr): Remove episode index if not being used
   int episode_index{0};

--- a/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
@@ -14,24 +14,22 @@
 namespace trossen::configuration {
 
 struct TrossenBackendConfig : public BaseConfig {
-  std::string root{"/data/trossen"};
-  int encoder_threads{1};
-  int max_image_queue{0};
-  int png_compression_level{3};
-  std::string drop_policy{"DropNewest"};
+  std::string root{trossen::io::backends::get_default_root_path().string()};
+  int encoder_threads{trossen::io::backends::DEFAULT_ENCODER_THREADS};
+  int max_image_queue{trossen::io::backends::DEFAULT_MAX_IMAGE_QUEUE};
+  int png_compression_level{trossen::io::backends::DEFAULT_PNG_COMPRESSION_LEVEL};
+  std::string drop_policy{trossen::io::backends::DEFAULT_DROP_POLICY};
 
   std::string type() const override { return "trossen_backend"; }
 
   static TrossenBackendConfig from_json(const nlohmann::json& j) {
     TrossenBackendConfig c;
-    c.root = j.value("root", "");
-    if (c.root.empty()) {
-        c.root = trossen::io::backends::get_default_root_path().string();
-    }
-    c.encoder_threads = j.value("encoder_threads", 1);
-    c.max_image_queue = j.value("max_image_queue", 0);
-    c.png_compression_level = j.value("png_compression_level", 3);
-    c.drop_policy = j.value("drop_policy", "DropNewest");
+    if (j.contains("root")) j.at("root").get_to(c.root);
+    if (j.contains("encoder_threads")) j.at("encoder_threads").get_to(c.encoder_threads);
+    if (j.contains("max_image_queue")) j.at("max_image_queue").get_to(c.max_image_queue);
+    if (j.contains("png_compression_level"))
+      j.at("png_compression_level").get_to(c.png_compression_level);
+    if (j.contains("drop_policy")) j.at("drop_policy").get_to(c.drop_policy);
 
     return c;
   }

--- a/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
@@ -13,12 +13,15 @@
 
 namespace trossen::configuration {
 
+// Trossen backend specific constants
+inline constexpr char TROSSEN_DEFAULT_DROP_POLICY[] = "DropNewest";
+
 struct TrossenBackendConfig : public BaseConfig {
   std::string root{trossen::io::backends::get_default_root_path().string()};
   int encoder_threads{trossen::io::backends::DEFAULT_ENCODER_THREADS};
   int max_image_queue{trossen::io::backends::DEFAULT_MAX_IMAGE_QUEUE};
   int png_compression_level{trossen::io::backends::DEFAULT_PNG_COMPRESSION_LEVEL};
-  std::string drop_policy{trossen::io::backends::DEFAULT_DROP_POLICY};
+  std::string drop_policy{TROSSEN_DEFAULT_DROP_POLICY};
 
   std::string type() const override { return "trossen_backend"; }
 

--- a/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
+++ b/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
@@ -23,14 +23,16 @@ struct SessionManagerConfig : public BaseConfig {
 
   static SessionManagerConfig from_json(const nlohmann::json& j) {
     SessionManagerConfig c;
-    c.max_duration = j.contains("max_duration")
-      ? std::optional<std::chrono::duration<double>>{
-        std::chrono::duration<double>{j.at("max_duration").get<double>()}}
-      : std::nullopt;
-    c.max_episodes = j.contains("max_episodes")
-      ? std::optional<uint32_t>{j.at("max_episodes").get<uint32_t>()}
-      : std::nullopt;
-    c.backend_type = j.value("backend_type", "mcap");
+
+    if (j.contains("max_duration")) {
+      c.max_duration = std::chrono::duration<double>{j.at("max_duration").get<double>()};
+    }
+    if (j.contains("max_episodes")) {
+      c.max_episodes = j.at("max_episodes").get<uint32_t>();
+    }
+    if (j.contains("backend_type")) {
+      j.at("backend_type").get_to(c.backend_type);
+    }
 
     return c;
   }

--- a/include/trossen_sdk/io/backend_utils.hpp
+++ b/include/trossen_sdk/io/backend_utils.hpp
@@ -23,6 +23,35 @@ inline std::filesystem::path get_default_root_path() {
   }
 }
 
+/**
+ * @brief Auto-generate a dataset ID based on the current timestamp
+ * @return Generated dataset ID string
+ */
+inline std::string auto_generate_dataset_id() {
+  // Generate a timestamp-based dataset ID
+  auto now = std::chrono::system_clock::now();
+  auto time_t_now = std::chrono::system_clock::to_time_t(now);
+  std::ostringstream oss;
+  // Format: dataset_YYYYMMDD_HHMMSS in local time
+  oss << "dataset_" << std::put_time(std::localtime(&time_t_now), "%Y%m%d_%H%M%S");
+  return oss.str();
+}
+
+// Constants for default variables
+constexpr int DEFAULT_ENCODER_THREADS = 1;
+constexpr int DEFAULT_MAX_IMAGE_QUEUE = 0;
+constexpr int DEFAULT_PNG_COMPRESSION_LEVEL = 3;
+constexpr bool DEFAULT_OVERWRITE_EXISTING = false;
+constexpr bool DEFAULT_ENCODE_VIDEOS = false;
+constexpr char DEFAULT_TASK_NAME[] = "perform a generic task";
+constexpr char DEFAULT_REPOSITORY_ID[] = "TrossenRoboticsCommunity";
+constexpr char DEFAULT_ROBOT_NAME[] = "trossen_ai_stationary";
+constexpr float DEFAULT_FPS = 30.0f;
+constexpr int DEFAULT_CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
+constexpr char DEFAULT_COMPRESSION[] = "";
+constexpr char DEFAULT_DROP_POLICY[] = "DropNewest";
+constexpr int DEFAULT_EPISODE_INDEX = 0;
+
 }  // namespace trossen::io::backends
 
 #endif  // INCLUDE_TROSSEN_SDK_IO_BACKEND_UTILS_HPP_

--- a/include/trossen_sdk/io/backend_utils.hpp
+++ b/include/trossen_sdk/io/backend_utils.hpp
@@ -37,20 +37,11 @@ inline std::string auto_generate_dataset_id() {
   return oss.str();
 }
 
-// Constants for default variables
-constexpr int DEFAULT_ENCODER_THREADS = 1;
-constexpr int DEFAULT_MAX_IMAGE_QUEUE = 0;
-constexpr int DEFAULT_PNG_COMPRESSION_LEVEL = 3;
-constexpr bool DEFAULT_OVERWRITE_EXISTING = false;
-constexpr bool DEFAULT_ENCODE_VIDEOS = false;
-constexpr char DEFAULT_TASK_NAME[] = "perform a generic task";
-constexpr char DEFAULT_REPOSITORY_ID[] = "TrossenRoboticsCommunity";
-constexpr char DEFAULT_ROBOT_NAME[] = "trossen_ai_stationary";
-constexpr float DEFAULT_FPS = 30.0f;
-constexpr int DEFAULT_CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
-constexpr char DEFAULT_COMPRESSION[] = "";
-constexpr char DEFAULT_DROP_POLICY[] = "DropNewest";
-constexpr int DEFAULT_EPISODE_INDEX = 0;
+// Common constants used across multiple backends
+inline constexpr int DEFAULT_ENCODER_THREADS = 1;
+inline constexpr int DEFAULT_MAX_IMAGE_QUEUE = 0;
+inline constexpr int DEFAULT_PNG_COMPRESSION_LEVEL = 3;
+inline constexpr char DEFAULT_ROBOT_NAME[] = "trossen_ai_stationary";
 
 }  // namespace trossen::io::backends
 

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -155,6 +155,12 @@ public:
 
     /// @brief Episodes finished this session
     uint64_t total_episodes_completed;
+
+    /// @brief Duration of episode preprocessing (seconds)
+    std::optional<double> preprocessing_duration_s;
+
+    /// @brief Duration of episode shutdown (seconds)
+    std::optional<double> postprocess_duration_s;
   };
 
   /**
@@ -185,6 +191,12 @@ private:
 
   /// @brief Sink's processed_count() at the start of current episode (for delta tracking)
   uint64_t episode_start_record_count_{0};
+
+  /// @brief Duration of last preprocessing phase (seconds)
+  double preprocessing_duration_s_{0.0};
+
+  /// @brief Duration of last shutdown phase (seconds)
+  double postprocess_duration_s_{0.0};
 
   /// @brief Monitoring thread for duration-based auto-stop
   std::thread monitor_thread_;

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -179,6 +180,24 @@ public:
   Stats stats() const;
 
   /**
+   * @brief Callback type for episode completion notification
+   *
+   * Invoked when an episode completes (either by auto-stop or manual stop).
+   * Receives final statistics for the completed episode.
+   */
+  using EpisodeCompleteCallback = std::function<void(const Stats&)>;
+
+  /**
+   * @brief Set callback to be invoked when episode completes
+   *
+   * @param callback Function to call with final stats when episode ends
+   *
+   * The callback is invoked from the monitoring thread or from stop_episode().
+   * It should be thread-safe and should not block for extended periods.
+   */
+  void set_episode_complete_callback(EpisodeCompleteCallback callback);
+
+  /**
    * @brief Print episode header to console
    */
   void print_episode_header();
@@ -199,13 +218,47 @@ public:
   * periodically and returns early if stop is requested.
   * Also, keeps a track of stats while monitoring the episode.
   *
-  * @param update_interval How often to print stats
+  * @param update_interval How often to update stats (and print if enabled)
   * @param sleep_interval How long to sleep between checks
+  * @param print_stats Whether to print stats to console (default: false)
   * @return true if completed normally, false if interrupted by stop request
   */
   Stats monitor_episode(
     std::chrono::duration<double> update_interval = std::chrono::milliseconds(500),
-    std::chrono::duration<double> sleep_interval = std::chrono::milliseconds(100));
+    std::chrono::duration<double> sleep_interval = std::chrono::milliseconds(100),
+    bool print_stats = false);
+
+  /**
+   * @brief Start asynchronous stats monitoring in background thread
+   *
+   * Launches a thread that continuously monitors episode statistics.
+   * This allows the main thread to remain free for other operations.
+   * The monitoring thread will automatically stop when the episode ends.
+   *
+   * @param update_interval How often to update stats (and print if enabled) (default: 500ms)
+   * @param sleep_interval Sleep duration between stat checks (default: 100ms)
+   * @param print_stats Whether to print stats to console (default: false)
+   *
+   * @note This is non-blocking. Stats are printed in the background if print_stats is true.
+   * @note Call get_async_monitor_stats() to retrieve final stats after episode completes.
+   */
+  void start_async_monitoring(
+    std::chrono::duration<double> update_interval = std::chrono::milliseconds(500),
+    std::chrono::duration<double> sleep_interval = std::chrono::milliseconds(100),
+    bool print_stats = false);
+
+  /**
+   * @brief Stop async monitoring and retrieve final stats
+   *
+   * Stops the async monitoring thread (if running) and returns the final
+   * statistics captured during monitoring.
+   *
+   * @return Final episode statistics from monitoring
+   *
+   * @note This will block until the monitoring thread completes.
+   * @note Safe to call even if async monitoring wasn't started.
+   */
+  Stats get_async_monitor_stats();
 
 private:
   /// @brief Configuration
@@ -244,11 +297,26 @@ private:
   /// @brief Flag to control monitoring thread lifecycle
   std::atomic<bool> monitoring_active_{false};
 
+  /// @brief Async stats monitoring thread
+  std::thread async_monitor_thread_;
+
+  /// @brief Flag to control async monitoring thread lifecycle
+  std::atomic<bool> async_monitoring_active_{false};
+
+  /// @brief Final stats from async monitoring
+  Stats async_monitor_final_stats_;
+
+  /// @brief Mutex to protect async monitor stats
+  mutable std::mutex async_monitor_mutex_;
+
   /// @brief Flag indicating that auto-stop was triggered by monitor thread
   std::atomic<bool> auto_stop_triggered_{false};
 
   /// @brief Flag indicating that episode final statistics were emitted
   mutable std::atomic<bool> stats_emitted_{false};
+
+  /// @brief Callback invoked when episode completes
+  EpisodeCompleteCallback episode_complete_callback_;
 
   /// @brief Condition variable for auto-stop signaling
   std::condition_variable auto_stop_cv_;

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -162,6 +162,11 @@ public:
    */
   Stats stats() const;
 
+  /**
+   * @brief Print episode header to console
+   */
+  void print_episode_header();
+
 private:
   /// @brief Configuration
   std::shared_ptr<trossen::configuration::SessionManagerConfig> cfg_;

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -108,6 +108,13 @@ public:
   bool is_episode_active() const;
 
   /**
+    * @brief Check if the final stats are emitted
+    *
+    * @return true if final stats have been emitted, false otherwise
+    */
+  bool are_final_stats_emitted() const;
+
+  /**
    * @brief Wait for auto-stop signal (if max_duration is set)
    *
    * @param timeout Maximum time to wait (default: wait indefinitely)
@@ -156,6 +163,9 @@ public:
     /// @brief Episodes finished this session
     uint64_t total_episodes_completed;
 
+    /// @brief Duration of episode recording
+    std::optional<double> recording_duration_s;
+
     /// @brief Duration of episode preprocessing (seconds)
     std::optional<double> preprocessing_duration_s;
 
@@ -198,6 +208,12 @@ private:
   /// @brief Duration of last shutdown phase (seconds)
   double postprocess_duration_s_{0.0};
 
+  /// @brief Final elapsed time when episode stopped
+  std::chrono::duration<double> final_elapsed_{0};
+
+  /// @brief Final record count when episode stopped
+  uint64_t final_records_written_{0};
+
   /// @brief Monitoring thread for duration-based auto-stop
   std::thread monitor_thread_;
 
@@ -206,6 +222,9 @@ private:
 
   /// @brief Flag indicating that auto-stop was triggered by monitor thread
   std::atomic<bool> auto_stop_triggered_{false};
+
+  /// @brief Flag indicating that episode final statistics were emitted
+  mutable std::atomic<bool> stats_emitted_{false};
 
   /// @brief Condition variable for auto-stop signaling
   std::condition_variable auto_stop_cv_;

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -183,6 +183,30 @@ public:
    */
   void print_episode_header();
 
+  /**
+  * @brief Print a single line of episode statistics (updates in place)
+  *
+  * Uses carriage return to overwrite the previous line for smooth updates.
+  *
+  * @param stats Session manager statistics
+  */
+  void print_stats_line(const Stats& stats);
+
+  /**
+  * @brief Pausable sleep that respects stop requests
+  *
+  * Sleeps for the specified duration but checks g_stop_requested
+  * periodically and returns early if stop is requested.
+  * Also, keeps a track of stats while monitoring the episode.
+  *
+  * @param update_interval How often to print stats
+  * @param sleep_interval How long to sleep between checks
+  * @return true if completed normally, false if interrupted by stop request
+  */
+  Stats monitor_episode(
+    std::chrono::duration<double> update_interval = std::chrono::milliseconds(500),
+    std::chrono::duration<double> sleep_interval = std::chrono::milliseconds(100));
+
 private:
   /// @brief Configuration
   std::shared_ptr<trossen::configuration::SessionManagerConfig> cfg_;

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -89,6 +89,9 @@ bool SessionManager::start_episode() {
     std::cerr << "Episode already active. Call stop_episode() first." << std::endl;
     return false;
   }
+  // Make sure stats_emitted_ is reset for new episode
+  stats_emitted_.store(false);
+
   // Start a timer to measure pre-processing duration
   auto prep_start_time = std::chrono::steady_clock::now();
 
@@ -222,6 +225,12 @@ void SessionManager::stop_episode() {
     scheduler_.reset();
   }
 
+  // Get the final record count before stopping sink
+  if (current_sink_) {
+    final_records_written_ = current_sink_->processed_count() - episode_start_record_count_;
+  } else {
+    final_records_written_ = 0;
+  }
   // Stop sink - drain queue and write all pending records
   if (current_sink_) {
     current_sink_->stop();
@@ -263,6 +272,10 @@ bool SessionManager::is_episode_active() const {
   return episode_active_;
 }
 
+bool SessionManager::are_final_stats_emitted() const {
+  return stats_emitted_.load();
+}
+
 bool SessionManager::wait_for_auto_stop(std::chrono::milliseconds timeout) {
   std::unique_lock<std::mutex> lock(auto_stop_mutex_);
 
@@ -296,7 +309,7 @@ SessionManager::Stats SessionManager::stats() const {
   s.current_episode_index = next_episode_index_;
   s.episode_active = episode_active_;
 
-  if (episode_active_) {
+  if (episode_active_ || !stats_emitted_.load()) {
     auto now = std::chrono::steady_clock::now();
     s.elapsed = std::chrono::duration<double>(now - episode_start_time_);
 
@@ -316,13 +329,18 @@ SessionManager::Stats SessionManager::stats() const {
       uint64_t current_count = current_sink_->processed_count();
       s.records_written_current = current_count - episode_start_record_count_;
     } else {
-      s.records_written_current = 0;
+      s.records_written_current = final_records_written_;
     }
     if (preprocessing_duration_s_ > 0.0) {
       s.preprocessing_duration_s = preprocessing_duration_s_;
     }
     if (postprocess_duration_s_ > 0.0) {
       s.postprocess_duration_s = postprocess_duration_s_;
+    }
+    if (!stats_emitted_.load() && !episode_active_) {
+      s.recording_duration_s = s.elapsed.count() -
+        (preprocessing_duration_s_ + postprocess_duration_s_);
+      stats_emitted_.store(true);
     }
   } else {
     s.elapsed = std::chrono::duration<double>(0);
@@ -367,11 +385,6 @@ void SessionManager::monitor_duration() {
 
       // Stop monitoring first
       monitoring_active_ = false;
-
-      // Detach this thread so it can clean itself up
-      if (monitor_thread_.joinable()) {
-        monitor_thread_.detach();
-      }
 
       // Call stop_episode() directly from this thread
       stop_episode();

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -414,4 +414,39 @@ void SessionManager::print_episode_header() {
   std::cout << "╚════════════════════════════════════════════════════════════╝\n";
 }
 
+void SessionManager::print_stats_line(const SessionManager::Stats& stats) {
+  std::cout << "\r[Episode " << stats.current_episode_index << "] "
+            << "Elapsed: " << std::fixed << std::setprecision(1) << stats.elapsed.count() << "s"
+            << " | Records: " << stats.records_written_current;
+
+  if (stats.remaining.has_value() && stats.remaining->count() > 0) {
+    std::cout << " | Remaining: " << std::fixed << std::setprecision(1)
+              << stats.remaining->count() << "s";
+  } else {
+    std::cout << " | Duration: unlimited";
+  }
+
+  std::cout << std::flush;
+}
+
+SessionManager::Stats SessionManager::monitor_episode(
+  std::chrono::duration<double> update_interval,
+  std::chrono::duration<double> sleep_interval)
+{
+  auto last_update = std::chrono::steady_clock::now();
+  SessionManager::Stats last_stats;
+
+  while (!are_final_stats_emitted()) {
+    auto now = std::chrono::steady_clock::now();
+    if (now - last_update >= update_interval) {
+      SessionManager::Stats stats_ = stats();
+      print_stats_line(stats_);
+      last_stats = stats_;
+      last_update = now;
+    }
+    std::this_thread::sleep_for(sleep_interval);
+  }
+  return last_stats;
+}
+
 }  // namespace trossen::runtime

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -49,11 +49,17 @@ SessionManager::SessionManager(){
 }
 
 SessionManager::~SessionManager() {
-  // Ensure monitoring thread is stopped
+  // Ensure monitoring threads are stopped
   monitoring_active_ = false;
   if (monitor_thread_.joinable()) {
     monitor_thread_.join();
   }
+
+  async_monitoring_active_ = false;
+  if (async_monitor_thread_.joinable()) {
+    async_monitor_thread_.join();
+  }
+
   shutdown();
 }
 
@@ -266,6 +272,15 @@ void SessionManager::stop_episode() {
     }
   }
   auto_stop_cv_.notify_all();
+
+  // Invoke callback if set (after episode is fully stopped and stats are available)
+  // Note: We do this outside the main lock to avoid blocking episode operations
+  // The callback will call stats() which has its own locking
+  if (episode_complete_callback_) {
+    // Get final stats to pass to callback
+    Stats final_stats = stats();
+    episode_complete_callback_(final_stats);
+  }
 }
 
 bool SessionManager::is_episode_active() const {
@@ -354,6 +369,11 @@ SessionManager::Stats SessionManager::stats() const {
   return s;
 }
 
+void SessionManager::set_episode_complete_callback(EpisodeCompleteCallback callback) {
+  std::lock_guard<std::mutex> lock(episode_mutex_);
+  episode_complete_callback_ = std::move(callback);
+}
+
 std::shared_ptr<io::Backend> SessionManager::create_backend(
   const ProducerMetadataList& producer_metadatas)
 {
@@ -431,7 +451,8 @@ void SessionManager::print_stats_line(const SessionManager::Stats& stats) {
 
 SessionManager::Stats SessionManager::monitor_episode(
   std::chrono::duration<double> update_interval,
-  std::chrono::duration<double> sleep_interval)
+  std::chrono::duration<double> sleep_interval,
+  bool print_stats)
 {
   auto last_update = std::chrono::steady_clock::now();
   SessionManager::Stats last_stats;
@@ -440,13 +461,53 @@ SessionManager::Stats SessionManager::monitor_episode(
     auto now = std::chrono::steady_clock::now();
     if (now - last_update >= update_interval) {
       SessionManager::Stats stats_ = stats();
-      print_stats_line(stats_);
+      if (print_stats) {
+        print_stats_line(stats_);
+      }
       last_stats = stats_;
       last_update = now;
     }
     std::this_thread::sleep_for(sleep_interval);
   }
   return last_stats;
+}
+
+void SessionManager::start_async_monitoring(
+  std::chrono::duration<double> update_interval,
+  std::chrono::duration<double> sleep_interval,
+  bool print_stats)
+{
+  // Stop any existing async monitoring
+  if (async_monitoring_active_) {
+    get_async_monitor_stats();
+  }
+
+  async_monitoring_active_ = true;
+  async_monitor_thread_ = std::thread([this, update_interval, sleep_interval, print_stats]() {
+    // Run monitor_episode in background thread
+    Stats final_stats = monitor_episode(update_interval, sleep_interval, print_stats);
+
+    // Store final stats
+    {
+      std::lock_guard<std::mutex> lock(async_monitor_mutex_);
+      async_monitor_final_stats_ = final_stats;
+    }
+
+    async_monitoring_active_ = false;
+  });
+}
+
+SessionManager::Stats SessionManager::get_async_monitor_stats() {
+  // Stop async monitoring if active
+  async_monitoring_active_ = false;
+
+  if (async_monitor_thread_.joinable()) {
+    async_monitor_thread_.join();
+  }
+
+  // Return the final stats
+  std::lock_guard<std::mutex> lock(async_monitor_mutex_);
+  return async_monitor_final_stats_;
 }
 
 }  // namespace trossen::runtime

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -46,29 +46,6 @@ SessionManager::SessionManager(){
     std::cout << "Backend Type: (none)" << std::endl;
   }
   std::cout << "==========================================================" << std::endl;
-  // TODO(shantanuparab-tr): Move this logic to a backend utility function
-  // Validate required configuration
-  // if (cfg_->base_path.empty()) {
-  //   throw std::invalid_argument("SessionConfig::base_path cannot be empty");
-  // }
-
-  // // Create base directory if it doesn't exist
-  // if (!std::filesystem::exists(cfg_->base_path)) {
-  //   // TODO(lukeschmitt-tr): Handle potential errors
-  //   std::filesystem::create_directories(cfg_->base_path);
-  // }
-
-  // // Auto-generate dataset_id if not provided
-  // if (cfg_->dataset_id.empty()) {
-  //   // TODO(lukeschmitt-tr): Generate UUID (for now, use timestamp-based ID)
-  //   auto now = std::chrono::system_clock::now();
-  //   auto time_t_now = std::chrono::system_clock::to_time_t(now);
-  //   std::ostringstream oss;
-  //   // Format: dataset_YYYYMMDD_HHMMSS in local time
-  //   oss << "dataset_" << std::put_time(std::localtime(&time_t_now), "%Y%m%d_%H%M%S");
-  //   cfg_->dataset_id = oss.str();
-  //   std::cout << "Auto-generated dataset_id: " << cfg_->dataset_id << std::endl;
-  // }
 }
 
 SessionManager::~SessionManager() {

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -361,4 +361,25 @@ void SessionManager::monitor_duration() {
   }
 }
 
+void SessionManager::print_episode_header() {
+  std::cout << "\n╔════════════════════════════════════════════════════════════╗\n";
+  std::cout << "║  Episode " << next_episode_index_ << " | Target Duration: ";
+  if (cfg_->max_duration.has_value()) {
+    std::cout << cfg_->max_duration->count() << "s";
+  } else {
+    std::cout << "unlimited";
+  }
+
+  // Calculate padding to align right edge
+  const std::size_t episode_len = std::to_string(next_episode_index_).length();
+  const std::size_t duration_len = cfg_->max_duration.has_value()
+    ? std::to_string(cfg_->max_duration->count()).length()
+    : static_cast<std::size_t>(9);
+  const std::size_t total_len = episode_len + duration_len;
+  const std::size_t padding_len = (41 > total_len) ? (41 - total_len) : 0;
+  std::string padding(padding_len, ' ');
+  std::cout << padding << "║\n";
+  std::cout << "╚════════════════════════════════════════════════════════════╝\n";
+}
+
 }  // namespace trossen::runtime

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -89,6 +89,8 @@ bool SessionManager::start_episode() {
     std::cerr << "Episode already active. Call stop_episode() first." << std::endl;
     return false;
   }
+  // Start a timer to measure pre-processing duration
+  auto prep_start_time = std::chrono::steady_clock::now();
 
   ProducerMetadataList producer_metadata;
 
@@ -182,13 +184,19 @@ bool SessionManager::start_episode() {
     monitoring_active_ = true;
     monitor_thread_ = std::thread([this]() { monitor_duration(); });
   }
-
+  // Measure and report pre-processing duration
+  auto prep_end_time = std::chrono::steady_clock::now();
+  preprocessing_duration_s_ =
+    std::chrono::duration<double>(prep_end_time - prep_start_time).count();
   std::cout << "Episode " << next_episode_index_ << " started." << std::endl;
 
   return true;
 }
 
 void SessionManager::stop_episode() {
+  // Start timer to measure shutdown duration
+  auto shutdown_start_time = std::chrono::steady_clock::now();
+
   // First, signal monitoring thread to stop (if any)
   monitoring_active_ = false;
 
@@ -232,6 +240,10 @@ void SessionManager::stop_episode() {
   ++total_episodes_completed_;
   ++next_episode_index_;
 
+  // Measure and report shutdown duration
+  auto shutdown_end_time = std::chrono::steady_clock::now();
+  auto shutdown_duration = shutdown_end_time - shutdown_start_time;
+  postprocess_duration_s_ = std::chrono::duration<double>(shutdown_duration).count();
   std::cout << "\nEpisode stopped. Total completed: " << total_episodes_completed_
             << ", Next index: " << next_episode_index_ << std::endl;
 
@@ -306,6 +318,12 @@ SessionManager::Stats SessionManager::stats() const {
     } else {
       s.records_written_current = 0;
     }
+    if (preprocessing_duration_s_ > 0.0) {
+      s.preprocessing_duration_s = preprocessing_duration_s_;
+    }
+    if (postprocess_duration_s_ > 0.0) {
+      s.postprocess_duration_s = postprocess_duration_s_;
+    }
   } else {
     s.elapsed = std::chrono::duration<double>(0);
     s.remaining = std::nullopt;
@@ -313,6 +331,7 @@ SessionManager::Stats SessionManager::stats() const {
   }
 
   s.total_episodes_completed = total_episodes_completed_;
+
 
   return s;
 }


### PR DESCRIPTION
### **Summary**

* Centralized episode lifecycle control, monitoring, and statistics inside `SessionManager`
* Simplified recording demos by removing redundant episode limits, timing logic, and utilities
* Introduced asynchronous monitoring support with richer session statistics
* Improved accuracy and consistency of episode duration and rate tracking
* Enhanced episode header and summary reporting with structured, detailed stats
* Refactored configuration handling with sensible defaults and auto-generated dataset IDs
* Cleaned up backend configuration by moving backend-specific constants to their respective config files

---

This change establishes `SessionManager` as the single authority for session control and monitoring, simplifies demo code paths, and provides a cleaner, more extensible foundation for UI-driven workflows and future session orchestration.
