### PR TITLE
camera connection status bug fix

### DIFF
--- a/apps/trossen_sdk_ui/backend/main.cpp
+++ b/apps/trossen_sdk_ui/backend/main.cpp
@@ -1496,7 +1496,7 @@ int main() {
         try {
             int index = std::stoi(req.matches[1]);
             json request_data = json::parse(req.body);
-            std::string camera_id = request_data["name"];
+            std::string camera_id = request_data["id"];
 
             std::string error;
             if (trossen::backend::connect_camera(
@@ -1531,7 +1531,7 @@ int main() {
         try {
             int index = std::stoi(req.matches[1]);
             json request_data = json::parse(req.body);
-            std::string camera_id = request_data["name"];
+            std::string camera_id = request_data["id"];
 
             std::string error;
             if (trossen::backend::disconnect_camera(camera_id, error)) {


### PR DESCRIPTION
This pull request makes a small but important update to how camera IDs are parsed from API requests in the backend. It changes the JSON field used to extract the camera identifier from `"name"` to `"id"` in two places, ensuring consistency with the expected request format.

- Updated camera connection logic to use the `"id"` field from the incoming JSON request instead of `"name"` in `main.cpp`.
- Updated camera disconnection logic to use the `"id"` field from the incoming JSON request instead of `"name"` in `main.cpp`.