### PR TITLE
added gitignore for full Trossen_sdk_ui folder

### DIFF
--- a/apps/trossen_sdk_ui/.gitignore
+++ b/apps/trossen_sdk_ui/.gitignore
@@ -1,0 +1,60 @@
+# Backend C++ build artifacts
+backend/build/
+backend/*.o
+backend/*.a
+backend/*.so
+backend/*.dylib
+backend/*.exe
+backend/trossen_backend
+
+# Frontend Node.js
+frontend/node_modules/
+frontend/.next/
+frontend/out/
+frontend/dist/
+frontend/build/
+frontend/.cache/
+frontend/.turbo/
+frontend/.react-router/
+
+# Frontend dependencies and lock files
+frontend/package-lock.json
+frontend/yarn.lock
+frontend/pnpm-lock.yaml
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Configuration data
+data.json
+*.db
+*.sqlite
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+
+# IDE files
+.vscode/
+.idea/
+*.iml
+
+# Docker volumes
+docker-data/
+
+# Temporary files
+*.tmp
+*.temp

--- a/apps/trossen_sdk_ui/frontend/README.md
+++ b/apps/trossen_sdk_ui/frontend/README.md
@@ -1,1 +1,0 @@
-# Welcome to React Router!


### PR DESCRIPTION
This pull request mainly improves project housekeeping by adding a comprehensive `.gitignore` file to the repository. This helps prevent build artifacts, dependencies, environment files, and other unnecessary files from being tracked in version control, making the project cleaner and easier to maintain.

Project housekeeping:

* Added a detailed `.gitignore` file to `apps/trossen_sdk_ui` to exclude backend build artifacts, frontend dependencies and build outputs, environment files, logs, OS/IDE files, Docker volumes, and temporary files from version control.

Minor documentation cleanup:

* Removed the default React Router welcome header from `apps/trossen_sdk_ui/frontend/README.md`.