### PR TITLE
Zed x mini support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,9 @@ jobs:
     - name: Build SDK
       run: |
         mkdir -p build
-        cd build && cmake -DTROSSEN_ENABLE_REALSENSE=ON .. && make -j$(nproc)
+        cd build && cmake -DTROSSEN_ENABLE_REALSENSE=ON -DTROSSEN_ENABLE_ZED=OFF .. && make -j$(nproc)
 
     - name: Run Tests
       run: |
         mkdir -p build
-        cd build && cmake -DTROSSEN_ENABLE_REALSENSE=ON -DBUILD_TESTING=ON .. && ctest --output-on-failure
+        cd build && cmake -DTROSSEN_ENABLE_REALSENSE=ON -DTROSSEN_ENABLE_ZED=OFF -DBUILD_TESTING=ON .. && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(TROSSEN_ENABLE_REALSENSE "Enable Intel RealSense support" OFF)
+option(TROSSEN_ENABLE_ZED "Enable ZED camera support" ON)
 
 add_library(trossen_sdk SHARED
   src/backends/backend_registry.cpp
@@ -41,12 +42,26 @@ if(TROSSEN_ENABLE_REALSENSE)
     src/hw/camera/realsense_depth_producer.cpp
     src/hw/camera/realsense_camera_component.cpp
   )
-  target_compile_definitions(trossen_sdk PRIVATE TROSSEN_ENABLE_REALSENSE)
+  target_compile_definitions(trossen_sdk PUBLIC TROSSEN_ENABLE_REALSENSE)
 
   # Find RealSense dependencies first
   find_package(fastcdr REQUIRED)
   find_package(fastrtps REQUIRED)
   find_package(realsense2 REQUIRED)
+endif()
+
+if(TROSSEN_ENABLE_ZED)
+  message(STATUS "ZED camera support enabled")
+  target_sources(trossen_sdk PRIVATE
+    src/hw/camera/zed_producer.cpp
+    src/hw/camera/zed_depth_producer.cpp
+    src/hw/camera/zed_camera_component.cpp
+  )
+  target_compile_definitions(trossen_sdk PUBLIC TROSSEN_ENABLE_ZED)
+
+  # Find ZED SDK
+  find_package(ZED 4 REQUIRED)
+  find_package(CUDA REQUIRED)
 endif()
 
 # Add architecture-specific CMAKE_PREFIX_PATH
@@ -175,6 +190,10 @@ target_link_libraries(
 )
 if(TROSSEN_ENABLE_REALSENSE)
   target_link_libraries(trossen_sdk PUBLIC realsense2::realsense2)
+endif()
+if(TROSSEN_ENABLE_ZED)
+  target_link_libraries(trossen_sdk PUBLIC ${ZED_LIBRARIES} ${CUDA_LIBRARIES})
+  target_include_directories(trossen_sdk PUBLIC ${ZED_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS})
 endif()
 
 # List proto files for MCAP backend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(TROSSEN_ENABLE_REALSENSE "Enable Intel RealSense support" OFF)
