### PR TITLE
Update Arrow and Parquet libraries from 2200 to 2300 in Dockerfile

### DIFF
--- a/apps/trossen_sdk_ui/backend/Dockerfile
+++ b/apps/trossen_sdk_ui/backend/Dockerfile
@@ -98,8 +98,8 @@ RUN wget https://packages.apache.org/artifactory/arrow/$(lsb_release --id --shor
     ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    libarrow2200 \
-    libparquet2200 && \
+    libarrow2300 \
+    libparquet2300 && \
     rm -rf /var/lib/apt/lists/* && \
     rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 


### PR DESCRIPTION
### TL;DR

Updated Apache Arrow library dependencies to newer versions in the Trossen SDK UI backend Dockerfile.

### What changed?

- Updated `libarrow` from version 2200 to 2300
- Updated `libparquet` from version 2200 to 2300

### How to test?

1. Build the Docker image for the Trossen SDK UI backend
2. Verify that the container starts successfully
3. Confirm that any functionality dependent on Arrow/Parquet libraries works as expected

### Why make this change?

This update ensures the backend is using the latest version of the Apache Arrow libraries, which likely includes bug fixes, performance improvements, and better compatibility with other components in the system.