### PR TITLE
working teleop demos

### DIFF
--- a/apps/trossen_sdk_ui/backend/data.json
+++ b/apps/trossen_sdk_ui/backend/data.json
@@ -1,5 +1,118 @@
 {
-  "activities": [],
+  "activities": [
+    {
+      "description": "Session created with 2 episodes @ 10s each",
+      "event_type": "created",
+      "session_id": "1767738308213",
+      "session_name": "Demo 1",
+      "timestamp": "1767738308216"
+    },
+    {
+      "description": "Session created with 2 episodes @ 10s each",
+      "event_type": "created",
+      "session_id": "1767738348637",
+      "session_name": "Demo 2",
+      "timestamp": "1767738348639"
+    },
+    {
+      "description": "Session created with 2 episodes @ 10s each",
+      "event_type": "created",
+      "session_id": "1767738366589",
+      "session_name": "Demo 3",
+      "timestamp": "1767738366591"
+    },
+    {
+      "description": "Recording started - teleop_widowx",
+      "event_type": "started",
+      "session_id": "1767738308213",
+      "session_name": "Demo 1",
+      "timestamp": "1767741705744"
+    },
+    {
+      "description": "Recording started - teleop_widowx",
+      "event_type": "started",
+      "session_id": "1767738308213",
+      "session_name": "Demo 1",
+      "timestamp": "1767742144424"
+    },
+    {
+      "description": "All 2 episodes completed",
+      "event_type": "completed",
+      "session_id": "1767738308213",
+      "session_name": "Demo 1",
+      "timestamp": "1767742167846"
+    },
+    {
+      "description": "Session data processed and finalized",
+      "event_type": "processed",
+      "session_id": "1767738308213",
+      "session_name": "Demo 1",
+      "timestamp": "1767742176252"
+    },
+    {
+      "description": "Recording started - teleop_widowx",
+      "event_type": "started",
+      "session_id": "1767738308213",
+      "session_name": "Demo 1",
+      "timestamp": "1767742671445"
+    },
+    {
+      "description": "All 2 episodes completed",
+      "event_type": "completed",
+      "session_id": "1767738308213",
+      "session_name": "Demo 1",
+      "timestamp": "1767742696570"
+    },
+    {
+      "description": "Session data processed and finalized",
+      "event_type": "processed",
+      "session_id": "1767738308213",
+      "session_name": "Demo 1",
+      "timestamp": "1767742707815"
+    },
+    {
+      "description": "Recording started - teleop_widowx_bimanual",
+      "event_type": "started",
+      "session_id": "1767738348637",
+      "session_name": "Demo 2",
+      "timestamp": "1767742729102"
+    },
+    {
+      "description": "All 2 episodes completed",
+      "event_type": "completed",
+      "session_id": "1767738348637",
+      "session_name": "Demo 2",
+      "timestamp": "1767742755219"
+    },
+    {
+      "description": "Session data processed and finalized",
+      "event_type": "processed",
+      "session_id": "1767738348637",
+      "session_name": "Demo 2",
+      "timestamp": "1767742767400"
+    },
+    {
+      "description": "Recording started - teleop_widowx_bimanual",
+      "event_type": "started",
+      "session_id": "1767738348637",
+      "session_name": "Demo 2",
+      "timestamp": "1767743122256"
+    },
+    {
+      "description": "All 2 episodes completed",
+      "event_type": "completed",
+      "session_id": "1767738348637",
+      "session_name": "Demo 2",
+      "timestamp": "1767743144276"
+    },
+    {
+      "description": "Session data processed and finalized",
+      "event_type": "processed",
+      "session_id": "1767738348637",
+      "session_name": "Demo 2",
+      "timestamp": "1767743150553"
+    }
+  ],
   "arms": [
     {
       "end_effector": "follower",
@@ -96,81 +209,122 @@
   ],
   "producers": [
     {
-      "camera_name": "bottom cam",
-      "device_index": 24,
-      "encoding": "bgr8",
+      "camera_id": "cc4a4734cfda2daa",
       "enforce_requested_fps": true,
-      "fps": 30,
-      "height": 480,
       "id": "cc4a4734cfda2daa",
       "name": "bottom cam",
       "type": "opencv_camera",
       "use_device_time": false,
-      "width": 640
+      "warmup_seconds": 0.0
     },
     {
-      "camera_name": "top cam",
-      "device_index": 12,
-      "encoding": "bgr8",
+      "camera_id": "7656a72361e3d6db",
       "enforce_requested_fps": true,
-      "fps": 30,
-      "height": 480,
       "id": "7656a72361e3d6db",
       "name": "top cam",
       "type": "opencv_camera",
       "use_device_time": false,
-      "width": 640
+      "warmup_seconds": 0.0
     },
     {
-      "camera_name": "left arm cam",
-      "device_index": 18,
-      "encoding": "bgr8",
+      "camera_id": "66055ee4fb432afb",
       "enforce_requested_fps": true,
-      "fps": 30,
-      "height": 480,
       "id": "66055ee4fb432afb",
       "name": "left arm cam",
       "type": "opencv_camera",
       "use_device_time": false,
-      "width": 640
+      "warmup_seconds": 0.0
     },
     {
-      "follower_name": "widowx Follower Right",
-      "id": "eab888cdc0e4576d",
-      "leader_name": "widowx Leader Right",
+      "follower_id": "654ff638792a83e6",
+      "id": "eab888cdc0e4576d_654ff638792a83e6_teleop",
+      "leader_id": "eab888cdc0e4576d",
       "name": "widowx Leader Right_widowx Follower Right_teleop",
       "type": "teleop_widowx_arm",
       "use_device_time": true
     },
     {
-      "follower_name": "widowx Follower Left",
-      "id": "b4a9217fa0ea9a64",
-      "leader_name": "widowx Leader Left",
+      "follower_id": "7c35b061a0b6310f",
+      "id": "b4a9217fa0ea9a64_7c35b061a0b6310f_teleop",
+      "leader_id": "b4a9217fa0ea9a64",
       "name": "widowx Leader Left_widowx Follower Left_teleop",
       "type": "teleop_widowx_arm",
       "use_device_time": true
     },
     {
-      "camera_name": "right arm cam",
-      "device_index": 6,
-      "encoding": "bgr8",
+      "camera_id": "0a2795068e060269",
       "enforce_requested_fps": true,
-      "fps": 30,
-      "height": 480,
       "id": "0a2795068e060269",
       "name": "right arm cam",
       "type": "opencv_camera",
       "use_device_time": false,
-      "width": 640
+      "warmup_seconds": 0.0
+    },
+    {
+      "follower_id": "2d6619c09ef2b6d8",
+      "id": "cd7b9f682cea7c67_2d6619c09ef2b6d8_teleop",
+      "leader_id": "cd7b9f682cea7c67",
+      "name": "so101 Leader_so101 Follower_teleop",
+      "type": "teleop_so101_arm",
+      "use_device_time": true
     }
   ],
-  "sessions": [],
+  "sessions": [
+    {
+      "action": "teleop_widowx",
+      "backend_type": "mcap",
+      "cameras": [],
+      "episode_duration": 10.0,
+      "id": "1767738308213",
+      "name": "Demo 1",
+      "num_episodes": 2,
+      "robots": [],
+      "system_id": "1767737254566"
+    },
+    {
+      "action": "teleop_widowx_bimanual",
+      "backend_type": "mcap",
+      "cameras": [],
+      "episode_duration": 10.0,
+      "id": "1767738348637",
+      "name": "Demo 2",
+      "num_episodes": 2,
+      "robots": [],
+      "system_id": "1767738229980"
+    },
+    {
+      "action": "teleop_so101",
+      "backend_type": "mcap",
+      "cameras": [],
+      "episode_duration": 10.0,
+      "id": "1767738366589",
+      "name": "Demo 3",
+      "num_episodes": 2,
+      "robots": [],
+      "system_id": "1767738270628"
+    }
+  ],
   "systems": [
     {
       "id": "1767737254566",
       "name": "Demo 1 widowx teleop",
       "producers": [
-        "eab888cdc0e4576d"
+        "eab888cdc0e4576d_654ff638792a83e6_teleop"
+      ]
+    },
+    {
+      "id": "1767738229980",
+      "name": "Demo 2 bimanual teleop",
+      "producers": [
+        "b4a9217fa0ea9a64_7c35b061a0b6310f_teleop",
+        "eab888cdc0e4576d_654ff638792a83e6_teleop"
+      ]
+    },
+    {
+      "id": "1767738270628",
+      "name": "Demo 3 so101 teleop",
+      "producers": [
+        "cd7b9f682cea7c67_2d6619c09ef2b6d8_teleop"
       ]
     }
   ]

--- a/apps/trossen_sdk_ui/backend/include/backend/config_manager.hpp
+++ b/apps/trossen_sdk_ui/backend/include/backend/config_manager.hpp
@@ -60,11 +60,12 @@ struct HardwareSystem {
 // Producer configuration
 struct ProducerConfig {
     std::string id;    // Unique identifier (also used as stream_id)
+    std::string name;  // Display name for frontend
     std::string type;  // Producer type
-    std::string leader_name;  // For teleop producers
-    std::string follower_name;  // For teleop producers
-    std::string camera_name;  // For camera producers (references CameraConfig.id)
-    std::string arm_name;  // For arm producers (references ArmConfig.id)
+    std::string leader_id;  // For teleop producers (references ArmConfig.id)
+    std::string follower_id;  // For teleop producers (references ArmConfig.id)
+    std::string camera_id;  // For camera producers (references CameraConfig.id)
+    std::string arm_id;  // For arm producers (references ArmConfig.id)
     bool use_device_time;
     bool enforce_requested_fps;
     double warmup_seconds;

--- a/apps/trossen_sdk_ui/backend/include/backend/session_actions.hpp
+++ b/apps/trossen_sdk_ui/backend/include/backend/session_actions.hpp
@@ -22,7 +22,7 @@ namespace trossen::backend {
 enum class SessionAction {
     TELEOP_SO101,
     TELEOP_WIDOWX,
-    RECORD_CAMERAS_ONLY
+    TELEOP_WIDOWX_BIMANUAL
 };
 
 // Active session state
@@ -62,6 +62,11 @@ bool setup_so101_teleop(
     std::string& error);
 
 bool setup_widowx_teleop(
+    std::shared_ptr<ActiveSession> active_session,
+    const std::string& system_id,
+    std::string& error);
+
+bool setup_widowx_bimanual_teleop(
     std::shared_ptr<ActiveSession> active_session,
     const std::string& system_id,
     std::string& error);

--- a/apps/trossen_sdk_ui/backend/main.cpp
+++ b/apps/trossen_sdk_ui/backend/main.cpp
@@ -318,7 +318,7 @@ int main() {
 
                 std::string camera_name = request_data["camera_name"];
 
-                // Find camera by name in cameras array
+                // Find camera by name in cameras array and save its ID
                 bool camera_found = false;
                 for (const auto& cam : data["cameras"]) {
                     if (cam.contains("name") && cam["name"] == camera_name) {
@@ -326,7 +326,7 @@ int main() {
                         producer_config["id"] = cam["id"];
                         producer_config["type"] = producer_type;
                         producer_config["name"] = camera_name;
-                        producer_config["camera_name"] = camera_name;
+                        producer_config["camera_id"] = cam["id"];  // Save camera ID, not name
 
                         // Copy relevant fields from camera config
                         if (cam.contains("device_index")) {
@@ -414,7 +414,7 @@ int main() {
                 producer_config["id"] = arm_id;
                 producer_config["type"] = producer_type;
                 producer_config["name"] = arm_name;
-                producer_config["arm_name"] = arm_name;
+                producer_config["arm_id"] = arm_id;  // Save arm ID, not name
                 producer_config["use_device_time"] = true;
             } else if (producer_type == "teleop_widowx_arm" ||
                        producer_type == "teleop_so101_arm") {
@@ -432,10 +432,11 @@ int main() {
                 std::string leader_name = request_data["leader_name"];
                 std::string follower_name = request_data["follower_name"];
 
-                // Find leader and follower arms
+                // Find leader and follower arms and get their IDs
                 bool leader_found = false;
                 bool follower_found = false;
                 std::string leader_id;
+                std::string follower_id;
 
                 for (const auto& arm : data["arms"]) {
                     if (arm.contains("name")) {
@@ -445,6 +446,7 @@ int main() {
                         }
                         if (arm["name"] == follower_name) {
                             follower_found = true;
+                            follower_id = arm["id"];
                         }
                     }
                 }
@@ -466,12 +468,12 @@ int main() {
                     return;
                 }
 
-                // Use leader arm's ID as producer ID
-                producer_config["id"] = leader_id;
+                // Use combined IDs as producer ID for uniqueness
+                producer_config["id"] = leader_id + "_" + follower_id + "_teleop";
                 producer_config["type"] = producer_type;
                 producer_config["name"] = leader_name + "_" + follower_name + "_teleop";
-                producer_config["leader_name"] = leader_name;
-                producer_config["follower_name"] = follower_name;
+                producer_config["leader_id"] = leader_id;
+                producer_config["follower_id"] = follower_id;
                 producer_config["use_device_time"] = true;
             } else {
                 res.status = 400;
@@ -659,17 +661,36 @@ int main() {
                 updated_config["use_device_time"] = true;
             } else if (producer_type == "teleop_widowx_arm" ||
                        producer_type == "teleop_so101_arm") {
-                // Handle teleop producers
+                // Handle teleop producers - need to look up IDs
                 std::string leader_name = request_data.contains("leader_name")
                     ? request_data["leader_name"].get<std::string>()
-                    : existing_producer.value("leader_name", "");
+                    : "";
                 std::string follower_name = request_data.contains("follower_name")
                     ? request_data["follower_name"].get<std::string>()
-                    : existing_producer.value("follower_name", "");
+                    : "";
 
-                updated_config["leader_name"] = leader_name;
-                updated_config["follower_name"] = follower_name;
-                updated_config["name"] = leader_name + "_" + follower_name + "_teleop";
+                // Find leader and follower IDs from arms array
+                std::string leader_id = existing_producer.value("leader_id", "");
+                std::string follower_id = existing_producer.value("follower_id", "");
+
+                if (!leader_name.empty() || !follower_name.empty()) {
+                    for (const auto& arm : data["arms"]) {
+                        if (arm.contains("name")) {
+                            if (!leader_name.empty() && arm["name"] == leader_name) {
+                                leader_id = arm["id"];
+                            }
+                            if (!follower_name.empty() && arm["name"] == follower_name) {
+                                follower_id = arm["id"];
+                            }
+                        }
+                    }
+                }
+
+                updated_config["leader_id"] = leader_id;
+                updated_config["follower_id"] = follower_id;
+                if (!leader_name.empty() && !follower_name.empty()) {
+                    updated_config["name"] = leader_name + "_" + follower_name + "_teleop";
+                }
                 updated_config["use_device_time"] = true;
             }
 
@@ -1154,8 +1175,8 @@ int main() {
                             active_session, session.system_id, setup_error);
                         break;
 
-                    case trossen::backend::SessionAction::RECORD_CAMERAS_ONLY:
-                        setup_success = trossen::backend::setup_camera_recording(
+                    case trossen::backend::SessionAction::TELEOP_WIDOWX_BIMANUAL:
+                        setup_success = trossen::backend::setup_widowx_bimanual_teleop(
                             active_session, session.system_id, setup_error);
                         break;
 
@@ -1544,7 +1565,7 @@ int main() {
         try {
             int index = std::stoi(req.matches[1]);
             json request_data = json::parse(req.body);
-            std::string arm_id = request_data["name"];
+            std::string arm_id = request_data["id"];  // Use ID, not name
 
             std::string error;
             if (trossen::backend::connect_arm(
@@ -1579,7 +1600,7 @@ int main() {
         try {
             int index = std::stoi(req.matches[1]);
             json request_data = json::parse(req.body);
-            std::string arm_id = request_data["name"];
+            std::string arm_id = request_data["id"];  // Use ID, not name
 
             std::string error;
             if (trossen::backend::disconnect_arm(arm_id, error)) {
@@ -1611,10 +1632,30 @@ int main() {
     // GET /hardware/status
     svr.Get("/hardware/status", [](const Request&, Response& res) {
         try {
+            // Get all hardware status keyed by ID
             json all_statuses = trossen::backend::get_all_hardware_status();
-            res.set_content(all_statuses.dump(2), "application/json");
+
+            // Load configurations to map IDs to names
+            auto configs = config_manager.get_configurations();
+            json status_by_name;
+
+            // Map camera status by name
+            for (const auto& camera : configs.cameras) {
+                if (all_statuses.contains(camera.id)) {
+                    status_by_name[camera.name] = all_statuses[camera.id];
+                }
+            }
+
+            // Map arm status by name
+            for (const auto& arm : configs.arms) {
+                if (all_statuses.contains(arm.id)) {
+                    status_by_name[arm.name] = all_statuses[arm.id];
+                }
+            }
+
+            res.set_content(status_by_name.dump(2), "application/json");
             std::cout << "GET /hardware/status - Retrieved status for "
-                      << all_statuses.size()
+                      << status_by_name.size()
                       << " hardware components" << std::endl;
         } catch (const std::exception& e) {
             res.status = 500;
@@ -1634,11 +1675,6 @@ int main() {
                 json data;
                 file >> data;
                 file.close();
-
-                // Ensure producers array exists
-                if (!data.contains("producers")) {
-                    data["producers"] = json::array();
-                }
 
                 res.set_content(data.dump(2), "application/json");
                 std::cout

--- a/apps/trossen_sdk_ui/backend/src/config_manager.cpp
+++ b/apps/trossen_sdk_ui/backend/src/config_manager.cpp
@@ -111,13 +111,14 @@ HardwareSystem HardwareSystem::from_json(const nlohmann::json& j) {
 
 // ProducerConfig JSON conversion
 nlohmann::json ProducerConfig::to_json() const {
-    return {
+    return nlohmann::json{
         {"id", id},
+        {"name", name},
         {"type", type},
-        {"leader_name", leader_name},
-        {"follower_name", follower_name},
-        {"camera_name", camera_name},
-        {"arm_name", arm_name},
+        {"leader_id", leader_id},
+        {"follower_id", follower_id},
+        {"camera_id", camera_id},
+        {"arm_id", arm_id},
         {"use_device_time", use_device_time},
         {"enforce_requested_fps", enforce_requested_fps},
         {"warmup_seconds", warmup_seconds}
@@ -131,11 +132,12 @@ ProducerConfig ProducerConfig::from_json(const nlohmann::json& j) {
     const nlohmann::json& cfg = j.contains("config") ? j["config"] : j;
 
     config.id = j.value("id", cfg.value("id", ""));
+    config.name = j.value("name", cfg.value("name", ""));
     config.type = j.value("type", "");  // Type is at top level
-    config.leader_name = cfg.value("leader_name", "");
-    config.follower_name = cfg.value("follower_name", "");
-    config.camera_name = cfg.value("camera_name", "");
-    config.arm_name = cfg.value("arm_name", "");
+    config.leader_id = cfg.value("leader_id", "");
+    config.follower_id = cfg.value("follower_id", "");
+    config.camera_id = cfg.value("camera_id", "");
+    config.arm_id = cfg.value("arm_id", "");
     config.use_device_time = cfg.value("use_device_time", false);
     config.enforce_requested_fps = cfg.value("enforce_requested_fps", true);
     config.warmup_seconds = cfg.value("warmup_seconds", 2.0);
@@ -256,9 +258,17 @@ Configurations Configurations::from_json(const nlohmann::json& j) {
     }
 
     if (j.contains("producers") && j["producers"].is_array()) {
+        std::cout << "DEBUG: Found producers array with " << j["producers"].size()
+                  << " items" << std::endl;
         for (const auto& prod_json : j["producers"]) {
-            configs.producers.push_back(ProducerConfig::from_json(prod_json));
+            auto prod = ProducerConfig::from_json(prod_json);
+            std::cout << "Loading producer: id='" << prod.id
+                      << "', type='" << prod.type
+                      << "', name='" << prod.name << "'" << std::endl;
+            configs.producers.push_back(prod);
         }
+    } else {
+        std::cout << "DEBUG: No producers array found in JSON or not an array" << std::endl;
     }
 
     if (j.contains("sessions") && j["sessions"].is_array()) {
@@ -886,6 +896,7 @@ bool ConfigManager::load_from_file() {
         configs_ = Configurations::from_json(j);
         std::cout << "Loaded " << configs_.cameras.size() << " cameras, "
                   << configs_.arms.size() << " arms, "
+                  << configs_.producers.size() << " producers, "
                   << configs_.systems.size() << " systems, and "
                   << configs_.sessions.size() << " sessions from "
                   << data_file_ << std::endl;

--- a/apps/trossen_sdk_ui/backend/src/session_actions.cpp
+++ b/apps/trossen_sdk_ui/backend/src/session_actions.cpp
@@ -9,6 +9,7 @@
 #include "trossen_sdk/hw/arm/teleop_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/so101_teleop_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/arm_producer.hpp"
+#include "trossen_sdk/hw/camera/opencv_producer.hpp"
 #include <iostream>
 #include <algorithm>
 
@@ -19,7 +20,7 @@ namespace trossen::backend {
 SessionAction string_to_action(const std::string& action_str) {
     if (action_str == "teleop_so101") return SessionAction::TELEOP_SO101;
     if (action_str == "teleop_widowx") return SessionAction::TELEOP_WIDOWX;
-    if (action_str == "record_cameras") return SessionAction::RECORD_CAMERAS_ONLY;
+    if (action_str == "teleop_widowx_bimanual") return SessionAction::TELEOP_WIDOWX_BIMANUAL;
 
     throw std::runtime_error("Unknown session action: " + action_str);
 }
@@ -28,7 +29,7 @@ std::string action_to_string(SessionAction action) {
     switch (action) {
         case SessionAction::TELEOP_SO101: return "teleop_so101";
         case SessionAction::TELEOP_WIDOWX: return "teleop_widowx";
-        case SessionAction::RECORD_CAMERAS_ONLY: return "record_cameras";
+        case SessionAction::TELEOP_WIDOWX_BIMANUAL: return "teleop_widowx_bimanual";
         default: return "unknown";
     }
 }
@@ -86,21 +87,21 @@ bool validate_hardware_for_action(
                     so101_count++;
 
                     // Check that both leader and follower are configured
-                    if (prod.leader_name.empty() || prod.follower_name.empty()) {
+                    if (prod.leader_id.empty() || prod.follower_id.empty()) {
                         error = "SO101 teleop producer must have both "
-                                "leader_name and follower_name configured";
+                                "leader_id and follower_id configured";
                         return false;
                     }
 
-                    // Verify the arms are connected
-                    if (g_arm_status.find(prod.leader_name) == g_arm_status.end() ||
-                        !g_arm_status[prod.leader_name].is_connected) {
-                        error = "Leader arm not connected: " + prod.leader_name;
+                    // Verify the arms are connected by ID
+                    if (g_arm_status.find(prod.leader_id) == g_arm_status.end() ||
+                        !g_arm_status[prod.leader_id].is_connected) {
+                        error = "Leader arm not connected: " + prod.leader_id;
                         return false;
                     }
-                    if (g_arm_status.find(prod.follower_name) == g_arm_status.end() ||
-                        !g_arm_status[prod.follower_name].is_connected) {
-                        error = "Follower arm not connected: " + prod.follower_name;
+                    if (g_arm_status.find(prod.follower_id) == g_arm_status.end() ||
+                        !g_arm_status[prod.follower_id].is_connected) {
+                        error = "Follower arm not connected: " + prod.follower_id;
                         return false;
                     }
 
@@ -126,26 +127,30 @@ bool validate_hardware_for_action(
             int widowx_count = 0;
             bool has_valid_config = false;
 
+            std::cout << "  Validating TELEOP_WIDOWX: checking "
+                      << system_producers.size() << " producers" << std::endl;
             for (const auto& prod : system_producers) {
-                if (prod.type == "teleop_arm") {
+                std::cout << "    Producer type: '" << prod.type << "'" << std::endl;
+                if (prod.type == "teleop_widowx_arm") {
                     widowx_count++;
+                    std::cout << "    ✓ Found WidowX teleop producer!" << std::endl;
 
                     // Check that both leader and follower are configured
-                    if (prod.leader_name.empty() || prod.follower_name.empty()) {
+                    if (prod.leader_id.empty() || prod.follower_id.empty()) {
                         error = "WidowX teleop producer must have both "
-                                "leader_name and follower_name configured";
+                                "leader_id and follower_id configured";
                         return false;
                     }
 
-                    // Verify the arms are connected
-                    if (g_arm_status.find(prod.leader_name) == g_arm_status.end() ||
-                        !g_arm_status[prod.leader_name].is_connected) {
-                        error = "Leader arm not connected: " + prod.leader_name;
+                    // Verify the arms are connected by ID
+                    if (g_arm_status.find(prod.leader_id) == g_arm_status.end() ||
+                        !g_arm_status[prod.leader_id].is_connected) {
+                        error = "Leader arm not connected: " + prod.leader_id;
                         return false;
                     }
-                    if (g_arm_status.find(prod.follower_name) == g_arm_status.end() ||
-                        !g_arm_status[prod.follower_name].is_connected) {
-                        error = "Follower arm not connected: " + prod.follower_name;
+                    if (g_arm_status.find(prod.follower_id) == g_arm_status.end() ||
+                        !g_arm_status[prod.follower_id].is_connected) {
+                        error = "Follower arm not connected: " + prod.follower_id;
                         return false;
                     }
 
@@ -166,17 +171,49 @@ bool validate_hardware_for_action(
             break;
         }
 
-        case SessionAction::RECORD_CAMERAS_ONLY: {
-            // Need at least one camera producer
-            int camera_count = std::count_if(system_producers.begin(), system_producers.end(),
-                [](const trossen::config::ProducerConfig& p) {
-                    return p.type == "opencv_camera" ||
-                           p.type == "realsense_color" ||
-                           p.type == "realsense_depth";
-                });
+        case SessionAction::TELEOP_WIDOWX_BIMANUAL: {
+            // Needs 2 WidowX teleop producers (2 pairs of arms)
+            int widowx_count = 0;
+            std::vector<std::string> all_arms;
 
-            if (camera_count == 0) {
-                error = "Camera recording requires at least one camera producer";
+            for (const auto& prod : system_producers) {
+                if (prod.type == "teleop_widowx_arm") {
+                    widowx_count++;
+
+                    // Check that both leader and follower are configured
+                    if (prod.leader_id.empty() || prod.follower_id.empty()) {
+                        error = "WidowX teleop producer must have both "
+                                "leader_id and follower_id configured";
+                        return false;
+                    }
+
+                    // Verify the arms are connected by ID
+                    if (g_arm_status.find(prod.leader_id) == g_arm_status.end() ||
+                        !g_arm_status[prod.leader_id].is_connected) {
+                        error = "Leader arm not connected: " + prod.leader_id;
+                        return false;
+                    }
+                    if (g_arm_status.find(prod.follower_id) == g_arm_status.end() ||
+                        !g_arm_status[prod.follower_id].is_connected) {
+                        error = "Follower arm not connected: " + prod.follower_id;
+                        return false;
+                    }
+
+                    all_arms.push_back(prod.leader_id);
+                    all_arms.push_back(prod.follower_id);
+                }
+            }
+
+            if (widowx_count != 2) {
+                error = "WidowX bimanual teleoperation requires exactly 2 WidowX "
+                        "teleop producers. Found: " + std::to_string(widowx_count);
+                return false;
+            }
+
+            // Verify no duplicate arms
+            std::sort(all_arms.begin(), all_arms.end());
+            if (std::adjacent_find(all_arms.begin(), all_arms.end()) != all_arms.end()) {
+                error = "WidowX bimanual teleoperation: duplicate arm names detected";
                 return false;
             }
             break;
@@ -209,24 +246,68 @@ bool setup_so101_teleop(
         return false;
     }
 
-    // Find SO101 teleop producer
+    std::shared_ptr<SO101ArmDriver> leader_driver;
+    std::shared_ptr<SO101ArmDriver> follower_driver;
+    std::string teleop_stream_id;
+    bool use_device_time = true;
+
+    // Loop through ALL producers in the system
+    std::cout << "Creating producers from system configuration..." << std::endl;
+    int camera_count = 0;
+    int arm_count = 0;
+
     for (const auto& producer_id : system_it->producers) {
         auto prod_it = std::find_if(configs.producers.begin(), configs.producers.end(),
             [&producer_id](const trossen::config::ProducerConfig& p) {
                 return p.id == producer_id;
             });
 
-        if (prod_it != configs.producers.end() && prod_it->type == "teleop_so101_arm") {
-            const auto& prod = *prod_it;
+        if (prod_it == configs.producers.end()) continue;
 
-            std::string leader_name = prod.leader_name;
-            std::string follower_name = prod.follower_name;
-            std::string id = prod.id;
-            bool use_device_time = prod.use_device_time;
+        const auto& prod = *prod_it;
 
-            // Get drivers from ActiveHardwareRegistry
-            auto leader_comp = trossen::hw::ActiveHardwareRegistry::get(leader_name);
-            auto follower_comp = trossen::hw::ActiveHardwareRegistry::get(follower_name);
+        // Create camera producers
+        if (prod.type == "opencv_camera") {
+            // Look up camera configuration by ID
+            auto cam_it = std::find_if(configs.cameras.begin(), configs.cameras.end(),
+                [&prod](const trossen::config::CameraConfig& c) {
+                    return c.id == prod.camera_id;
+                });
+
+            if (cam_it == configs.cameras.end()) {
+                std::cerr << "Warning: Camera not found for producer: "
+                          << prod.camera_id << std::endl;
+                continue;
+            }
+
+            const auto& cam = *cam_it;
+            trossen::hw::camera::OpenCvCameraProducer::Config cam_cfg;
+            cam_cfg.device_index = cam.device_index;
+            cam_cfg.stream_id = prod.id;
+            cam_cfg.width = cam.width;
+            cam_cfg.height = cam.height;
+            cam_cfg.height = cam.height;
+            cam_cfg.fps = cam.fps;
+            cam_cfg.use_device_time = prod.use_device_time;
+
+            auto camera_producer = std::make_shared<
+                trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
+
+            auto camera_period = std::chrono::milliseconds(
+                static_cast<int>(1000.0f / cam.fps));
+            active_session->manager->add_producer(
+                camera_producer, camera_period);
+            camera_count++;
+            std::cout << "  ✓ Registered camera producer: "
+                      << cam.name << std::endl;
+        } else if (prod.type == "teleop_so101_arm") {
+            // Handle SO101 teleop producer
+            teleop_stream_id = prod.id;
+            use_device_time = prod.use_device_time;
+
+            // Get drivers from ActiveHardwareRegistry using IDs
+            auto leader_comp = trossen::hw::ActiveHardwareRegistry::get(prod.leader_id);
+            auto follower_comp = trossen::hw::ActiveHardwareRegistry::get(prod.follower_id);
 
             if (!leader_comp || !follower_comp) {
                 error = "Failed to get SO101 components from registry";
@@ -234,90 +315,85 @@ bool setup_so101_teleop(
             }
 
             auto leader_so101 =
-                std::dynamic_pointer_cast<trossen::hw::arm::SO101ArmComponent>(
-                    leader_comp);
+                std::dynamic_pointer_cast<trossen::hw::arm::SO101ArmComponent>(leader_comp);
             auto follower_so101 =
-                std::dynamic_pointer_cast<trossen::hw::arm::SO101ArmComponent>(
-                    follower_comp);
+                std::dynamic_pointer_cast<trossen::hw::arm::SO101ArmComponent>(follower_comp);
 
             if (!leader_so101 || !follower_so101) {
                 error = "Failed to cast to SO101ArmComponent";
                 return false;
             }
 
-            auto leader_driver = leader_so101->get_driver();
-            auto follower_driver = follower_so101->get_driver();
+            leader_driver = leader_so101->get_driver();
+            follower_driver = follower_so101->get_driver();
 
             if (!leader_driver || !follower_driver) {
                 error = "Failed to get SO101 drivers";
                 return false;
             }
 
-            // Create SO101 teleop producer
+            // Store drivers to keep them alive
+            active_session->arm_drivers.push_back(leader_driver);
+            active_session->arm_drivers.push_back(follower_driver);
+
+            // Create and register SO101 teleop producer
             trossen::hw::arm::TeleopSO101ArmProducer::Config teleop_cfg;
-            teleop_cfg.stream_id = id;
+            teleop_cfg.stream_id = teleop_stream_id;
             teleop_cfg.use_device_time = use_device_time;
 
             auto teleop_producer = std::make_shared<
                 trossen::hw::arm::TeleopSO101ArmProducer>(
                     leader_driver, follower_driver, teleop_cfg);
 
-            // Register with 30Hz polling rate
             auto teleop_period = std::chrono::milliseconds(33);  // ~30Hz
             active_session->manager->add_producer(teleop_producer, teleop_period);
-
-            // Store drivers to keep them alive
-            active_session->arm_drivers.push_back(leader_driver);
-            active_session->arm_drivers.push_back(follower_driver);
-
-            std::cout << "  ✓ Registered SO101 teleop producer: " << id << std::endl;
-
-            // Give servos time to initialize after connection
-            std::cout << "  Waiting for servos to initialize..." << std::endl;
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-            auto test_leader = leader_driver->get_joint_positions(false);
-            auto test_follower = follower_driver->get_joint_positions(false);
-
-            // false = raw values
-            auto leader_positions = leader_driver->get_joint_positions(false);
-            std::cout << "  Leader RAW positions: [";
-            for (size_t i = 0; i < leader_positions.size(); ++i) {
-                std::cout << leader_positions[i];
-                if (i < leader_positions.size() - 1) std::cout << ", ";
-            }
-            std::cout << "]" << std::endl;
-
-            follower_driver->set_joint_positions(leader_positions, false);
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            std::cout << "  ✓ Synced follower to leader position" << std::endl;
-
-            // Start teleoperation thread (100Hz control loop)
-            // This runs continuously across all episodes until manually
-            // stopped
-            active_session->teleop_active = true;
-            active_session->teleop_thread = std::thread(
-                [leader_driver, follower_driver, active_session]() {
-                std::cout << "  ✓ Teleoperation loop started" << std::endl;
-
-                int loop_count = 0;
-                while (active_session->teleop_active) {
-                    auto leader_positions = leader_driver->get_joint_positions(false);
-
-                    follower_driver->set_joint_positions(leader_positions, false);
-                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                    loop_count++;
-                }
-
-                std::cout << "  ✓ Teleoperation loop stopped" << std::endl;
-            });
-
-            return true;
+            arm_count++;
+            std::cout << "  ✓ Registered SO101 teleop producer: " << prod.id << std::endl;
         }
     }
 
-    error = "No SO101 teleop producer found in system";
-    return false;
+    if (arm_count == 0) {
+        error = "No SO101 teleop producer found in system";
+        return false;
+    }
+
+    std::cout << "Producers created: " << arm_count << " arm(s), "
+              << camera_count << " camera(s)" << std::endl;
+
+    // Sync follower to leader's current position before starting
+    std::cout << "Syncing follower to leader position..." << std::endl;
+    auto leader_positions = leader_driver->get_joint_positions(false);
+    follower_driver->set_joint_positions(leader_positions, false);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::cout << "  ✓ Follower synced to leader" << std::endl;
+
+    // Start teleoperation thread (runs continuously, mirrors leader to follower)
+    active_session->teleop_active = true;
+    active_session->teleop_thread = std::thread([leader_driver, follower_driver, active_session]() {
+        std::cout << "SO101 teleoperation thread started" << std::endl;
+
+        while (active_session->teleop_active) {
+            // Check if we should freeze (waiting for next episode)
+            if (active_session->waiting_for_next.load()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                continue;
+            }
+
+            try {
+                auto leader_pos = leader_driver->get_joint_positions(false);
+                follower_driver->set_joint_positions(leader_pos, false);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));  // 100Hz
+            } catch (const std::exception& e) {
+                std::cerr << "Error in SO101 teleop thread: " << e.what() << std::endl;
+                break;
+            }
+        }
+
+        std::cout << "SO101 teleoperation thread stopped" << std::endl;
+    });
+
+    std::cout << "  ✓ SO101 teleoperation ready" << std::endl;
+    return true;
 }
 
 bool setup_widowx_teleop(
@@ -339,96 +415,201 @@ bool setup_widowx_teleop(
         return false;
     }
 
-    // Find teleop_arm producer in configuration
+    std::shared_ptr<trossen_arm::TrossenArmDriver> leader_driver;
+    std::shared_ptr<trossen_arm::TrossenArmDriver> follower_driver;
     std::string teleop_stream_id;
-    std::string leader_arm_id, follower_arm_id;
     bool use_device_time = true;
+
+    // Loop through ALL producers in the system
+    std::cout << "Creating producers from system configuration..." << std::endl;
+    int camera_count = 0;
+    int arm_count = 0;
 
     for (const auto& producer_id : system_it->producers) {
         auto prod_it = std::find_if(configs.producers.begin(), configs.producers.end(),
             [&producer_id](const trossen::config::ProducerConfig& p) {
                 return p.id == producer_id;
             });
-        if (prod_it != configs.producers.end() && prod_it->type == "teleop_arm") {
-            teleop_stream_id = prod_it->id;
-            leader_arm_id = prod_it->leader_name;
-            follower_arm_id = prod_it->follower_name;
-            use_device_time = prod_it->use_device_time;
-            break;
+
+        if (prod_it == configs.producers.end()) continue;
+
+        const auto& prod = *prod_it;
+
+        // Create camera producers
+        if (prod.type == "opencv_camera") {
+            // Look up camera configuration by ID
+            auto cam_it = std::find_if(configs.cameras.begin(), configs.cameras.end(),
+                [&prod](const trossen::config::CameraConfig& c) {
+                    return c.id == prod.camera_id;
+                });
+
+            if (cam_it == configs.cameras.end()) {
+                std::cerr << "Warning: Camera not found for producer: "
+                          << prod.camera_id << std::endl;
+                continue;
+            }
+
+            const auto& cam = *cam_it;
+            trossen::hw::camera::OpenCvCameraProducer::Config cam_cfg;
+            cam_cfg.device_index = cam.device_index;
+            cam_cfg.stream_id = prod.id;
+            cam_cfg.encoding = cam.encoding;
+            cam_cfg.width = cam.width;
+            cam_cfg.height = cam.height;
+            cam_cfg.fps = cam.fps;
+            cam_cfg.use_device_time = prod.use_device_time;
+
+            auto camera_producer = std::make_shared<
+                trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
+
+            auto camera_period = std::chrono::milliseconds(
+                static_cast<int>(1000.0f / cam.fps));
+            active_session->manager->add_producer(
+                camera_producer, camera_period);
+            camera_count++;
+            std::cout << "  ✓ Registered camera producer: "
+                      << cam.name << std::endl;
+        } else if (prod.type == "teleop_widowx_arm") {
+            // Handle WidowX teleop producer
+            teleop_stream_id = prod.id;
+            use_device_time = prod.use_device_time;
+
+            // Get hardware components from registry using IDs
+            auto leader_comp = trossen::hw::ActiveHardwareRegistry::get(prod.leader_id);
+            auto follower_comp = trossen::hw::ActiveHardwareRegistry::get(prod.follower_id);
+
+            if (!leader_comp || !follower_comp) {
+                error = "WidowX arms not found in hardware registry";
+                return false;
+            }
+
+            // Cast to TrossenArmComponent and extract drivers
+            auto leader_trossen =
+                std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(leader_comp);
+            auto follower_trossen =
+                std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(follower_comp);
+
+            if (!leader_trossen || !follower_trossen) {
+                error = "Failed to cast components to TrossenArmComponent";
+                return false;
+            }
+
+            leader_driver = leader_trossen->get_hardware();
+            follower_driver = follower_trossen->get_hardware();
+
+            if (!leader_driver || !follower_driver) {
+                error = "Failed to get arm drivers from components";
+                return false;
+            }
+
+            // Store drivers to keep them alive
+            active_session->widowx_drivers.push_back(leader_driver);
+            active_session->widowx_drivers.push_back(follower_driver);
+
+            // Set leader to external_effort mode (gravity compensation) for teleoperation
+            std::cout << "  Setting leader to external_effort mode..." << std::endl;
+            leader_driver->set_all_modes(trossen_arm::Mode::external_effort);
+            leader_driver->set_all_external_efforts(
+                std::vector<double>(leader_driver->get_num_joints(), 0.0),
+                0.0,
+                false);
+
+            // Set follower to position mode
+            follower_driver->set_all_modes(trossen_arm::Mode::position);
+
+            // Create and register the teleop producer
+            trossen::hw::arm::TeleopTrossenArmProducer::Config teleop_cfg;
+            teleop_cfg.stream_id = teleop_stream_id;
+            teleop_cfg.use_device_time = use_device_time;
+
+            auto teleop_producer = std::make_shared<
+                trossen::hw::arm::TeleopTrossenArmProducer>(
+                    leader_driver, follower_driver, teleop_cfg);
+
+            auto teleop_period = std::chrono::milliseconds(5);  // 200Hz
+            active_session->manager->add_producer(teleop_producer, teleop_period);
+            arm_count++;
+            std::cout << "  ✓ Registered WidowX teleop producer: " << prod.id << std::endl;
         }
     }
 
-    if (teleop_stream_id.empty()) {
-        error = "No teleop_arm producer found in system configuration";
+    if (arm_count == 0) {
+        error = "No WidowX teleop producer found in system";
         return false;
     }
 
-    // Get hardware components from registry
-    auto leader_comp = trossen::hw::ActiveHardwareRegistry::get(leader_arm_id);
-    auto follower_comp = trossen::hw::ActiveHardwareRegistry::get(follower_arm_id);
+    std::cout << "Producers created: " << arm_count << " arm(s), "
+              << camera_count << " camera(s)" << std::endl;
 
-    if (!leader_comp || !follower_comp) {
-        error = "WidowX arms not found in hardware registry";
-        return false;
-    }
+    const float moving_time_s = 2.0f;
+    const std::vector<double> STAGED_POSITIONS = {
+        0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0
+    };
 
-    // Cast to TrossenArmComponent and extract drivers
-    auto leader_trossen =
-        std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(
-            leader_comp);
-    auto follower_trossen =
-        std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(
-            follower_comp);
+    // Stage both arms to ready position
+    std::cout << "Staging arms to ready position..." << std::endl;
+    leader_driver->set_all_modes(trossen_arm::Mode::position);
+    follower_driver->set_all_modes(trossen_arm::Mode::position);
+    leader_driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    follower_driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+    std::cout << "  ✓ Arms staged to ready position" << std::endl;
 
-    if (!leader_trossen || !follower_trossen) {
-        error = "Failed to cast components to TrossenArmComponent";
-        return false;
-    }
+    // Move follower to mirror leader's current position
+    std::cout << "Syncing follower to leader position..." << std::endl;
+    auto leader_positions = leader_driver->get_all_positions();
+    follower_driver->set_all_positions(leader_positions, moving_time_s, false);
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
 
-    auto leader_driver = leader_trossen->get_hardware();
-    auto follower_driver = follower_trossen->get_hardware();
+    // Set leader back to external_effort mode for teleoperation
+    leader_driver->set_all_modes(trossen_arm::Mode::external_effort);
+    leader_driver->set_all_external_efforts(
+        std::vector<double>(leader_driver->get_num_joints(), 0.0),
+        0.0,
+        false);
+    std::cout << "  ✓ Follower synced to leader" << std::endl;
 
-    if (!leader_driver || !follower_driver) {
-        error = "Failed to get arm drivers from components";
-        return false;
-    }
-
-    // Store drivers in active session
-    active_session->widowx_drivers.push_back(leader_driver);
-    active_session->widowx_drivers.push_back(follower_driver);
-
-    // Create and register the teleop producer
-    trossen::hw::arm::TeleopTrossenArmProducer::Config teleop_cfg;
-    teleop_cfg.stream_id = teleop_stream_id;
-    teleop_cfg.use_device_time = use_device_time;
-
-    auto teleop_producer = std::make_shared<
-        trossen::hw::arm::TeleopTrossenArmProducer>(
-            leader_driver, follower_driver, teleop_cfg);
-
-    active_session->manager->add_producer(
-        teleop_producer, std::chrono::milliseconds(1));
-    std::cout << "  ✓ Registered WidowX teleop producer: " << teleop_stream_id << std::endl;
-
-    // Start teleoperation thread with freeze logic
+    // Start teleoperation thread (runs continuously, mirrors leader to follower)
     active_session->teleop_active = true;
     active_session->teleop_thread = std::thread([active_session]() {
-        std::cout << "Starting WidowX teleoperation thread..." << std::endl;
+        std::cout << "WidowX teleoperation thread started" << std::endl;
 
-        auto leader_driver = active_session->widowx_drivers[0];
-        auto follower_driver = active_session->widowx_drivers[1];
+        auto leader = active_session->widowx_drivers[0];
+        auto follower = active_session->widowx_drivers[1];
+        bool was_frozen = false;
 
         while (active_session->teleop_active) {
             // Check if we should freeze (waiting for next episode)
             if (active_session->waiting_for_next.load()) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                if (!was_frozen) {
+                    // Lock both arms in position mode to prevent movement
+                    std::cout << "  Freezing WidowX arms (waiting for next episode)..."
+                              << std::endl;
+                    leader->set_all_modes(trossen_arm::Mode::position);
+                    follower->set_all_modes(trossen_arm::Mode::position);
+                    was_frozen = true;
+                }
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(10));
                 continue;
+            }
+
+            // Unfreeze - restore external_effort mode for leader
+            if (was_frozen) {
+                std::cout << "  Resuming WidowX teleoperation..." << std::endl;
+                leader->set_all_modes(trossen_arm::Mode::external_effort);
+                leader->set_all_external_efforts(
+                    std::vector<double>(leader->get_num_joints(), 0.0),
+                    0.0,
+                    false);
+                follower->set_all_modes(trossen_arm::Mode::position);
+                was_frozen = false;
             }
 
             try {
                 // Mirror leader arm positions to follower
-                auto positions = leader_driver->get_all_positions();
-                follower_driver->set_all_positions(positions, 0.0f, false);
+                auto positions = leader->get_all_positions();
+                follower->set_all_positions(positions, 0.0f, false);
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
             } catch (const std::exception& e) {
                 std::cerr << "Error in WidowX teleop thread: " << e.what() << std::endl;
@@ -437,8 +618,44 @@ bool setup_widowx_teleop(
         }
 
         std::cout << "WidowX teleoperation thread stopped" << std::endl;
+
+        // Reset arms to rest position if all episodes complete
+        if (active_session->all_episodes_complete) {
+            std::cout << "Resetting WidowX arms to rest position..." << std::endl;
+            const float moving_time_s = 2.0f;
+            const std::vector<double> STAGED_POSITIONS = {
+                0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0
+            };
+
+            try {
+                auto leader = active_session->widowx_drivers[0];
+                auto follower = active_session->widowx_drivers[1];
+
+                // Set to position mode
+                leader->set_all_modes(trossen_arm::Mode::position);
+                follower->set_all_modes(trossen_arm::Mode::position);
+
+                // Move to staged positions
+                leader->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+                follower->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+                std::this_thread::sleep_for(
+                    std::chrono::duration<float>(moving_time_s + 0.1f));
+
+                // Move to sleep position (all zeros)
+                std::vector<double> sleep_position(leader->get_num_joints(), 0.0);
+                leader->set_all_positions(sleep_position, moving_time_s, false);
+                follower->set_all_positions(sleep_position, moving_time_s, false);
+                std::this_thread::sleep_for(
+                    std::chrono::duration<float>(moving_time_s + 0.1f));
+
+                std::cout << "  ✓ Arms returned to rest position" << std::endl;
+            } catch (const std::exception& e) {
+                std::cerr << "Error resetting arms: " << e.what() << std::endl;
+            }
+        }
     });
 
+    std::cout << "  ✓ WidowX teleoperation ready" << std::endl;
     return true;
 }
 
@@ -496,6 +713,323 @@ bool setup_camera_recording(
     return true;
 }
 
+bool setup_widowx_bimanual_teleop(
+    std::shared_ptr<ActiveSession> active_session,
+    const std::string& system_id,
+    std::string& error)
+{
+    std::cout << "Setting up WidowX bimanual teleoperation session..." << std::endl;
 
+    // Get system configuration
+    auto configs = config_manager.get_configurations();
+    auto system_it = std::find_if(configs.systems.begin(), configs.systems.end(),
+        [&system_id](const trossen::config::HardwareSystem& s) {
+            return s.id == system_id;
+        });
+
+    if (system_it == configs.systems.end()) {
+        error = "Hardware system not found";
+        return false;
+    }
+
+    struct TeleopPairConfig {
+        std::string stream_id;
+        std::string leader_id;
+        std::string follower_id;
+        bool use_device_time;
+    };
+    std::vector<TeleopPairConfig> pairs;
+
+    // Loop through ALL producers in the system
+    std::cout << "Creating producers from system configuration..." << std::endl;
+    int camera_count = 0;
+    int arm_count = 0;
+
+    for (const auto& producer_id : system_it->producers) {
+        auto prod_it = std::find_if(configs.producers.begin(), configs.producers.end(),
+            [&producer_id](const trossen::config::ProducerConfig& p) {
+                return p.id == producer_id;
+            });
+
+        if (prod_it == configs.producers.end()) continue;
+
+        const auto& prod = *prod_it;
+
+        // Create camera producers
+        if (prod.type == "opencv_camera") {
+            // Look up camera configuration by ID
+            auto cam_it = std::find_if(configs.cameras.begin(), configs.cameras.end(),
+                [&prod](const trossen::config::CameraConfig& c) {
+                    return c.id == prod.camera_id;
+                });
+
+            if (cam_it == configs.cameras.end()) {
+                std::cerr << "Warning: Camera not found for producer: "
+                          << prod.camera_id << std::endl;
+                continue;
+            }
+
+            const auto& cam = *cam_it;
+            trossen::hw::camera::OpenCvCameraProducer::Config cam_cfg;
+            cam_cfg.device_index = cam.device_index;
+            cam_cfg.stream_id = prod.id;
+            cam_cfg.encoding = cam.encoding;
+            cam_cfg.width = cam.width;
+            cam_cfg.height = cam.height;
+            cam_cfg.fps = cam.fps;
+            cam_cfg.use_device_time = prod.use_device_time;
+
+            auto camera_producer = std::make_shared<
+                trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
+
+            auto camera_period = std::chrono::milliseconds(
+                static_cast<int>(1000.0f / cam.fps));
+            active_session->manager->add_producer(camera_producer, camera_period);
+            camera_count++;
+            std::cout << "  ✓ Registered camera producer: " << cam.name << std::endl;
+        } else if (prod.type == "teleop_widowx_arm") {
+            // Collect WidowX teleop producers
+            TeleopPairConfig pair;
+            pair.stream_id = prod.id;
+            pair.leader_id = prod.leader_id;
+            pair.follower_id = prod.follower_id;
+            pair.use_device_time = prod.use_device_time;
+            pairs.push_back(pair);
+        }
+    }
+
+    if (pairs.size() != 2) {
+        error = "Expected exactly 2 WidowX teleop producers, found: " +
+                std::to_string(pairs.size());
+        return false;
+    }
+
+    // Setup both teleop pairs
+    for (size_t i = 0; i < pairs.size(); ++i) {
+        const auto& pair = pairs[i];
+
+        // Get hardware components from registry using IDs
+        auto leader_comp = trossen::hw::ActiveHardwareRegistry::get(pair.leader_id);
+        auto follower_comp = trossen::hw::ActiveHardwareRegistry::get(pair.follower_id);
+
+        if (!leader_comp || !follower_comp) {
+            error = "WidowX arms not found in hardware registry for pair " +
+                    std::to_string(i + 1);
+            return false;
+        }
+
+        // Cast to TrossenArmComponent and extract drivers
+        auto leader_trossen =
+            std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(leader_comp);
+        auto follower_trossen =
+            std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(follower_comp);
+
+        if (!leader_trossen || !follower_trossen) {
+            error = "Failed to cast components to TrossenArmComponent for pair " +
+                    std::to_string(i + 1);
+            return false;
+        }
+
+        auto leader_driver = leader_trossen->get_hardware();
+        auto follower_driver = follower_trossen->get_hardware();
+
+        if (!leader_driver || !follower_driver) {
+            error = "Failed to get arm drivers from components for pair " +
+                    std::to_string(i + 1);
+            return false;
+        }
+
+        // Store drivers in active session
+        active_session->widowx_drivers.push_back(leader_driver);
+        active_session->widowx_drivers.push_back(follower_driver);
+
+        // Set leader to external_effort mode (gravity compensation)
+        std::cout << "  Setting leader " << (i + 1) << " to external_effort mode..." << std::endl;
+        leader_driver->set_all_modes(trossen_arm::Mode::external_effort);
+        leader_driver->set_all_external_efforts(
+            std::vector<double>(leader_driver->get_num_joints(), 0.0),
+            0.0,
+            false);
+
+        // Set follower to position mode
+        follower_driver->set_all_modes(trossen_arm::Mode::position);
+
+        // Create and register the teleop producer for this pair
+        trossen::hw::arm::TeleopTrossenArmProducer::Config teleop_cfg;
+        teleop_cfg.stream_id = pair.stream_id;
+        teleop_cfg.use_device_time = pair.use_device_time;
+
+        auto teleop_producer = std::make_shared<
+            trossen::hw::arm::TeleopTrossenArmProducer>(
+                leader_driver, follower_driver, teleop_cfg);
+
+        auto teleop_period = std::chrono::milliseconds(5);  // 200Hz
+        active_session->manager->add_producer(teleop_producer, teleop_period);
+        arm_count++;
+        std::cout << "  ✓ Registered WidowX teleop producer " << (i + 1)
+                  << ": " << pair.stream_id << std::endl;
+    }
+
+    std::cout << "Producers created: " << arm_count << " arm pair(s), "
+              << camera_count << " camera(s)" << std::endl;
+
+    const float moving_time_s = 2.0f;
+    const std::vector<double> STAGED_POSITIONS = {
+        0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0
+    };
+
+    auto leader1 = active_session->widowx_drivers[0];
+    auto follower1 = active_session->widowx_drivers[1];
+    auto leader2 = active_session->widowx_drivers[2];
+    auto follower2 = active_session->widowx_drivers[3];
+
+    // Stage all arms to ready position
+    std::cout << "Staging all arms to ready position..." << std::endl;
+    leader1->set_all_modes(trossen_arm::Mode::position);
+    follower1->set_all_modes(trossen_arm::Mode::position);
+    leader2->set_all_modes(trossen_arm::Mode::position);
+    follower2->set_all_modes(trossen_arm::Mode::position);
+    leader1->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    follower1->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    leader2->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    follower2->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+    std::cout << "  ✓ All arms staged to ready position" << std::endl;
+
+    // Sync both pairs: move followers to mirror leaders' current positions
+    std::cout << "Syncing followers to leaders' positions..." << std::endl;
+
+    // Lock leaders temporarily
+    leader1->set_all_modes(trossen_arm::Mode::position);
+    leader2->set_all_modes(trossen_arm::Mode::position);
+
+    auto leader1_pos = leader1->get_all_positions();
+    auto leader2_pos = leader2->get_all_positions();
+
+    follower1->set_all_positions(leader1_pos, moving_time_s, false);
+    follower2->set_all_positions(leader2_pos, moving_time_s, false);
+
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+
+    // Unlock leaders back to external_effort mode
+    leader1->set_all_modes(trossen_arm::Mode::external_effort);
+    leader1->set_all_external_efforts(
+        std::vector<double>(leader1->get_num_joints(), 0.0), 0.0, false);
+
+    leader2->set_all_modes(trossen_arm::Mode::external_effort);
+    leader2->set_all_external_efforts(
+        std::vector<double>(leader2->get_num_joints(), 0.0), 0.0, false);
+
+    std::cout << "  ✓ Both followers synced to leaders" << std::endl;
+
+    // Start bimanual teleoperation thread
+    active_session->teleop_active = true;
+    active_session->teleop_thread = std::thread([active_session]() {
+        std::cout << "WidowX bimanual teleoperation thread started" << std::endl;
+
+        // We have 4 drivers: [leader1, follower1, leader2, follower2]
+        auto leader1 = active_session->widowx_drivers[0];
+        auto follower1 = active_session->widowx_drivers[1];
+        auto leader2 = active_session->widowx_drivers[2];
+        auto follower2 = active_session->widowx_drivers[3];
+        bool was_frozen = false;
+
+        while (active_session->teleop_active) {
+            // Check if we should freeze (waiting for next episode)
+            if (active_session->waiting_for_next.load()) {
+                if (!was_frozen) {
+                    // Lock all arms in position mode to prevent movement
+                    std::cout << "  Freezing WidowX bimanual arms "
+                              << "(waiting for next episode)..." << std::endl;
+                    leader1->set_all_modes(trossen_arm::Mode::position);
+                    follower1->set_all_modes(trossen_arm::Mode::position);
+                    leader2->set_all_modes(trossen_arm::Mode::position);
+                    follower2->set_all_modes(trossen_arm::Mode::position);
+                    was_frozen = true;
+                }
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(10));
+                continue;
+            }
+
+            // Unfreeze - restore external_effort mode for leaders
+            if (was_frozen) {
+                std::cout << "  Resuming WidowX bimanual teleoperation..." << std::endl;
+                leader1->set_all_modes(trossen_arm::Mode::external_effort);
+                leader1->set_all_external_efforts(
+                    std::vector<double>(leader1->get_num_joints(), 0.0), 0.0, false);
+                leader2->set_all_modes(trossen_arm::Mode::external_effort);
+                leader2->set_all_external_efforts(
+                    std::vector<double>(leader2->get_num_joints(), 0.0), 0.0, false);
+                follower1->set_all_modes(trossen_arm::Mode::position);
+                follower2->set_all_modes(trossen_arm::Mode::position);
+                was_frozen = false;
+            }
+
+            try {
+                // Mirror both pairs simultaneously
+                auto positions1 = leader1->get_all_positions();
+                follower1->set_all_positions(positions1, 0.0f, false);
+
+                auto positions2 = leader2->get_all_positions();
+                follower2->set_all_positions(positions2, 0.0f, false);
+
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            } catch (const std::exception& e) {
+                std::cerr << "Error in WidowX bimanual teleop thread: "
+                          << e.what() << std::endl;
+                break;
+            }
+        }
+
+        std::cout << "WidowX bimanual teleoperation thread stopped" << std::endl;
+
+        // Reset arms to rest position if all episodes complete
+        if (active_session->all_episodes_complete) {
+            std::cout << "Resetting WidowX bimanual arms to rest position..." << std::endl;
+            const float moving_time_s = 2.0f;
+            const std::vector<double> STAGED_POSITIONS = {
+                0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0
+            };
+
+            try {
+                auto leader1 = active_session->widowx_drivers[0];
+                auto follower1 = active_session->widowx_drivers[1];
+                auto leader2 = active_session->widowx_drivers[2];
+                auto follower2 = active_session->widowx_drivers[3];
+
+                // Set all to position mode
+                leader1->set_all_modes(trossen_arm::Mode::position);
+                follower1->set_all_modes(trossen_arm::Mode::position);
+                leader2->set_all_modes(trossen_arm::Mode::position);
+                follower2->set_all_modes(trossen_arm::Mode::position);
+
+                // Move to staged positions
+                leader1->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+                follower1->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+                leader2->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+                follower2->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+                std::this_thread::sleep_for(
+                    std::chrono::duration<float>(moving_time_s + 0.1f));
+
+                // Move to sleep position (all zeros)
+                std::vector<double> sleep_position(leader1->get_num_joints(), 0.0);
+                leader1->set_all_positions(sleep_position, moving_time_s, false);
+                follower1->set_all_positions(sleep_position, moving_time_s, false);
+                leader2->set_all_positions(sleep_position, moving_time_s, false);
+                follower2->set_all_positions(sleep_position, moving_time_s, false);
+                std::this_thread::sleep_for(
+                    std::chrono::duration<float>(moving_time_s + 0.1f));
+
+                std::cout << "  ✓ All arms returned to rest position" << std::endl;
+            } catch (const std::exception& e) {
+                std::cerr << "Error resetting bimanual arms: " << e.what() << std::endl;
+            }
+        }
+    });
+
+    std::cout << "  ✓ WidowX bimanual teleoperation ready" << std::endl;
+    return true;
+}
 
 }  // namespace trossen::backend

--- a/apps/trossen_sdk_ui/frontend/app/RecordPage.tsx
+++ b/apps/trossen_sdk_ui/frontend/app/RecordPage.tsx
@@ -36,7 +36,7 @@ export function RecordPage() {
   const [sessionForm, setSessionForm] = useState({
     name: '',
     systemId: '',
-    action: 'teleop_so101' as 'teleop_so101' | 'teleop_widowx' | 'record_cameras' | 'record_arms' | 'record_full',
+    action: 'teleop_so101' as 'teleop_so101' | 'teleop_widowx' | 'teleop_widowx_bimanual',
     numEpisodes: 10,
     episodeDuration: 60,
     backendType: 'mcap' as 'mcap' | 'lerobot'
@@ -591,10 +591,8 @@ export function RecordPage() {
                   className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 >
                   <option value="teleop_so101">SO101 Teleoperation</option>
-                  <option value="teleop_widowx">WidowX Teleoperation</option>
-                  <option value="record_cameras">Record Cameras Only</option>
-                  <option value="record_arms">Record Arms Only</option>
-                  <option value="record_full">Record Full System</option>
+                  <option value="teleop_widowx">WidowX Teleoperation (Single Pair)</option>
+                  <option value="teleop_widowx_bimanual">WidowX Teleoperation (Bimanual)</option>
                 </select>
                 <p className="text-sm text-gray-500 mt-1">
                   Choose the type of recording session to perform

--- a/apps/trossen_sdk_ui/frontend/app/SessionMonitor.tsx
+++ b/apps/trossen_sdk_ui/frontend/app/SessionMonitor.tsx
@@ -35,6 +35,8 @@ export function SessionMonitor({ session, onClose, onFinish }: SessionMonitorPro
   const [isFinishing, setIsFinishing] = useState(false);
   const [allEpisodesComplete, setAllEpisodesComplete] = useState(false);
   const [completionElapsedTime, setCompletionElapsedTime] = useState<number | null>(null);
+  const [waitingForNext, setWaitingForNext] = useState(false);
+  const [isContinuing, setIsContinuing] = useState(false);
 
   // Poll for stats every 500ms
   useEffect(() => {
@@ -63,6 +65,9 @@ export function SessionMonitor({ session, onClose, onFinish }: SessionMonitorPro
 
             // Check if all episodes are complete
             const isComplete = stats.all_episodes_complete || (!stats.episode_active && stats.total_episodes_completed >= session.episodes);
+
+            // Check if waiting for user to continue to next episode
+            setWaitingForNext(stats.waiting_for_next || false);
 
             // If just completed, capture the elapsed time
             if (isComplete && !allEpisodesComplete) {
@@ -98,6 +103,32 @@ export function SessionMonitor({ session, onClose, onFinish }: SessionMonitorPro
     } catch (err) {
       console.error('Failed to finish session:', err);
       setIsFinishing(false);
+    }
+  };
+
+  const handleContinueNextEpisode = async () => {
+    setIsContinuing(true);
+    try {
+      const response = await fetch(`${BACKEND_URL}/session/${session.id}/next`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to continue to next episode');
+      }
+
+      const data = await response.json();
+      console.log('Continue to next episode:', data);
+      setWaitingForNext(false);
+    } catch (err) {
+      console.error('Failed to continue to next episode:', err);
+      alert('Failed to continue to next episode. Please check the console for details.');
+    } finally {
+      setIsContinuing(false);
     }
   };
   return (
@@ -189,6 +220,22 @@ export function SessionMonitor({ session, onClose, onFinish }: SessionMonitorPro
                 <p className="text-green-800 font-semibold">
                   All {session.episodes} episodes completed! Click Finish to process and save the session.
                 </p>
+              </div>
+            )}
+
+            {/* Waiting for Next Episode Message */}
+            {waitingForNext && !allEpisodesComplete && (
+              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mt-4">
+                <p className="text-blue-800 font-semibold mb-3">
+                  Episode {currentStats.totalEpisodesCompleted} completed! Ready to start episode {currentStats.totalEpisodesCompleted + 1} of {session.episodes}.
+                </p>
+                <button
+                  onClick={handleContinueNextEpisode}
+                  disabled={isContinuing}
+                  className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
+                >
+                  {isContinuing ? 'Starting...' : `Continue to Episode ${currentStats.totalEpisodesCompleted + 1}`}
+                </button>
               </div>
             )}
           </div>


### PR DESCRIPTION
This pull request makes significant improvements to how hardware producers and sessions are represented and managed in the backend of the Trossen SDK UI. The main focus is on replacing name-based references with unique IDs for cameras and arms, introducing support for bimanual teleoperation sessions, and ensuring data consistency across configuration, session, and status endpoints.

**Key changes include:**

### Data Model and Configuration Consistency

* Updated `ProducerConfig` and related JSON handling to use unique IDs (`leader_id`, `follower_id`, `camera_id`, `arm_id`) instead of names for referencing hardware components, improving reliability and consistency across the system. 
* Refactored producer creation and update logic in `main.cpp` to set and resolve hardware references by IDs rather than names, ensuring that all configuration and session data is keyed to unique hardware identifiers. 

### Session and Activity Tracking

* Expanded the `data.json` schema to include detailed session, activity, and system records, with activities now tracking creation, start, completion, and processing events for each session. 
* Added explicit session definitions for teleop and bimanual actions, with sessions referencing systems and producers by their unique IDs.

### Bimanual Teleoperation Support

* Introduced support for the new session action `TELEOP_WIDOWX_BIMANUAL`, including backend logic for setup and session handling. 
* Updated session and system configuration to support bimanual teleop producers and their relationships. 

### Hardware Status and API Improvements

* Improved `/hardware/status` endpoint to return hardware status mapped by human-readable names, while internally using IDs for reliability.
* Ensured hardware connect/disconnect endpoints use IDs for all operations, preventing ambiguity and errors. 

### Cleanup and Consistency

* Removed unused or redundant fields and logic related to name-based references, and ensured all configuration loading and saving is consistent with the new ID-based schema.