-option(TROSSEN_ENABLE_ZED "Enable ZED camera support" ON)
+option(TROSSEN_ENABLE_ZED "Enable ZED camera support" OFF)
 
 add_library(trossen_sdk SHARED
   src/backends/backend_registry.cpp

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,8 @@ realsense:
 	mkdir -p build
 	cd build && cmake -DTROSSEN_ENABLE_REALSENSE=ON .. && make -j4
 .PHONY: realsense
+
+zed:
+	mkdir -p build
+	cd build && cmake -DTROSSEN_ENABLE_ZED=ON .. && make -j$(NPROC)
+.PHONY: zed

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -447,7 +447,8 @@ int main(int argc, char** argv) {
       {"resolution", resolution},
       {"fps", zed_fps},
       {"use_depth", enable_depth},
-      {"depth_mode", depth_mode}
+      {"depth_mode", depth_mode},
+      {"warmup_seconds", 1.0}
     };
 
     zed_component->configure(zed_config);
@@ -463,16 +464,8 @@ int main(int argc, char** argv) {
     zed_cfg.height = 0;
     zed_cfg.fps = zed_fps;
     zed_cfg.use_device_time = true;
-    zed_cfg.warmup_seconds = 1.0;
 
     camera_producer = std::make_shared<trossen::hw::camera::ZedCameraProducer>(zed_cache, zed_cfg);
-
-    // Perform warmup
-    auto zed_producer =
-      std::dynamic_pointer_cast<trossen::hw::camera::ZedCameraProducer>(camera_producer);
-    if (zed_producer) {
-      zed_producer->warmup();
-    }
 
     std::cout << "  ✓ ZED color producer (" << zed_fps << " Hz, " << resolution
               << ", SN: " << serial_number << ")\n";
@@ -487,19 +480,9 @@ int main(int argc, char** argv) {
       zed_depth_cfg.height = 0;
       zed_depth_cfg.fps = zed_fps;
       zed_depth_cfg.use_device_time = true;
-      zed_depth_cfg.warmup_seconds = 1.0;
 
       depth_producer =
         std::make_shared<trossen::hw::camera::ZedDepthCameraProducer>(zed_cache, zed_depth_cfg);
-
-      // Perform warmup for depth
-      if (depth_producer) {
-        auto zed_depth =
-          std::dynamic_pointer_cast<trossen::hw::camera::ZedDepthCameraProducer>(depth_producer);
-        if (zed_depth) {
-          zed_depth->warmup();
-        }
-      }
 
       std::cout << "  ✓ ZED depth producer (" << zed_fps << " Hz, " << resolution
                 << ", mode: " << depth_mode << ")\n";

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -87,7 +87,7 @@ void print_usage(const char* prog_name) {
     << "  --repository-id <string> Repository identifier (default: TrossenRoboticsCommunity, "
     << "only for LeRobot backend)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
-    << "  --camera_type            Camera type: mock, opencv, realsense, zed (default: opencv)\n"
+    << "  --camera-type            Camera type: mock, opencv, realsense, zed (default: opencv)\n"
     << "  --camera-index <num>     Camera device index for opencv (default: 2, i.e., /dev/video2)\n"
     << "  --camera-width <pixels>  Camera width (default: 1920)\n"
     << "  --camera-height <pixels> Camera height (default: 1080)\n"
@@ -100,8 +100,8 @@ void print_usage(const char* prog_name) {
     << "Examples:\n"
     << "  " << prog_name << "\n"
     << "  " << prog_name << " --mock\n"
-    << "  " << prog_name << " --camera_type realsense\n"
-    << "  " << prog_name << " --camera_type opencv --camera-index 0\n"
+    << "  " << prog_name << " --camera-type realsense\n"
+    << "  " << prog_name << " --camera-type opencv --camera-index 0\n"
     << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
 }
 
@@ -120,7 +120,7 @@ Config parse_args(int argc, char** argv) {
       cfg.repository_id = argv[++i];
     } else if (arg == "--mock") {
       cfg.use_mock = true;
-    } else if (arg == "--camera_type" && i + 1 < argc) {
+    } else if (arg == "--camera-type" && i + 1 < argc) {
       cfg.camera_type = argv[++i];
     } else if (arg == "--camera-index" && i + 1 < argc) {
       cfg.camera_index = std::atoi(argv[++i]);

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -459,8 +459,8 @@ int main(int argc, char** argv) {
     zed_cfg.serial_number = serial_number;
     zed_cfg.stream_id = "zed_camera_main";
     zed_cfg.encoding = "bgr8";
-    zed_cfg.width = 672;   // Actual resolution depends on camera model
-    zed_cfg.height = 376;
+    zed_cfg.width = 0;   // 0 = use camera default resolution
+    zed_cfg.height = 0;
     zed_cfg.fps = zed_fps;
     zed_cfg.use_device_time = true;
     zed_cfg.warmup_seconds = 1.0;
@@ -483,8 +483,8 @@ int main(int argc, char** argv) {
       zed_depth_cfg.serial_number = serial_number;
       zed_depth_cfg.stream_id = "zed_depth_camera_main";
       zed_depth_cfg.encoding = "16UC1";
-      zed_depth_cfg.width = 672;
-      zed_depth_cfg.height = 376;
+      zed_depth_cfg.width = 0;  // 0 = use camera default resolution
+      zed_depth_cfg.height = 0;
       zed_depth_cfg.fps = zed_fps;
       zed_depth_cfg.use_device_time = true;
       zed_depth_cfg.warmup_seconds = 1.0;

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -30,9 +30,20 @@
 #include "trossen_sdk/hw/arm/teleop_mock_joint_producer.hpp"
 #include "trossen_sdk/hw/camera/opencv_producer.hpp"
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
+
+#ifdef TROSSEN_ENABLE_ZED
+#include "trossen_sdk/hw/camera/zed_producer.hpp"
+#include "trossen_sdk/hw/camera/zed_depth_producer.hpp"
+#include "trossen_sdk/hw/camera/zed_camera_component.hpp"
+#include "trossen_sdk/hw/camera/zed_frame_cache.hpp"
+#endif
+
+#ifdef TROSSEN_ENABLE_REALSENSE
+#include "trossen_sdk/hw/camera/realsense_producer.hpp"
 #include "trossen_sdk/hw/camera/realsense_depth_producer.hpp"
 #include "trossen_sdk/hw/camera/realsense_frame_cache.hpp"
-#include "trossen_sdk/hw/camera/realsense_producer.hpp"
+#endif
+
 #include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/configuration/global_config.hpp"
 #include "trossen_sdk/configuration/loaders/json_loader.hpp"
@@ -52,6 +63,7 @@ struct Config {
   bool show_help = false;
 
   // Camera settings
+  std::string camera_type = "zed";  // mock, opencv, realsense, zed
   int camera_index = 2;
   int camera_width = 1920;
   int camera_height = 1080;
@@ -75,7 +87,8 @@ void print_usage(const char* prog_name) {
     << "  --repository-id <string> Repository identifier (default: TrossenRoboticsCommunity, "
     << "only for LeRobot backend)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
-    << "  --camera-index <num>     Camera device index (default: 2, i.e., /dev/video2)\n"
+    << "  --camera <type>          Camera type: mock, opencv, realsense, zed (default: zed)\n"
+    << "  --camera-index <num>     Camera device index for opencv (default: 2, i.e., /dev/video2)\n"
     << "  --camera-width <pixels>  Camera width (default: 1920)\n"
     << "  --camera-height <pixels> Camera height (default: 1080)\n"
     << "  --camera-fps <fps>       Camera frame rate (default: 30)\n"
@@ -87,6 +100,8 @@ void print_usage(const char* prog_name) {
     << "Examples:\n"
     << "  " << prog_name << "\n"
     << "  " << prog_name << " --mock\n"
+    << "  " << prog_name << " --camera realsense\n"
+    << "  " << prog_name << " --camera opencv --camera-index 0\n"
     << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
 }
 
@@ -105,6 +120,8 @@ Config parse_args(int argc, char** argv) {
       cfg.repository_id = argv[++i];
     } else if (arg == "--mock") {
       cfg.use_mock = true;
+    } else if (arg == "--camera" && i + 1 < argc) {
+      cfg.camera_type = argv[++i];
     } else if (arg == "--camera-index" && i + 1 < argc) {
       cfg.camera_index = std::atoi(argv[++i]);
     } else if (arg == "--camera-width" && i + 1 < argc) {
@@ -148,13 +165,17 @@ int main(int argc, char** argv) {
   auto j = trossen::configuration::JsonLoader::load("config/sdk_config.json");
   trossen::configuration::GlobalConfig::instance().load_from_json(j);
 
+  // Note: --mock flag only affects robot hardware, not camera
+  // Use --camera mock to explicitly use mock camera
+
   // Print configuration
   std::vector<std::string> config_lines = {
     "Mode:                 " + std::string(cfg.use_mock ? "Mock (no hardware)" : "Hardware"),
     "Dataset ID:           " + (cfg.dataset_id.empty() ? "<auto-generate>" : cfg.dataset_id),
     "Root directory:       " + cfg.root,
     "Repository ID:        " + cfg.repository_id,
-    "Backend:              " + cfg.backend_type
+    "Backend:              " + cfg.backend_type,
+    "Camera Type:          " + cfg.camera_type
   };
 
   if (!cfg.use_mock) {
@@ -163,10 +184,22 @@ int main(int argc, char** argv) {
   }
 
   config_lines.push_back("Joint rate:           " + std::to_string(cfg.joint_rate_hz) + " Hz");
-  config_lines.push_back(
-    "Camera:               /dev/video" + std::to_string(cfg.camera_index) +
-    " @ " + std::to_string(cfg.camera_width) + "x" + std::to_string(cfg.camera_height) +
-    " @ " + std::to_string(cfg.camera_fps) + " fps");
+
+  // Add camera-specific info
+  if (cfg.camera_type == "opencv") {
+    config_lines.push_back(
+      "Camera:               /dev/video" + std::to_string(cfg.camera_index) +
+      " @ " + std::to_string(cfg.camera_width) + "x" + std::to_string(cfg.camera_height) +
+      " @ " + std::to_string(cfg.camera_fps) + " fps");
+  } else if (cfg.camera_type == "mock") {
+    config_lines.push_back(
+      "Camera:               Mock (" +
+      std::to_string(cfg.camera_width) + "x" + std::to_string(cfg.camera_height) +
+      " @ " + std::to_string(cfg.camera_fps) + " fps)");
+  } else {
+    // For ZED and RealSense, just show the type (details will be shown during setup)
+    config_lines.push_back("Camera:               " + cfg.camera_type);
+  }
 
   trossen::demo::print_config_banner("Trossen AI LeRobot Solo Complete Demo", config_lines);
 
@@ -275,9 +308,24 @@ int main(int argc, char** argv) {
   auto joint_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.joint_rate_hz));
   mgr.add_producer(joint_producer, joint_period);
 
-  // Camera producer (OpenCV or mock)
+  // Camera producer setup
+
+  std::cout << "\nSetting up camera producer (type: " << cfg.camera_type << ")...\n";
+
   std::shared_ptr<trossen::hw::PolledProducer> camera_producer;
-  if (cfg.use_mock) {
+  std::shared_ptr<trossen::hw::PolledProducer> depth_producer;  // Optional depth producer
+  auto camera_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.camera_fps));
+
+  // Component storage (must outlive producers)
+#ifdef TROSSEN_ENABLE_ZED
+  std::shared_ptr<trossen::hw::camera::ZedCameraComponent> zed_component;
+#endif
+#ifdef TROSSEN_ENABLE_REALSENSE
+  std::shared_ptr<rs2::pipeline> rs_pipeline_ptr;
+#endif
+
+  if (cfg.camera_type == "mock") {
+    // Mock Camera
     trossen::hw::camera::MockCameraProducer::Config cam_cfg;
     cam_cfg.width = cfg.camera_width;
     cam_cfg.height = cfg.camera_height;
@@ -289,7 +337,9 @@ int main(int argc, char** argv) {
     camera_producer = std::make_shared<trossen::hw::camera::MockCameraProducer>(cam_cfg);
     std::cout << "  ✓ Mock camera producer (" << cfg.camera_fps << " Hz, "
               << cfg.camera_width << "x" << cfg.camera_height << ")\n";
-  } else {
+
+  } else if (cfg.camera_type == "opencv") {
+    // OpenCV Camera
     trossen::hw::camera::OpenCvCameraProducer::Config cam_cfg;
     cam_cfg.device_index = cfg.camera_index;
     cam_cfg.stream_id = "camera_main";
@@ -300,89 +350,180 @@ int main(int argc, char** argv) {
     cam_cfg.use_device_time = false;
     camera_producer = std::make_shared<trossen::hw::camera::OpenCvCameraProducer>(cam_cfg);
     std::cout << "  ✓ OpenCV camera producer (" << cfg.camera_fps << " Hz, "
-              << cfg.camera_width << "x" << cfg.camera_height << ")\n";
+              << cfg.camera_width << "x" << cfg.camera_height << ", /dev/video"
+              << cfg.camera_index << ")\n";
+
+#ifdef TROSSEN_ENABLE_REALSENSE
+  } else if (cfg.camera_type == "realsense") {
+    // RealSense Camera
+    // Note: This section can be customized with command-line args if needed
+    std::string serial_number = "";  // Empty = use any available camera
+    int rs_width = 640;
+    int rs_height = 480;
+    int rs_fps = 30;
+    bool enable_depth = true;
+
+    // Create RealSense config
+    rs2::config cam_cfg;
+    rs2::pipeline rs_pipeline;
+    rs_pipeline_ptr = std::make_shared<rs2::pipeline>(rs_pipeline);
+
+    // Enable the device using serial number (if provided)
+    if (!serial_number.empty()) {
+      cam_cfg.enable_device(serial_number);
+    }
+
+    // Enable color and depth streams
+    cam_cfg.enable_stream(RS2_STREAM_COLOR, rs_width, rs_height, RS2_FORMAT_RGB8, rs_fps);
+    if (enable_depth) {
+      cam_cfg.enable_stream(RS2_STREAM_DEPTH, rs_width, rs_height, RS2_FORMAT_Z16, rs_fps);
+    }
+
+    // Start the camera pipeline
+    try {
+      rs2::pipeline_profile profile = rs_pipeline_ptr->start(cam_cfg);
+      auto dev = profile.get_device();
+      serial_number = std::string(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
+      std::cout << "  ✓ RealSense camera opened (SN: " << serial_number << ")\n";
+    } catch (const rs2::error& e) {
+      std::cerr << "Failed to start RealSense camera: " << e.what() << "\n";
+      return 1;
+    }
+
+    // Create frame cache (consumer count = 2 if depth enabled, else 1)
+    int consumer_count = enable_depth ? 2 : 1;
+    auto frame_cache =
+      std::make_shared<trossen::hw::camera::RealsenseFrameCache>(rs_pipeline_ptr, consumer_count);
+
+    // Create color producer
+    trossen::hw::camera::RealsenseCameraProducer::Config rs_cfg;
+    rs_cfg.serial_number = serial_number;
+    rs_cfg.stream_id = "realsense_camera_main";
+    rs_cfg.encoding = "bgr8";
+    rs_cfg.width = rs_width;
+    rs_cfg.height = rs_height;
+    rs_cfg.fps = rs_fps;
+    rs_cfg.use_device_time = true;
+    rs_cfg.warmup_seconds = 2.0;
+
+    camera_producer =
+      std::make_shared<trossen::hw::camera::RealsenseCameraProducer>(frame_cache, rs_cfg);
+    std::cout << "  ✓ RealSense color producer (" << rs_fps << " Hz, "
+              << rs_width << "x" << rs_height << ")\n";
+
+    // Create depth producer (if enabled)
+    if (enable_depth) {
+      trossen::hw::camera::RealsenseDepthCameraProducer::Config rs_depth_cfg;
+      rs_depth_cfg.serial_number = serial_number;
+      rs_depth_cfg.stream_id = "realsense_depth_camera_main";
+      rs_depth_cfg.encoding = "16UC1";
+      rs_depth_cfg.width = rs_width;
+      rs_depth_cfg.height = rs_height;
+      rs_depth_cfg.fps = rs_fps;
+      rs_depth_cfg.use_device_time = true;
+      rs_depth_cfg.warmup_seconds = 2.0;
+
+      depth_producer =
+        std::make_shared<trossen::hw::camera::RealsenseDepthCameraProducer>(
+          frame_cache, rs_depth_cfg);
+      std::cout << "  ✓ RealSense depth producer (" << rs_fps << " Hz, "
+                << rs_width << "x" << rs_height << ")\n";
+    }
+#endif
+
+#ifdef TROSSEN_ENABLE_ZED
+  } else if (cfg.camera_type == "zed") {
+    // ────────────── ZED Camera ──────────────
+    // Note: This section can be customized with command-line args if needed
+    std::string resolution = "SVGA";  // SVGA, HD720, HD1080, HD2K
+    int zed_fps = 30;
+    bool enable_depth = true;
+    std::string depth_mode = "PERFORMANCE";  // PERFORMANCE, QUALITY, ULTRA, NEURAL
+
+    // Create ZED camera component (must outlive producers)
+    zed_component = std::make_shared<trossen::hw::camera::ZedCameraComponent>("zed_main");
+
+    nlohmann::json zed_config = {
+      {"resolution", resolution},
+      {"fps", zed_fps},
+      {"use_depth", enable_depth},
+      {"depth_mode", depth_mode}
+    };
+
+    zed_component->configure(zed_config);
+    auto zed_cache = zed_component->get_hardware();
+    int serial_number = zed_component->get_serial_number();
+
+    // Create ZED color producer
+    trossen::hw::camera::ZedCameraProducer::Config zed_cfg;
+    zed_cfg.serial_number = serial_number;
+    zed_cfg.stream_id = "zed_camera_main";
+    zed_cfg.encoding = "bgr8";
+    zed_cfg.width = 672;   // Actual resolution depends on camera model
+    zed_cfg.height = 376;
+    zed_cfg.fps = zed_fps;
+    zed_cfg.use_device_time = true;
+    zed_cfg.warmup_seconds = 1.0;
+
+    camera_producer = std::make_shared<trossen::hw::camera::ZedCameraProducer>(zed_cache, zed_cfg);
+
+    // Perform warmup
+    auto zed_producer =
+      std::dynamic_pointer_cast<trossen::hw::camera::ZedCameraProducer>(camera_producer);
+    if (zed_producer) {
+      zed_producer->warmup();
+    }
+
+    std::cout << "  ✓ ZED color producer (" << zed_fps << " Hz, " << resolution
+              << ", SN: " << serial_number << ")\n";
+
+    // Create ZED depth producer (if enabled)
+    if (enable_depth) {
+      trossen::hw::camera::ZedDepthCameraProducer::Config zed_depth_cfg;
+      zed_depth_cfg.serial_number = serial_number;
+      zed_depth_cfg.stream_id = "zed_depth_camera_main";
+      zed_depth_cfg.encoding = "16UC1";
+      zed_depth_cfg.width = 672;
+      zed_depth_cfg.height = 376;
+      zed_depth_cfg.fps = zed_fps;
+      zed_depth_cfg.use_device_time = true;
+      zed_depth_cfg.warmup_seconds = 1.0;
+
+      depth_producer =
+        std::make_shared<trossen::hw::camera::ZedDepthCameraProducer>(zed_cache, zed_depth_cfg);
+
+      // Perform warmup for depth
+      if (depth_producer) {
+        auto zed_depth =
+          std::dynamic_pointer_cast<trossen::hw::camera::ZedDepthCameraProducer>(depth_producer);
+        if (zed_depth) {
+          zed_depth->warmup();
+        }
+      }
+
+      std::cout << "  ✓ ZED depth producer (" << zed_fps << " Hz, " << resolution
+                << ", mode: " << depth_mode << ")\n";
+    }
+#endif
+
+  } else {
+    std::cerr << "Error: Unknown camera type '" << cfg.camera_type << "'\n";
+    std::cerr << "Supported types: mock, opencv";
+#ifdef TROSSEN_ENABLE_REALSENSE
+    std::cerr << ", realsense";
+#endif
+#ifdef TROSSEN_ENABLE_ZED
+    std::cerr << ", zed";
+#endif
+    std::cerr << "\n";
+    return 1;
   }
 
-  auto camera_period = std::chrono::milliseconds(static_cast<int>(1000.0f / cfg.camera_fps));
+  // Register camera producer(s)
   mgr.add_producer(camera_producer, camera_period);
-
-  // TODO(shantanuparab-tr): Add this to configurations after main executable is created
-  // // Create a Realsense Camera Producer (Hardcoded configuration for demo purposes)
-
-  // trossen::hw::camera::RealsenseCameraProducer::Config realsense_cfg;
-  // realsense_cfg.serial_number = "218622274938";  // Replace with your camera's serial number
-  // realsense_cfg.stream_id = "realsense_camera0";
-  // realsense_cfg.encoding = "bgr8";
-  // realsense_cfg.width = 640;
-  // realsense_cfg.height = 480;
-  // realsense_cfg.fps = 30;
-  // realsense_cfg.use_device_time = true;
-  // realsense_cfg.warmup_seconds = 2.0;
-
-  // // Create Realsense config
-  // rs2::config cam_cfg;
-
-  // // Create a realsense pipeline
-  // rs2::pipeline realsense_pipeline;
-  // auto camera_ = std::make_shared<rs2::pipeline>(realsense_pipeline);
-
-  // // Enable the device using the unique ID
-  // if (!realsense_cfg.serial_number.empty()) {
-  //   cam_cfg.enable_device(realsense_cfg.serial_number);
-  // } else {
-  //   std::cout << "Unique ID is empty. Cannot connect to RealSense camera: "
-  //     << realsense_cfg.stream_id << std::endl;
-  //   throw std::runtime_error("Unique ID is empty for camera: " + realsense_cfg.stream_id);
-  // }
-
-  // // Enable the color stream as default
-  // cam_cfg.enable_stream(RS2_STREAM_COLOR, realsense_cfg.width, realsense_cfg.height,
-  //                   RS2_FORMAT_RGB8, realsense_cfg.fps);
-
-  // // Make this conditional to enable depth stream
-  // cam_cfg.enable_stream(RS2_STREAM_DEPTH, realsense_cfg.width, realsense_cfg.height,
-  //                   RS2_FORMAT_Z16, realsense_cfg.fps);
-  // try {
-  //   // Start the camera pipeline
-  //   rs2::pipeline_profile profile = camera_->start(cam_cfg);
-  // } catch (const rs2::error& e) {
-  //   std::cout << "Failed to enable device with Unique ID: " << realsense_cfg.serial_number
-  //             << ". Error: " << e.what() << ". Listing all available cameras." << std::endl;
-  //   std::cout << "Available cameras listed above. Please check outputs folder to get "
-  //       "Available cameras listed above. Please check outputs folder to get "
-  //       "images associated "
-  //       "with each camera." << std::endl;
-  //   throw std::runtime_error(
-  //       "Unique ID (serial number) is required to connect to RealSense camera");
-  // }
-
-  // auto frame_cache = std::make_shared<trossen::hw::camera::RealsenseFrameCache>(camera_, 2);
-
-  // auto realsense_producer =
-  //   std::make_shared<trossen::hw::camera::RealsenseCameraProducer>(frame_cache, realsense_cfg);
-
-  // auto realsense_period = std::chrono::milliseconds(static_cast<int>(1000.0f / 30.0f));
-
-  // mgr.add_producer(realsense_producer, realsense_period);
-  // std::cout << "  ✓ Realsense camera producer (30 Hz, 640x480)\n";
-
-  // trossen::hw::camera::RealsenseDepthCameraProducer::Config realsense_depth_cfg;
-  // // Replace with your camera's serial number
-  // realsense_depth_cfg.serial_number = "218622274938";
-  // realsense_depth_cfg.stream_id = "realsense_depth_camera0";
-  // realsense_depth_cfg.encoding = "16UC1";
-  // realsense_depth_cfg.width = 640;
-  // realsense_depth_cfg.height = 480;
-  // realsense_depth_cfg.fps = 30;
-  // realsense_depth_cfg.use_device_time = true;
-  // realsense_depth_cfg.warmup_seconds = 2.0;
-
-  // auto realsense_depth_producer =
-  //   std::make_shared<trossen::hw::camera::RealsenseDepthCameraProducer>(
-  //     frame_cache,
-  //     realsense_depth_cfg);
-  // mgr.add_producer(realsense_depth_producer, realsense_period);
-  // std::cout << "  ✓ Realsense depth camera producer (30 Hz, 640x480)\n";
+  if (depth_producer) {
+    mgr.add_producer(depth_producer, camera_period);
+  }
 
   std::cout << "\nProducers registered. Ready to record.\n";
 
@@ -488,11 +629,14 @@ int main(int argc, char** argv) {
     // Sanity check: verify expected record counts
     // ──────────────────────────────────────────────────────────
 
+    // Calculate expected camera count (1 or 2 depending on depth)
+    int camera_count = depth_producer ? 2 : 1;
+
     trossen::demo::SanityCheckConfig sanity_cfg{
       last_stats.recording_duration_s.value_or(0.0),
       1,  // 1 joint producer (follower)
       cfg.joint_rate_hz,
-      1,  // 1 camera
+      camera_count,
       cfg.camera_fps,
       5.0  // 5% tolerance
     };

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -32,16 +32,16 @@
 #include "trossen_sdk/hw/camera/mock_producer.hpp"
 
 #ifdef TROSSEN_ENABLE_ZED
-#include "trossen_sdk/hw/camera/zed_producer.hpp"
-#include "trossen_sdk/hw/camera/zed_depth_producer.hpp"
 #include "trossen_sdk/hw/camera/zed_camera_component.hpp"
+#include "trossen_sdk/hw/camera/zed_depth_producer.hpp"
 #include "trossen_sdk/hw/camera/zed_frame_cache.hpp"
+#include "trossen_sdk/hw/camera/zed_producer.hpp"
 #endif
 
 #ifdef TROSSEN_ENABLE_REALSENSE
-#include "trossen_sdk/hw/camera/realsense_producer.hpp"
 #include "trossen_sdk/hw/camera/realsense_depth_producer.hpp"
 #include "trossen_sdk/hw/camera/realsense_frame_cache.hpp"
+#include "trossen_sdk/hw/camera/realsense_producer.hpp"
 #endif
 
 #include "trossen_sdk/io/backend_utils.hpp"

--- a/examples/widowxai_lerobot.cpp
+++ b/examples/widowxai_lerobot.cpp
@@ -63,7 +63,7 @@ struct Config {
   bool show_help = false;
 
   // Camera settings
-  std::string camera_type = "zed";  // mock, opencv, realsense, zed
+  std::string camera_type = "opencv";  // mock, opencv, realsense, zed
   int camera_index = 2;
   int camera_width = 1920;
   int camera_height = 1080;
@@ -87,7 +87,7 @@ void print_usage(const char* prog_name) {
     << "  --repository-id <string> Repository identifier (default: TrossenRoboticsCommunity, "
     << "only for LeRobot backend)\n"
     << "  --mock                   Use mock producers instead of real hardware\n"
-    << "  --camera <type>          Camera type: mock, opencv, realsense, zed (default: zed)\n"
+    << "  --camera_type            Camera type: mock, opencv, realsense, zed (default: opencv)\n"
     << "  --camera-index <num>     Camera device index for opencv (default: 2, i.e., /dev/video2)\n"
     << "  --camera-width <pixels>  Camera width (default: 1920)\n"
     << "  --camera-height <pixels> Camera height (default: 1080)\n"
@@ -100,8 +100,8 @@ void print_usage(const char* prog_name) {
     << "Examples:\n"
     << "  " << prog_name << "\n"
     << "  " << prog_name << " --mock\n"
-    << "  " << prog_name << " --camera realsense\n"
-    << "  " << prog_name << " --camera opencv --camera-index 0\n"
+    << "  " << prog_name << " --camera_type realsense\n"
+    << "  " << prog_name << " --camera_type opencv --camera-index 0\n"
     << "  " << prog_name << " --dataset-id solo_demo_001 --root /data/recordings\n";
 }
 
@@ -120,7 +120,7 @@ Config parse_args(int argc, char** argv) {
       cfg.repository_id = argv[++i];
     } else if (arg == "--mock") {
       cfg.use_mock = true;
-    } else if (arg == "--camera" && i + 1 < argc) {
+    } else if (arg == "--camera_type" && i + 1 < argc) {
       cfg.camera_type = argv[++i];
     } else if (arg == "--camera-index" && i + 1 < argc) {
       cfg.camera_index = std::atoi(argv[++i]);

--- a/include/trossen_sdk/hw/camera/zed_camera_component.hpp
+++ b/include/trossen_sdk/hw/camera/zed_camera_component.hpp
@@ -1,0 +1,136 @@
+/**
+ * @file zed_camera_component.hpp
+ * @brief Hardware component for ZED cameras
+ */
+
+#ifndef TROSSEN_SDK__HW__CAMERA__ZED_CAMERA_COMPONENT_HPP
+#define TROSSEN_SDK__HW__CAMERA__ZED_CAMERA_COMPONENT_HPP
+
+#include <memory>
+#include <string>
+
+#include "trossen_sdk/hw/camera/zed_frame_cache.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+
+namespace trossen::hw::camera {
+
+/**
+ * @brief Hardware component for ZED cameras
+ *
+ * This component manages the lifecycle of a ZED camera and provides
+ * a frame cache for use by color and depth producers.
+ */
+class ZedCameraComponent : public HardwareComponent {
+public:
+  /**
+   * @brief Construct ZED camera component
+   *
+   * @param identifier Unique identifier for this camera instance
+   */
+  explicit ZedCameraComponent(std::string identifier)
+    : HardwareComponent(std::move(identifier)) {}
+
+  /**
+   * @brief Destructor closes camera if open
+   */
+  ~ZedCameraComponent() override;
+
+  /**
+   * @brief Configure camera from JSON
+   *
+   * Expected JSON structure:
+   * {
+   *   "serial_number": 0,          // Optional, 0 = use any camera
+   *   "resolution": "SVGA",        // VGA, SVGA, HD720, HD1080, HD2K
+   *   "fps": 30,                   // Camera frame rate
+   *   "use_depth": false,          // Enable depth computation
+   *   "depth_mode": "NONE"         // NONE, PERFORMANCE, QUALITY, ULTRA, NEURAL
+   * }
+   *
+   * @param config JSON configuration object
+   */
+  void configure(const nlohmann::json& config) override;
+
+  /**
+   * @brief Get the type string for this hardware component
+   *
+   * @return Type identifier "zed_camera"
+   */
+  std::string get_type() const override { return "zed_camera"; }
+
+  /**
+   * @brief Get camera info as JSON
+   *
+   * @return JSON object with camera details
+   */
+  nlohmann::json get_info() const override;
+
+  /**
+   * @brief Check if camera is opened
+   *
+   * @return true if camera is opened, false otherwise
+   */
+  bool is_opened() const;
+
+  /**
+   * @brief Get frame cache for use by producers
+   *
+   * @return Shared pointer to frame cache
+   */
+  std::shared_ptr<ZedFrameCache> get_hardware() const {
+    return frame_cache_;
+  }
+
+  /**
+   * @brief Get camera serial number
+   *
+   * @return Serial number of the camera
+   */
+  int get_serial_number() const { return serial_number_; }
+
+  /**
+   * @brief Get image width
+   *
+   * @return Width in pixels
+   */
+  int get_width() const { return width_; }
+
+  /**
+   * @brief Get image height
+   *
+   * @return Height in pixels
+   */
+  int get_height() const { return height_; }
+
+private:
+  /// @brief ZED camera instance
+  std::shared_ptr<sl::Camera> camera_;
+
+  /// @brief Frame cache (shared between color and depth producers)
+  std::shared_ptr<ZedFrameCache> frame_cache_;
+
+  /// @brief Camera serial number (0 = use any)
+  int serial_number_{0};
+
+  /// @brief Camera resolution
+  sl::RESOLUTION resolution_{sl::RESOLUTION::SVGA};
+
+  /// @brief Camera FPS
+  int fps_{30};
+
+  /// @brief Whether to use depth
+  bool use_depth_{false};
+
+  /// @brief Depth computation mode
+  sl::DEPTH_MODE depth_mode_{sl::DEPTH_MODE::NONE};
+
+  /// @brief Actual image width (from camera calibration)
+  int width_{0};
+
+  /// @brief Actual image height (from camera calibration)
+  int height_{0};
+};
+
+}  // namespace trossen::hw::camera
+
+#endif  // TROSSEN_SDK__HW__CAMERA__ZED_CAMERA_COMPONENT_HPP

--- a/include/trossen_sdk/hw/camera/zed_camera_component.hpp
+++ b/include/trossen_sdk/hw/camera/zed_camera_component.hpp
@@ -44,7 +44,8 @@ public:
    *   "resolution": "SVGA",        // VGA, SVGA, HD720, HD1080, HD2K
    *   "fps": 30,                   // Camera frame rate
    *   "use_depth": false,          // Enable depth computation
-   *   "depth_mode": "NONE"         // NONE, PERFORMANCE, QUALITY, ULTRA, NEURAL
+   *   "depth_mode": "NONE",        // NONE, PERFORMANCE, QUALITY, ULTRA, NEURAL
+   *   "warmup_seconds": 0.0        // Seconds to warm up (discard initial frames)
    * }
    *
    * @param config JSON configuration object
@@ -103,6 +104,16 @@ public:
   int get_height() const { return height_; }
 
 private:
+  /**
+   * @brief Perform warmup by discarding initial frames
+   *
+   * Called automatically after camera is opened in configure().
+   * Includes error handling to prevent infinite loops.
+   *
+   * @return true on success, false on failure
+   */
+  bool warmup();
+
   /// @brief ZED camera instance
   std::shared_ptr<sl::Camera> camera_;
 
@@ -129,6 +140,9 @@ private:
 
   /// @brief Actual image height (from camera calibration)
   int height_{0};
+
+  /// @brief Seconds to warm up (discard initial frames)
+  double warmup_seconds_{0.0};
 };
 
 }  // namespace trossen::hw::camera

--- a/include/trossen_sdk/hw/camera/zed_depth_producer.hpp
+++ b/include/trossen_sdk/hw/camera/zed_depth_producer.hpp
@@ -51,9 +51,6 @@ public:
     /// @brief Prefer device timestamp if available
     bool use_device_time{true};
 
-    /// @brief Seconds to warm up (discard frames) after device open before emitting
-    double warmup_seconds{0.0};
-
     /// @brief Whether to enforce the requested fps (may reduce if device cannot keep up)
     bool enforce_requested_fps = true;
   };
@@ -146,13 +143,6 @@ public:
   std::shared_ptr<ProducerMetadata> metadata() const override {
     return std::make_shared<ZedDepthCameraProducerMetadata>(metadata_);
   }
-
-  /**
-   * @brief Perform warmup (discard initial frames)
-   *
-   * @return true on success, false on failure
-   */
-  bool warmup();
 
 private:
   /// @brief Frame cache shared with color producer

--- a/include/trossen_sdk/hw/camera/zed_depth_producer.hpp
+++ b/include/trossen_sdk/hw/camera/zed_depth_producer.hpp
@@ -40,10 +40,10 @@ public:
     std::string encoding{"16UC1"};
 
     /// @brief Desired image width (pixels)
-    int width{672};
+    int width{0};
 
     /// @brief Desired image height (pixels)
-    int height{376};
+    int height{0};
 
     /// @brief Desired frame rate (fps)
     int fps{30};

--- a/include/trossen_sdk/hw/camera/zed_depth_producer.hpp
+++ b/include/trossen_sdk/hw/camera/zed_depth_producer.hpp
@@ -1,0 +1,191 @@
+/**
+ * @file zed_depth_producer.hpp
+ * @brief Camera producer for depth using ZED SDK for real hardware.
+ */
+
+#ifndef TROSSEN_SDK__HW__CAMERA__ZED_DEPTH_PRODUCER_HPP
+#define TROSSEN_SDK__HW__CAMERA__ZED_DEPTH_PRODUCER_HPP
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "opencv2/imgproc.hpp"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/camera/zed_frame_cache.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::hw::camera {
+
+/**
+ * @brief Depth camera producer using ZED SDK for real hardware.
+ */
+class ZedDepthCameraProducer : public ::trossen::hw::PolledProducer {
+public:
+  /**
+   * @brief Configuration parameters for ZedDepthCameraProducer
+   */
+  struct Config {
+    /// @brief Serial Number of the camera device
+    int serial_number{0};
+
+    /// @brief Logical stream identifier (e.g. "zed_depth_camera_main")
+    std::string stream_id{"zed_depth_camera_main"};
+
+    /// @brief Desired output image encoding (e.g. "16UC1" for 16-bit depth)
+    std::string encoding{"16UC1"};
+
+    /// @brief Desired image width (pixels)
+    int width{672};
+
+    /// @brief Desired image height (pixels)
+    int height{376};
+
+    /// @brief Desired frame rate (fps)
+    int fps{30};
+
+    /// @brief Prefer device timestamp if available
+    bool use_device_time{true};
+
+    /// @brief Seconds to warm up (discard frames) after device open before emitting
+    double warmup_seconds{0.0};
+
+    /// @brief Whether to enforce the requested fps (may reduce if device cannot keep up)
+    bool enforce_requested_fps = true;
+  };
+
+  /**
+   * @brief Metadata specific to ZedDepthCameraProducer
+   */
+  struct ZedDepthCameraProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// @brief Image width
+    int width;
+
+    /// @brief Image height
+    int height;
+
+    /// @brief Image encoding
+    std::string codec;
+
+    /// @brief Pixel format
+    std::string pix_fmt;
+
+    /// @brief Channels
+    int channels;
+
+    /// @brief Does the camera have an audio stream?
+    bool has_audio{false};
+
+    /// @brief Target frames per second
+    int fps;
+
+    /// @brief Is this a depth camera?
+    bool is_depth_map{true};
+
+    /**
+     * @brief Get producer info as JSON
+     *
+     * @return JSON object containing producer information
+     */
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      nlohmann::ordered_json camera_feature;
+      camera_feature["id"] = id;
+      camera_feature["dtype"] = "video";
+      camera_feature["shape"] = {height, width, 1};
+      camera_feature["names"] = {"height", "width", "channel"};
+      camera_feature["info"] = {
+        {"video.encoding", "depth"}
+      };
+      features["observation.images." + name] = camera_feature;
+
+      nlohmann::ordered_json j = PolledProducer::ProducerMetadata::get_info();
+      j["features"] = features;
+      j["width"] = width;
+      j["height"] = height;
+      j["codec"] = codec;
+      j["pix_fmt"] = pix_fmt;
+      j["channels"] = channels;
+      j["has_audio"] = has_audio;
+      j["fps"] = fps;
+      j["is_depth_map"] = is_depth_map;
+
+      return j;
+    }
+  };
+
+  /**
+   * @brief Construct ZedDepthCameraProducer
+   *
+   * @param frame_cache Shared frame cache from ZedCameraComponent
+   * @param cfg Configuration parameters
+   */
+  ZedDepthCameraProducer(std::shared_ptr<ZedFrameCache> frame_cache, Config cfg);
+
+  /**
+   * @brief Destructor
+   */
+  ~ZedDepthCameraProducer() override;
+
+  /**
+   * @brief Poll for new depth frames
+   *
+   * @param emit Callback to emit records
+   */
+  void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  /**
+   * @brief Get producer metadata
+   *
+   * @return Shared pointer to metadata
+   */
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<ZedDepthCameraProducerMetadata>(metadata_);
+  }
+
+  /**
+   * @brief Perform warmup (discard initial frames)
+   *
+   * @return true on success, false on failure
+   */
+  bool warmup();
+
+private:
+  /// @brief Frame cache shared with color producer
+  std::shared_ptr<ZedFrameCache> frame_cache_;
+
+  /// @brief Configuration
+  Config cfg_;
+
+  /// @brief Metadata
+  ZedDepthCameraProducerMetadata metadata_;
+
+  /// @brief Sequence number for frames
+  uint64_t seq_{0};
+
+  /// @brief Whether camera has been opened
+  bool opened_{false};
+
+  /// @brief Last capture monotonic timestamp (ns) for inter-frame timing
+  uint64_t last_capture_mono_{0};
+
+  /// @brief Inter-frame timing accumulator (ns)
+  uint64_t if_accum_ns_{0};
+
+  /// @brief Max inter-frame time (ns)
+  uint64_t if_max_ns_{0};
+
+  /// @brief Number of inter-frame samples
+  uint64_t if_samples_{0};
+
+  /// @brief Next frame number to report health stats
+  uint64_t next_health_report_frame_{300};
+};
+
+}  // namespace trossen::hw::camera
+
+#endif  // TROSSEN_SDK__HW__CAMERA__ZED_DEPTH_PRODUCER_HPP

--- a/include/trossen_sdk/hw/camera/zed_frame_cache.hpp
+++ b/include/trossen_sdk/hw/camera/zed_frame_cache.hpp
@@ -1,0 +1,113 @@
+/**
+ * @file zed_frame_cache.hpp
+ * @brief Frame cache for ZED SDK camera frames.
+ */
+
+#ifndef TROSSEN_SDK__HW__CAMERA__ZED_FRAME_CACHE_HPP
+#define TROSSEN_SDK__HW__CAMERA__ZED_FRAME_CACHE_HPP
+
+#include <memory>
+#include <mutex>
+
+#include <sl/Camera.hpp>
+
+namespace trossen::hw::camera {
+
+/**
+ * @brief Frame cache for ZED camera to share frames between color and depth producers
+ *
+ * Similar to RealsenseFrameCache, this class ensures that when multiple producers
+ * (e.g., color and depth) need frames from the same camera, we only call grab() once
+ * and share the result.
+ */
+class ZedFrameCache {
+public:
+  /**
+   * @brief Construct a ZED frame cache
+   *
+   * @param camera Shared pointer to ZED camera instance
+   * @param num_consumers Expected number of consumers (e.g., 1 for color only, 2 for color+depth)
+   */
+  explicit ZedFrameCache(std::shared_ptr<sl::Camera> camera, size_t num_consumers)
+    : camera_(std::move(camera)),
+      expected_consumers_(num_consumers),
+      consumed_(0),
+      has_grabbed_(false) {}
+
+  /**
+   * @brief Get frames from the ZED camera with caching for multiple consumers
+   *
+   * The first consumer triggers camera->grab(), subsequent consumers reuse the result.
+   * After all expected consumers have called this, the cache is cleared for the next frame.
+   *
+   * @return sl::ERROR_CODE from grab() operation
+   */
+  sl::ERROR_CODE grab() {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // First consumer grabs new frame
+    if (!has_grabbed_) {
+      // Add runtime parameters for grab() - required for proper operation
+      sl::RuntimeParameters runtime_params;
+      runtime_params.confidence_threshold = 50;
+      runtime_params.texture_confidence_threshold = 100;
+
+      last_error_ = camera_->grab(runtime_params);
+      has_grabbed_ = true;
+      consumed_ = 0;
+    }
+
+    ++consumed_;
+
+    // Last consumer clears the cache
+    if (consumed_ >= expected_consumers_) {
+      has_grabbed_ = false;
+      consumed_ = 0;
+    }
+
+    return last_error_;
+  }
+
+  /**
+   * @brief Reset the frame cache state
+   *
+   * Call this when starting/stopping episodes to ensure clean state
+   */
+  void reset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    has_grabbed_ = false;
+    consumed_ = 0;
+  }
+
+  /**
+   * @brief Get the underlying camera instance for retrieving images/depth
+   *
+   * @return Shared pointer to the sl::Camera
+   */
+  std::shared_ptr<sl::Camera> get_camera() const {
+    return camera_;
+  }
+
+private:
+  /// @brief ZED camera instance
+  std::shared_ptr<sl::Camera> camera_;
+
+  /// @brief Mutex to protect cache state
+  std::mutex mutex_;
+
+  /// @brief Number of expected consumers
+  size_t expected_consumers_;
+
+  /// @brief Number of consumers that have consumed the current frame
+  size_t consumed_;
+
+  /// @brief Whether grab() has been called for current frame
+  bool has_grabbed_;
+
+  /// @brief Last grab error code
+  sl::ERROR_CODE last_error_;
+};
+
+}  // namespace trossen::hw::camera
+
+#endif  // TROSSEN_SDK__HW__CAMERA__ZED_FRAME_CACHE_HPP

--- a/include/trossen_sdk/hw/camera/zed_frame_cache.hpp
+++ b/include/trossen_sdk/hw/camera/zed_frame_cache.hpp
@@ -13,6 +13,10 @@
 
 namespace trossen::hw::camera {
 
+// ZED depth filtering confidence thresholds (0-100: lower=permissive, higher=strict)
+constexpr int ZED_DEFAULT_CONFIDENCE_THRESHOLD = 50;          // General depth confidence
+constexpr int ZED_DEFAULT_TEXTURE_CONFIDENCE_THRESHOLD = 100;  // Texture-based filtering
+
 /**
  * @brief Frame cache for ZED camera to share frames between color and depth producers
  *
@@ -49,8 +53,8 @@ public:
     if (!has_grabbed_) {
       // Add runtime parameters for grab() - required for proper operation
       sl::RuntimeParameters runtime_params;
-      runtime_params.confidence_threshold = 50;
-      runtime_params.texture_confidence_threshold = 100;
+      runtime_params.confidence_threshold = ZED_DEFAULT_CONFIDENCE_THRESHOLD;
+      runtime_params.texture_confidence_threshold = ZED_DEFAULT_TEXTURE_CONFIDENCE_THRESHOLD;
 
       last_error_ = camera_->grab(runtime_params);
       has_grabbed_ = true;

--- a/include/trossen_sdk/hw/camera/zed_frame_cache.hpp
+++ b/include/trossen_sdk/hw/camera/zed_frame_cache.hpp
@@ -17,13 +17,6 @@ namespace trossen::hw::camera {
 constexpr int ZED_DEFAULT_CONFIDENCE_THRESHOLD = 50;          // General depth confidence
 constexpr int ZED_DEFAULT_TEXTURE_CONFIDENCE_THRESHOLD = 100;  // Texture-based filtering
 
-/**
- * @brief Frame cache for ZED camera to share frames between color and depth producers
- *
- * Similar to RealsenseFrameCache, this class ensures that when multiple producers
- * (e.g., color and depth) need frames from the same camera, we only call grab() once
- * and share the result.
- */
 class ZedFrameCache {
 public:
   /**

--- a/include/trossen_sdk/hw/camera/zed_producer.hpp
+++ b/include/trossen_sdk/hw/camera/zed_producer.hpp
@@ -1,0 +1,188 @@
+/**
+ * @file zed_producer.hpp
+ * @brief Camera producer using ZED SDK for real hardware.
+ */
+
+#ifndef TROSSEN_SDK__HW__CAMERA__ZED_PRODUCER_HPP
+#define TROSSEN_SDK__HW__CAMERA__ZED_PRODUCER_HPP
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "opencv2/imgproc.hpp"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/camera/zed_frame_cache.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::hw::camera {
+
+/**
+ * @brief Camera producer using ZED SDK for real hardware.
+ */
+class ZedCameraProducer : public ::trossen::hw::PolledProducer {
+public:
+  /**
+   * @brief Configuration parameters for ZedCameraProducer
+   */
+  struct Config {
+    /// @brief Serial Number of the camera device
+    int serial_number{0};
+
+    /// @brief Logical stream identifier (e.g. "zed_camera_main")
+    std::string stream_id{"zed_camera_main"};
+
+    /// @brief Desired output image encoding (e.g. "bgr8", "rgb8", "bgra8")
+    std::string encoding{"bgr8"};
+
+    /// @brief Desired image width (pixels)
+    int width{672};
+
+    /// @brief Desired image height (pixels)
+    int height{376};
+
+    /// @brief Desired frame rate (fps)
+    int fps{30};
+
+    /// @brief Prefer device timestamp if available
+    bool use_device_time{true};
+
+    /// @brief Seconds to warm up (discard frames) after device open before emitting
+    double warmup_seconds{0.0};
+
+    /// @brief Whether to enforce the requested fps (may reduce if device cannot keep up)
+    bool enforce_requested_fps = true;
+  };
+
+  /**
+   * @brief Metadata specific to ZedCameraProducer
+   */
+  struct ZedCameraProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// @brief Image width
+    int width;
+
+    /// @brief Image height
+    int height;
+
+    /// @brief Image encoding
+    std::string codec;
+
+    /// @brief Pixel format
+    std::string pix_fmt;
+
+    /// @brief Channels
+    int channels;
+
+    /// @brief Does the camera have an audio stream?
+    bool has_audio{false};
+
+    /// @brief Target frames per second
+    int fps;
+
+    /// @brief Is this a depth camera?
+    bool is_depth_map{false};
+
+    /**
+     * @brief Get producer info as JSON
+     *
+     * @return JSON object containing producer information
+     */
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      nlohmann::ordered_json camera_feature;
+      camera_feature["id"] = id;
+      camera_feature["dtype"] = "video";
+      camera_feature["shape"] = {height, width, 3};
+      camera_feature["names"] = {"height", "width", "channel"};
+      features["observation.images." + name] = camera_feature;
+
+      nlohmann::ordered_json j = PolledProducer::ProducerMetadata::get_info();
+      j["features"] = features;
+      j["width"] = width;
+      j["height"] = height;
+      j["codec"] = codec;
+      j["pix_fmt"] = pix_fmt;
+      j["channels"] = channels;
+      j["has_audio"] = has_audio;
+      j["fps"] = fps;
+      j["is_depth_map"] = is_depth_map;
+
+      return j;
+    }
+  };
+
+  /**
+   * @brief Construct ZedCameraProducer
+   *
+   * @param frame_cache Shared frame cache from ZedCameraComponent
+   * @param cfg Configuration parameters
+   */
+  ZedCameraProducer(std::shared_ptr<ZedFrameCache> frame_cache, Config cfg);
+
+  /**
+   * @brief Destructor
+   */
+  ~ZedCameraProducer() override;
+
+  /**
+   * @brief Poll for new image frames
+   *
+   * @param emit Callback to emit records
+   */
+  void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  /**
+   * @brief Get producer metadata
+   *
+   * @return Shared pointer to metadata
+   */
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<ZedCameraProducerMetadata>(metadata_);
+  }
+
+  /**
+   * @brief Perform warmup (discard initial frames)
+   *
+   * @return true on success, false on failure
+   */
+  bool warmup();
+
+private:
+  /// @brief Frame cache shared with other producers
+  std::shared_ptr<ZedFrameCache> frame_cache_;
+
+  /// @brief Configuration
+  Config cfg_;
+
+  /// @brief Metadata
+  ZedCameraProducerMetadata metadata_;
+
+  /// @brief Sequence number for frames
+  uint64_t seq_{0};
+
+  /// @brief Whether camera has been opened
+  bool opened_{false};
+
+  /// @brief Last capture monotonic timestamp (ns) for inter-frame timing
+  uint64_t last_capture_mono_{0};
+
+  /// @brief Inter-frame timing accumulator (ns)
+  uint64_t if_accum_ns_{0};
+
+  /// @brief Max inter-frame time (ns)
+  uint64_t if_max_ns_{0};
+
+  /// @brief Number of inter-frame samples
+  uint64_t if_samples_{0};
+
+  /// @brief Next frame number to report health stats
+  uint64_t next_health_report_frame_{300};
+};
+
+}  // namespace trossen::hw::camera
+
+#endif  // TROSSEN_SDK__HW__CAMERA__ZED_PRODUCER_HPP

--- a/include/trossen_sdk/hw/camera/zed_producer.hpp
+++ b/include/trossen_sdk/hw/camera/zed_producer.hpp
@@ -40,10 +40,10 @@ public:
     std::string encoding{"bgr8"};
 
     /// @brief Desired image width (pixels)
-    int width{672};
+    int width{0};
 
     /// @brief Desired image height (pixels)
-    int height{376};
+    int height{0};
 
     /// @brief Desired frame rate (fps)
     int fps{30};

--- a/include/trossen_sdk/hw/camera/zed_producer.hpp
+++ b/include/trossen_sdk/hw/camera/zed_producer.hpp
@@ -51,9 +51,6 @@ public:
     /// @brief Prefer device timestamp if available
     bool use_device_time{true};
 
-    /// @brief Seconds to warm up (discard frames) after device open before emitting
-    double warmup_seconds{0.0};
-
     /// @brief Whether to enforce the requested fps (may reduce if device cannot keep up)
     bool enforce_requested_fps = true;
   };
@@ -143,13 +140,6 @@ public:
   std::shared_ptr<ProducerMetadata> metadata() const override {
     return std::make_shared<ZedCameraProducerMetadata>(metadata_);
   }
-
-  /**
-   * @brief Perform warmup (discard initial frames)
-   *
-   * @return true on success, false on failure
-   */
-  bool warmup();
 
 private:
   /// @brief Frame cache shared with other producers

--- a/src/hw/camera/opencv_producer.cpp
+++ b/src/hw/camera/opencv_producer.cpp
@@ -16,7 +16,7 @@
 namespace trossen::hw::camera {
 
 // FPS tolerance for produced vs requested frame-rate checks
-constexpr int FPS_TOLERANCE = 50;
+constexpr double FPS_TOLERANCE = 0.5;
 
 OpenCvCameraProducer::OpenCvCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   // Populate metadata

--- a/src/hw/camera/opencv_producer.cpp
+++ b/src/hw/camera/opencv_producer.cpp
@@ -15,6 +15,9 @@
 
 namespace trossen::hw::camera {
 
+// FPS tolerance for produced vs requested frame-rate checks
+constexpr int FPS_TOLERANCE = 50;
+
 OpenCvCameraProducer::OpenCvCameraProducer(Config cfg) : cfg_(std::move(cfg)) {
   // Populate metadata
   metadata_.type = "opencv_camera";
@@ -156,7 +159,7 @@ void OpenCvCameraProducer::poll(
     if (if_samples_ > 0 && if_accum_ns_ > 0) {
       produced_fps = 1e9 / (static_cast<double>(if_accum_ns_) / static_cast<double>(if_samples_));
     }
-    if (produced_fps > 0 && (produced_fps + 0.5) < cfg_.fps) {
+    if (produced_fps > 0 && (produced_fps + FPS_TOLERANCE) < cfg_.fps) {
       std::cerr << "Camera FPS health: produced_fps=" << produced_fps << " requested=" << cfg_.fps
                 << " avg_if_ms=" << avg_if_ms << " max_if_ms=" << max_if_ms << std::endl;
     } else {

--- a/src/hw/camera/realsense_depth_producer.cpp
+++ b/src/hw/camera/realsense_depth_producer.cpp
@@ -16,7 +16,7 @@
 namespace trossen::hw::camera {
 
 // FPS tolerance for produced vs requested frame-rate checks
-constexpr int FPS_TOLERANCE = 50;
+constexpr double FPS_TOLERANCE = 0.5;
 
 RealsenseDepthCameraProducer::RealsenseDepthCameraProducer(
   std::shared_ptr<trossen::hw::camera::RealsenseFrameCache> frame_cache, Config cfg)

--- a/src/hw/camera/realsense_depth_producer.cpp
+++ b/src/hw/camera/realsense_depth_producer.cpp
@@ -15,6 +15,9 @@
 
 namespace trossen::hw::camera {
 
+// FPS tolerance for produced vs requested frame-rate checks
+constexpr int FPS_TOLERANCE = 50;
+
 RealsenseDepthCameraProducer::RealsenseDepthCameraProducer(
   std::shared_ptr<trossen::hw::camera::RealsenseFrameCache> frame_cache, Config cfg)
   : frame_cache_(std::move(frame_cache)),
@@ -114,7 +117,7 @@ void RealsenseDepthCameraProducer::poll(
     if (if_samples_ > 0 && if_accum_ns_ > 0) {
       produced_fps = 1e9 / (static_cast<double>(if_accum_ns_) / static_cast<double>(if_samples_));
     }
-    if (produced_fps > 0 && (produced_fps + 0.5) < cfg_.fps) {
+    if (produced_fps > 0 && (produced_fps + FPS_TOLERANCE) < cfg_.fps) {
       std::cout << "Camera FPS health: produced_fps=" << produced_fps << " requested=" << cfg_.fps
                 << " avg_if_ms=" << avg_if_ms << " max_if_ms=" << max_if_ms << std::endl;
     } else {

--- a/src/hw/camera/realsense_producer.cpp
+++ b/src/hw/camera/realsense_producer.cpp
@@ -13,7 +13,7 @@
 namespace trossen::hw::camera {
 
 // FPS tolerance for produced vs requested frame-rate checks
-constexpr int FPS_TOLERANCE = 50;
+constexpr double FPS_TOLERANCE = 0.5;
 
 RealsenseCameraProducer::RealsenseCameraProducer(
   std::shared_ptr<trossen::hw::camera::RealsenseFrameCache> frame_cache, Config cfg)

--- a/src/hw/camera/realsense_producer.cpp
+++ b/src/hw/camera/realsense_producer.cpp
@@ -12,6 +12,9 @@
 
 namespace trossen::hw::camera {
 
+// FPS tolerance for produced vs requested frame-rate checks
+constexpr int FPS_TOLERANCE = 50;
+
 RealsenseCameraProducer::RealsenseCameraProducer(
   std::shared_ptr<trossen::hw::camera::RealsenseFrameCache> frame_cache, Config cfg)
   : frame_cache_(std::move(frame_cache)),
@@ -112,7 +115,7 @@ void RealsenseCameraProducer::poll(
     if (if_samples_ > 0 && if_accum_ns_ > 0) {
       produced_fps = 1e9 / (static_cast<double>(if_accum_ns_) / static_cast<double>(if_samples_));
     }
-    if (produced_fps > 0 && (produced_fps + 0.5) < cfg_.fps) {
+    if (produced_fps > 0 && (produced_fps + FPS_TOLERANCE) < cfg_.fps) {
       std::cerr << "Camera FPS health: produced_fps=" << produced_fps << " requested=" << cfg_.fps
                 << " avg_if_ms=" << avg_if_ms << " max_if_ms=" << max_if_ms << std::endl;
     } else {

--- a/src/hw/camera/zed_camera_component.cpp
+++ b/src/hw/camera/zed_camera_component.cpp
@@ -1,0 +1,142 @@
+/**
+ * @file zed_camera_component.cpp
+ * @brief Implementation of ZedCameraComponent
+ */
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "trossen_sdk/hw/camera/zed_camera_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+
+namespace trossen::hw::camera {
+
+// Helper to parse resolution string
+static sl::RESOLUTION parse_resolution(const std::string& res_str) {
+  if (res_str == "VGA") return sl::RESOLUTION::VGA;
+  if (res_str == "SVGA") return sl::RESOLUTION::SVGA;
+  if (res_str == "HD720") return sl::RESOLUTION::HD720;
+  if (res_str == "HD1080") return sl::RESOLUTION::HD1080;
+  if (res_str == "HD2K") return sl::RESOLUTION::HD2K;
+
+  std::cerr << "Unknown resolution: " << res_str << ", defaulting to SVGA\n";
+  return sl::RESOLUTION::SVGA;
+}
+
+// Helper to parse depth mode string
+static sl::DEPTH_MODE parse_depth_mode(const std::string& mode_str) {
+  if (mode_str == "NONE") return sl::DEPTH_MODE::NONE;
+  if (mode_str == "PERFORMANCE") return sl::DEPTH_MODE::PERFORMANCE;
+  if (mode_str == "QUALITY") return sl::DEPTH_MODE::QUALITY;
+  if (mode_str == "ULTRA") return sl::DEPTH_MODE::ULTRA;
+  if (mode_str == "NEURAL") return sl::DEPTH_MODE::NEURAL;
+
+  std::cerr << "Unknown depth mode: " << mode_str << ", defaulting to NONE\n";
+  return sl::DEPTH_MODE::NONE;
+}
+
+ZedCameraComponent::~ZedCameraComponent() {
+  if (camera_ && camera_->isOpened()) {
+    std::cout << "ZedCameraComponent: Destructor called for " << get_identifier() << std::endl;
+    camera_->close();
+  }
+}
+
+void ZedCameraComponent::configure(const nlohmann::json& config) {
+  // Extract device index
+  if (config.contains("serial_number")) {
+    serial_number_ = config.at("serial_number").get<int>();
+  }
+
+  // Extract optional parameters
+  if (config.contains("resolution")) {
+    std::string res_str = config.at("resolution").get<std::string>();
+    resolution_ = parse_resolution(res_str);
+  }
+
+  if (config.contains("fps")) {
+    fps_ = config.at("fps").get<int>();
+  }
+
+  if (config.contains("use_depth")) {
+    use_depth_ = config.at("use_depth").get<bool>();
+  }
+
+  if (config.contains("depth_mode")) {
+    std::string mode_str = config.at("depth_mode").get<std::string>();
+    depth_mode_ = parse_depth_mode(mode_str);
+  }
+
+  // Create camera instance
+  camera_ = std::make_shared<sl::Camera>();
+
+  // Configure initialization parameters
+  sl::InitParameters init_params;
+  init_params.camera_resolution = resolution_;
+  init_params.camera_fps = fps_;
+  init_params.depth_mode = depth_mode_;
+  init_params.coordinate_units = sl::UNIT::METER;
+  init_params.sdk_verbose = false;
+
+  // Set serial number if specified (0 = use any camera)
+  if (serial_number_ > 0) {
+    init_params.input.setFromSerialNumber(serial_number_);
+  }
+
+  // Open camera
+  sl::ERROR_CODE err = camera_->open(init_params);
+  if (err != sl::ERROR_CODE::SUCCESS) {
+    throw std::runtime_error(
+      "ZedCameraComponent: Failed to open camera " + get_identifier() +
+      ": " + std::string(sl::toString(err)));
+  }
+
+  // Get actual camera information
+  sl::CameraInformation cam_info = camera_->getCameraInformation();
+  sl::CalibrationParameters calib = cam_info.camera_configuration.calibration_parameters;
+
+  // Store actual serial number if we didn't specify one
+  if (serial_number_ == 0) {
+    serial_number_ = cam_info.serial_number;
+  }
+
+  // Get actual resolution
+  width_ = calib.left_cam.image_size.width;
+  height_ = calib.left_cam.image_size.height;
+
+  // Create frame cache (1 consumer for color only, 2 for color+depth)
+  size_t num_consumers = use_depth_ ? 2 : 1;
+  frame_cache_ = std::make_shared<ZedFrameCache>(camera_, num_consumers);
+
+  std::cout << "ZedCameraComponent: Camera " << get_identifier()
+            << " opened successfully\n";
+  std::cout << "  Serial Number: " << serial_number_ << "\n";
+  std::cout << "  Model: " << sl::toString(cam_info.camera_model) << "\n";
+  std::cout << "  Resolution: " << width_ << "x" << height_ << " @ " << fps_ << " FPS\n";
+  std::cout << "  Depth: " << (use_depth_ ? "Enabled" : "Disabled") << "\n";
+}
+
+nlohmann::json ZedCameraComponent::get_info() const {
+  nlohmann::json info = {
+    {"type", "zed_camera"},
+    {"serial_number", serial_number_},
+    {"width", width_},
+    {"height", height_},
+    {"fps", fps_},
+    {"use_depth", use_depth_},
+    {"depth_mode", sl::toString(depth_mode_)}
+  };
+
+  info["is_opened"] = is_opened();
+
+  return info;
+}
+
+bool ZedCameraComponent::is_opened() const {
+  return camera_ && camera_->isOpened();
+}
+
+REGISTER_HARDWARE(ZedCameraComponent, "zed_camera")
+
+}  // namespace trossen::hw::camera

--- a/src/hw/camera/zed_camera_component.cpp
+++ b/src/hw/camera/zed_camera_component.cpp
@@ -3,9 +3,11 @@
  * @brief Implementation of ZedCameraComponent
  */
 
+#include <chrono>
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <thread>
 
 #include "trossen_sdk/hw/camera/zed_camera_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
@@ -68,6 +70,10 @@ void ZedCameraComponent::configure(const nlohmann::json& config) {
     depth_mode_ = parse_depth_mode(mode_str);
   }
 
+  if (config.contains("warmup_seconds")) {
+    warmup_seconds_ = config.at("warmup_seconds").get<double>();
+  }
+
   // Create camera instance
   camera_ = std::make_shared<sl::Camera>();
 
@@ -115,6 +121,12 @@ void ZedCameraComponent::configure(const nlohmann::json& config) {
   std::cout << "  Model: " << sl::toString(cam_info.camera_model) << "\n";
   std::cout << "  Resolution: " << width_ << "x" << height_ << " @ " << fps_ << " FPS\n";
   std::cout << "  Depth: " << (use_depth_ ? "Enabled" : "Disabled") << "\n";
+
+  // Perform warmup (discard initial frames for stabilization)
+  if (!warmup()) {
+    throw std::runtime_error(
+      "ZedCameraComponent: Warmup failed for camera " + get_identifier());
+  }
 }
 
 nlohmann::json ZedCameraComponent::get_info() const {
@@ -135,6 +147,46 @@ nlohmann::json ZedCameraComponent::get_info() const {
 
 bool ZedCameraComponent::is_opened() const {
   return camera_ && camera_->isOpened();
+}
+
+bool ZedCameraComponent::warmup() {
+  if (warmup_seconds_ <= 0.0) {
+    return true;
+  }
+
+  std::cout << "ZedCameraComponent: Warming up for " << warmup_seconds_ << " seconds...\n";
+
+  auto start = std::chrono::steady_clock::now();
+  int warmup_frames = 0;
+  int consecutive_errors = 0;
+  constexpr int MAX_CONSECUTIVE_ERRORS = 50;  // Prevent infinite loop on persistent errors
+
+  while (true) {
+    auto now = std::chrono::steady_clock::now();
+    double elapsed = std::chrono::duration<double>(now - start).count();
+    if (elapsed >= warmup_seconds_) {
+      break;
+    }
+
+    // Grab and discard frames
+    sl::ERROR_CODE err = frame_cache_->grab();
+    if (err == sl::ERROR_CODE::SUCCESS) {
+      warmup_frames++;
+      consecutive_errors = 0;  // Reset error counter on success
+    } else {
+      consecutive_errors++;
+      if (consecutive_errors >= MAX_CONSECUTIVE_ERRORS) {
+        std::cerr << "ZedCameraComponent: Warmup failed after " << MAX_CONSECUTIVE_ERRORS
+                  << " consecutive errors. Last error: " << sl::toString(err) << "\n";
+        return false;
+      }
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  std::cout << "ZedCameraComponent: Warmup complete, discarded " << warmup_frames << " frames\n";
+  return true;
 }
 
 REGISTER_HARDWARE(ZedCameraComponent, "zed_camera")

--- a/src/hw/camera/zed_depth_producer.cpp
+++ b/src/hw/camera/zed_depth_producer.cpp
@@ -14,7 +14,7 @@
 namespace trossen::hw::camera {
 
 // FPS tolerance for produced vs requested frame-rate checks
-constexpr int FPS_TOLERANCE = 50;
+constexpr double FPS_TOLERANCE = 0.5;
 
 ZedDepthCameraProducer::ZedDepthCameraProducer(
   std::shared_ptr<ZedFrameCache> frame_cache, Config cfg)

--- a/src/hw/camera/zed_depth_producer.cpp
+++ b/src/hw/camera/zed_depth_producer.cpp
@@ -1,0 +1,180 @@
+/**
+ * @file zed_depth_producer.cpp
+ * @brief Implementation of ZedDepthCameraProducer
+ */
+
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "trossen_sdk/hw/camera/zed_depth_producer.hpp"
+
+namespace trossen::hw::camera {
+
+ZedDepthCameraProducer::ZedDepthCameraProducer(
+  std::shared_ptr<ZedFrameCache> frame_cache, Config cfg)
+  : frame_cache_(std::move(frame_cache)),
+    cfg_(std::move(cfg)) {
+  // Populate metadata
+  metadata_.type = "zed_depth_camera";
+  metadata_.id = "zed_depth_camera_" + std::to_string(cfg_.serial_number);
+  metadata_.name = cfg_.stream_id;
+  metadata_.description = "Produces depth frames from ZED camera using ZED SDK";
+  metadata_.width = cfg_.width;
+  metadata_.height = cfg_.height;
+  metadata_.fps = cfg_.fps;
+  metadata_.codec = "av1";
+  metadata_.pix_fmt = "yuv420p";
+  metadata_.channels = 1;  // Depth is single channel
+  metadata_.has_audio = false;
+  metadata_.is_depth_map = true;
+
+  opened_ = true;
+}
+
+ZedDepthCameraProducer::~ZedDepthCameraProducer() {
+  if (opened_) {
+    std::cout << "ZedDepthCameraProducer: Stopping depth camera: " << metadata_.name << std::endl;
+  }
+}
+
+bool ZedDepthCameraProducer::warmup() {
+  if (cfg_.warmup_seconds <= 0.0) {
+    return true;
+  }
+
+  std::cout << "ZedDepthCameraProducer: Warming up for " << cfg_.warmup_seconds << " seconds...\n";
+
+  auto start = std::chrono::steady_clock::now();
+  int warmup_frames = 0;
+
+  while (true) {
+    auto now = std::chrono::steady_clock::now();
+    double elapsed = std::chrono::duration<double>(now - start).count();
+    if (elapsed >= cfg_.warmup_seconds) {
+      break;
+    }
+
+    // Grab and discard frames
+    sl::ERROR_CODE err = frame_cache_->grab();
+    if (err == sl::ERROR_CODE::SUCCESS) {
+      warmup_frames++;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  std::cout << "ZedDepthCameraProducer: Warmup complete, discarded "
+            << warmup_frames << " frames\n";
+  return true;
+}
+
+void ZedDepthCameraProducer::poll(
+  const std::function<void(std::shared_ptr<data::RecordBase>)>& emit)
+{
+  auto img = std::make_shared<data::ImageRecord>();
+
+  // Use frame cache to grab (shared with color producer)
+  sl::ERROR_CODE err = frame_cache_->grab();
+
+  if (err != sl::ERROR_CODE::SUCCESS) {
+    if (err != sl::ERROR_CODE::END_OF_SVOFILE_REACHED) {
+      std::cerr << "[WARN] ZED depth grab failed: " << sl::toString(err) << std::endl;
+    }
+    ++stats_.dropped;
+    return;
+  }
+
+  // Retrieve depth map
+  sl::Mat zed_depth;
+  auto camera = frame_cache_->get_camera();
+  camera->retrieveMeasure(zed_depth, sl::MEASURE::DEPTH);
+
+  // Check if depth map is valid
+  if (!zed_depth.isInit() || zed_depth.getWidth() == 0 || zed_depth.getHeight() == 0) {
+    std::cerr << "[WARN] ZED retrieved invalid depth map\n";
+    ++stats_.dropped;
+    return;
+  }
+
+  // Convert ZED depth (float32, meters) to 16-bit unsigned (millimeters) for compatibility
+  cv::Mat depth_float(zed_depth.getHeight(), zed_depth.getWidth(), CV_32FC1,
+                      zed_depth.getPtr<sl::uchar1>(sl::MEM::CPU));
+
+  // Convert from meters to millimeters and then to 16-bit unsigned
+  cv::Mat depth_16u;
+  depth_float.convertTo(depth_16u, CV_16UC1, 1000.0);  // meters to millimeters
+
+  // Clone the image to ensure we own the data
+  img->image = depth_16u.clone();
+
+  // Timestamp handling
+  data::Timestamp ts;
+  uint64_t mono_now = data::now_mono().to_ns();
+
+  if (cfg_.use_device_time) {
+    // Get ZED camera timestamp
+    sl::Timestamp zed_ts = camera->getTimestamp(sl::TIME_REFERENCE::IMAGE);
+    uint64_t device_ts_ns = zed_ts.getNanoseconds();
+    ts.monotonic = data::Timespec::from_ns(device_ts_ns);
+  } else {
+    ts.monotonic = data::now_mono();
+  }
+  ts.realtime = data::now_real();
+
+  // Inter-frame timing instrumentation
+  if (last_capture_mono_ != 0) {
+    uint64_t dt = mono_now - last_capture_mono_;
+    if_accum_ns_ += dt;
+    if (dt > if_max_ns_) if_max_ns_ = dt;
+    ++if_samples_;
+  }
+  last_capture_mono_ = mono_now;
+
+  // Populate record
+  img->ts = ts;
+  img->seq = seq_++;
+  img->id = cfg_.stream_id;
+  img->width = static_cast<uint32_t>(img->image.cols);
+  img->height = static_cast<uint32_t>(img->image.rows);
+  img->encoding = cfg_.encoding;
+  img->channels = static_cast<uint32_t>(img->image.channels());
+
+  emit(img);
+  ++stats_.produced;
+
+  // Periodically report FPS health
+  if (cfg_.fps > 0 && stats_.produced >= next_health_report_frame_) {
+    double avg_if_ms = 0.0;
+    double max_if_ms = 0.0;
+    if (if_samples_ > 0) {
+      avg_if_ms = (if_accum_ns_ / 1e6) / static_cast<double>(if_samples_);
+      max_if_ms = if_max_ns_ / 1e6;
+    }
+    double produced_fps = 0.0;
+    if (if_samples_ > 0 && if_accum_ns_ > 0) {
+      produced_fps = 1e9 / (static_cast<double>(if_accum_ns_) / static_cast<double>(if_samples_));
+    }
+
+    if (produced_fps > 0 && (produced_fps + 0.5) < cfg_.fps) {
+      std::cerr << "ZED Depth Camera FPS health: produced_fps=" << produced_fps
+                << " requested=" << cfg_.fps
+                << " avg_if_ms=" << avg_if_ms
+                << " max_if_ms=" << max_if_ms << std::endl;
+    } else {
+      std::cout << "ZED Depth Camera FPS health: produced_fps=" << produced_fps
+                << " requested=" << cfg_.fps
+                << " avg_if_ms=" << avg_if_ms
+                << " max_if_ms=" << max_if_ms << std::endl;
+    }
+
+    // Schedule next report ~10 seconds later
+    uint64_t interval = static_cast<uint64_t>(cfg_.fps) * 10;
+    if (interval == 0) interval = 300;
+    next_health_report_frame_ += interval;
+  }
+}
+
+}  // namespace trossen::hw::camera

--- a/src/hw/camera/zed_depth_producer.cpp
+++ b/src/hw/camera/zed_depth_producer.cpp
@@ -43,37 +43,6 @@ ZedDepthCameraProducer::~ZedDepthCameraProducer() {
   }
 }
 
-bool ZedDepthCameraProducer::warmup() {
-  if (cfg_.warmup_seconds <= 0.0) {
-    return true;
-  }
-
-  std::cout << "ZedDepthCameraProducer: Warming up for " << cfg_.warmup_seconds << " seconds...\n";
-
-  auto start = std::chrono::steady_clock::now();
-  int warmup_frames = 0;
-
-  while (true) {
-    auto now = std::chrono::steady_clock::now();
-    double elapsed = std::chrono::duration<double>(now - start).count();
-    if (elapsed >= cfg_.warmup_seconds) {
-      break;
-    }
-
-    // Grab and discard frames
-    sl::ERROR_CODE err = frame_cache_->grab();
-    if (err == sl::ERROR_CODE::SUCCESS) {
-      warmup_frames++;
-    }
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-  }
-
-  std::cout << "ZedDepthCameraProducer: Warmup complete, discarded "
-            << warmup_frames << " frames\n";
-  return true;
-}
-
 void ZedDepthCameraProducer::poll(
   const std::function<void(std::shared_ptr<data::RecordBase>)>& emit)
 {

--- a/src/hw/camera/zed_depth_producer.cpp
+++ b/src/hw/camera/zed_depth_producer.cpp
@@ -13,6 +13,9 @@
 
 namespace trossen::hw::camera {
 
+// FPS tolerance for produced vs requested frame-rate checks
+constexpr int FPS_TOLERANCE = 50;
+
 ZedDepthCameraProducer::ZedDepthCameraProducer(
   std::shared_ptr<ZedFrameCache> frame_cache, Config cfg)
   : frame_cache_(std::move(frame_cache)),
@@ -158,7 +161,7 @@ void ZedDepthCameraProducer::poll(
       produced_fps = 1e9 / (static_cast<double>(if_accum_ns_) / static_cast<double>(if_samples_));
     }
 
-    if (produced_fps > 0 && (produced_fps + 0.5) < cfg_.fps) {
+    if (produced_fps > 0 && (produced_fps + FPS_TOLERANCE) < cfg_.fps) {
       std::cerr << "ZED Depth Camera FPS health: produced_fps=" << produced_fps
                 << " requested=" << cfg_.fps
                 << " avg_if_ms=" << avg_if_ms

--- a/src/hw/camera/zed_producer.cpp
+++ b/src/hw/camera/zed_producer.cpp
@@ -14,7 +14,7 @@
 namespace trossen::hw::camera {
 
 // FPS tolerance for produced vs requested frame-rate checks
-constexpr int FPS_TOLERANCE = 50;
+constexpr double FPS_TOLERANCE = 0.5;
 
 ZedCameraProducer::ZedCameraProducer(
   std::shared_ptr<ZedFrameCache> frame_cache, Config cfg)

--- a/src/hw/camera/zed_producer.cpp
+++ b/src/hw/camera/zed_producer.cpp
@@ -52,36 +52,6 @@ ZedCameraProducer::~ZedCameraProducer() {
   }
 }
 
-bool ZedCameraProducer::warmup() {
-  if (cfg_.warmup_seconds <= 0.0) {
-    return true;
-  }
-
-  std::cout << "ZedCameraProducer: Warming up for " << cfg_.warmup_seconds << " seconds...\n";
-
-  auto start = std::chrono::steady_clock::now();
-  int warmup_frames = 0;
-
-  while (true) {
-    auto now = std::chrono::steady_clock::now();
-    double elapsed = std::chrono::duration<double>(now - start).count();
-    if (elapsed >= cfg_.warmup_seconds) {
-      break;
-    }
-
-    // Grab and discard frames
-    sl::ERROR_CODE err = frame_cache_->grab();
-    if (err == sl::ERROR_CODE::SUCCESS) {
-      warmup_frames++;
-    }
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-  }
-
-  std::cout << "ZedCameraProducer: Warmup complete, discarded " << warmup_frames << " frames\n";
-  return true;
-}
-
 void ZedCameraProducer::poll(
   const std::function<void(std::shared_ptr<data::RecordBase>)>& emit)
 {

--- a/src/hw/camera/zed_producer.cpp
+++ b/src/hw/camera/zed_producer.cpp
@@ -1,0 +1,196 @@
+/**
+ * @file zed_producer.cpp
+ * @brief Implementation of ZedCameraProducer
+ */
+
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "trossen_sdk/hw/camera/zed_producer.hpp"
+
+namespace trossen::hw::camera {
+
+ZedCameraProducer::ZedCameraProducer(
+  std::shared_ptr<ZedFrameCache> frame_cache, Config cfg)
+  : frame_cache_(std::move(frame_cache)),
+    cfg_(std::move(cfg)) {
+  // Populate metadata
+  metadata_.type = "zed_camera";
+  metadata_.id = "zed_camera_" + std::to_string(cfg_.serial_number);
+  metadata_.name = cfg_.stream_id;
+  metadata_.description = "Produces camera frames from ZED camera using ZED SDK";
+  metadata_.width = cfg_.width;
+  metadata_.height = cfg_.height;
+  metadata_.fps = cfg_.fps;
+  metadata_.codec = "av1";
+  metadata_.pix_fmt = "yuv420p";
+
+  // ZED cameras output BGRA (4 channels) by default, but we convert to BGR (3 channels)
+  if (cfg_.encoding == "bgr8" || cfg_.encoding == "rgb8") {
+    metadata_.channels = 3;
+  } else if (cfg_.encoding == "bgra8") {
+    metadata_.channels = 4;
+  } else {
+    metadata_.channels = 1;  // mono
+  }
+
+  metadata_.has_audio = false;
+  metadata_.is_depth_map = false;
+
+  opened_ = true;
+}
+
+ZedCameraProducer::~ZedCameraProducer() {
+  if (opened_) {
+    std::cout << "ZedCameraProducer: Stopping camera: " << metadata_.name << std::endl;
+  }
+}
+
+bool ZedCameraProducer::warmup() {
+  if (cfg_.warmup_seconds <= 0.0) {
+    return true;
+  }
+
+  std::cout << "ZedCameraProducer: Warming up for " << cfg_.warmup_seconds << " seconds...\n";
+
+  auto start = std::chrono::steady_clock::now();
+  int warmup_frames = 0;
+
+  while (true) {
+    auto now = std::chrono::steady_clock::now();
+    double elapsed = std::chrono::duration<double>(now - start).count();
+    if (elapsed >= cfg_.warmup_seconds) {
+      break;
+    }
+
+    // Grab and discard frames
+    sl::ERROR_CODE err = frame_cache_->grab();
+    if (err == sl::ERROR_CODE::SUCCESS) {
+      warmup_frames++;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  std::cout << "ZedCameraProducer: Warmup complete, discarded " << warmup_frames << " frames\n";
+  return true;
+}
+
+void ZedCameraProducer::poll(
+  const std::function<void(std::shared_ptr<data::RecordBase>)>& emit)
+{
+  auto img = std::make_shared<data::ImageRecord>();
+
+  // Use frame cache to grab (shared with depth producer if present)
+  sl::ERROR_CODE err = frame_cache_->grab();
+
+  if (err != sl::ERROR_CODE::SUCCESS) {
+    if (err != sl::ERROR_CODE::END_OF_SVOFILE_REACHED) {
+      std::cerr << "[WARN] ZED grab failed: " << sl::toString(err) << std::endl;
+    }
+    ++stats_.dropped;
+    return;
+  }
+
+  // Retrieve LEFT eye image
+  sl::Mat zed_image;
+  auto camera = frame_cache_->get_camera();
+  camera->retrieveImage(zed_image, sl::VIEW::LEFT);
+
+  // Check if image is valid (ZED SDK doesn't have isEmpty, check dimensions)
+  if (!zed_image.isInit() || zed_image.getWidth() == 0 || zed_image.getHeight() == 0) {
+    std::cerr << "[WARN] ZED retrieved invalid image\n";
+    ++stats_.dropped;
+    return;
+  }
+
+  // Convert ZED sl::Mat to OpenCV cv::Mat
+  // ZED images are in BGRA format by default
+  cv::Mat cv_image;
+  int cv_type = (zed_image.getChannels() == 4) ? CV_8UC4 : CV_8UC3;
+  cv_image = cv::Mat(zed_image.getHeight(), zed_image.getWidth(), cv_type,
+                     zed_image.getPtr<sl::uchar1>(sl::MEM::CPU));
+
+  // Convert BGRA to BGR if needed
+  if (cfg_.encoding == "bgr8" && zed_image.getChannels() == 4) {
+    cv::cvtColor(cv_image, cv_image, cv::COLOR_BGRA2BGR);
+  } else if (cfg_.encoding == "rgb8" && zed_image.getChannels() == 4) {
+    cv::cvtColor(cv_image, cv_image, cv::COLOR_BGRA2RGB);
+  } else if (cfg_.encoding == "bgra8") {
+    // Keep as-is
+  }
+
+  // Clone the image to ensure we own the data
+  img->image = cv_image.clone();
+
+  // Timestamp handling
+  data::Timestamp ts;
+  uint64_t mono_now = data::now_mono().to_ns();
+
+  if (cfg_.use_device_time) {
+    // Get ZED camera timestamp
+    sl::Timestamp zed_ts = camera->getTimestamp(sl::TIME_REFERENCE::IMAGE);
+    uint64_t device_ts_ns = zed_ts.getNanoseconds();
+    ts.monotonic = data::Timespec::from_ns(device_ts_ns);
+  } else {
+    ts.monotonic = data::now_mono();
+  }
+  ts.realtime = data::now_real();
+
+  // Inter-frame timing instrumentation
+  if (last_capture_mono_ != 0) {
+    uint64_t dt = mono_now - last_capture_mono_;
+    if_accum_ns_ += dt;
+    if (dt > if_max_ns_) if_max_ns_ = dt;
+    ++if_samples_;
+  }
+  last_capture_mono_ = mono_now;
+
+  // Populate record
+  img->ts = ts;
+  img->seq = seq_++;
+  img->id = cfg_.stream_id;
+  img->width = static_cast<uint32_t>(img->image.cols);
+  img->height = static_cast<uint32_t>(img->image.rows);
+  img->encoding = cfg_.encoding;
+  img->channels = static_cast<uint32_t>(img->image.channels());
+
+  emit(img);
+  ++stats_.produced;
+
+  // Periodically report FPS health
+  if (cfg_.fps > 0 && stats_.produced >= next_health_report_frame_) {
+    double avg_if_ms = 0.0;
+    double max_if_ms = 0.0;
+    if (if_samples_ > 0) {
+      avg_if_ms = (if_accum_ns_ / 1e6) / static_cast<double>(if_samples_);
+      max_if_ms = if_max_ns_ / 1e6;
+    }
+    double produced_fps = 0.0;
+    if (if_samples_ > 0 && if_accum_ns_ > 0) {
+      produced_fps = 1e9 / (static_cast<double>(if_accum_ns_) / static_cast<double>(if_samples_));
+    }
+
+    if (produced_fps > 0 && (produced_fps + 0.5) < cfg_.fps) {
+      std::cerr << "ZED Camera FPS health: produced_fps=" << produced_fps
+                << " requested=" << cfg_.fps
+                << " avg_if_ms=" << avg_if_ms
+                << " max_if_ms=" << max_if_ms << std::endl;
+    } else {
+      std::cout << "ZED Camera FPS health: produced_fps=" << produced_fps
+                << " requested=" << cfg_.fps
+                << " avg_if_ms=" << avg_if_ms
+                << " max_if_ms=" << max_if_ms << std::endl;
+    }
+
+    // Schedule next report ~10 seconds later
+    uint64_t interval = static_cast<uint64_t>(cfg_.fps) * 10;
+    if (interval == 0) interval = 300;
+    next_health_report_frame_ += interval;
+  }
+}
+
+}  // namespace trossen::hw::camera

--- a/src/hw/camera/zed_producer.cpp
+++ b/src/hw/camera/zed_producer.cpp
@@ -13,6 +13,9 @@
 
 namespace trossen::hw::camera {
 
+// FPS tolerance for produced vs requested frame-rate checks
+constexpr int FPS_TOLERANCE = 50;
+
 ZedCameraProducer::ZedCameraProducer(
   std::shared_ptr<ZedFrameCache> frame_cache, Config cfg)
   : frame_cache_(std::move(frame_cache)),
@@ -174,7 +177,7 @@ void ZedCameraProducer::poll(
       produced_fps = 1e9 / (static_cast<double>(if_accum_ns_) / static_cast<double>(if_samples_));
     }
 
-    if (produced_fps > 0 && (produced_fps + 0.5) < cfg_.fps) {
+    if (produced_fps > 0 && (produced_fps + FPS_TOLERANCE) < cfg_.fps) {
       std::cerr << "ZED Camera FPS health: produced_fps=" << produced_fps
                 << " requested=" << cfg_.fps
                 << " avg_if_ms=" << avg_if_ms


### PR DESCRIPTION
# Add ZED X Mini Camera Support

## TL;DR

Added complete ZED X Mini camera support to Trossen SDK with color and depth frames, following the same camera producer pattern as RealSense camera.

## What changed?

- Created ZedCameraComponent for hardware lifecycle management
- Implemented ZedFrameCache to share frames between color and depth producers efficiently
- Added ZedCameraProducer for LEFT eye color capture with BGRA to BGR conversion
- Added ZedDepthCameraProducer for depth maps with float to uint16 conversion (meters to millimeters)
- Updated CMakeLists.txt with TROSSEN_ENABLE_ZED option (default: ON)
- Changed compile definitions from PRIVATE to PUBLIC so they propagate to all executables
- Added make zed convenience target for easy building
- Refactored widowxai_lerobot example to support multiple camera backends via --camera flag
- Added support for mock, opencv, realsense, and zed camera types
- Fixed --mock flag to only affect robot hardware, not camera selection

## How to test?

1. Connect a ZED X Mini camera to your system
2. Build with ZED support:
   ```bash
   make zed
   ```
3. Run the example with default settings (uses ZED camera):
   ```bash
   ./build/examples/widowxai_lerobot
   ```
4. Or test with mock robot and ZED camera:
   ```bash
   ./build/examples/widowxai_lerobot --mock --camera zed
   ```
5. Verify both color and depth streams are initialized
6. Check that frames are being captured at ~ 30 Hz

Configuration options:
- Resolution: SVGA (960x600), HD720, HD1080, HD2K
- FPS: 30 (adjustable)
- Depth modes: PERFORMANCE, QUALITY, ULTRA, NEURAL

## Why make this change?

This adds ZED camera support to give users more hardware options for robotics applications. 

Making the compile definitions PUBLIC was a key fix - it means executables automatically get the TROSSEN_ENABLE_ZED macro when they link against the library, eliminating the need to manually add it to every example's CMakeLists.txt.
