### PR TITLE
Remove Docker Compose version specification in trossen_sdk_ui

### DIFF
--- a/apps/trossen_sdk_ui/docker-compose.yml
+++ b/apps/trossen_sdk_ui/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   backend:
     build:


### PR DESCRIPTION
### TL;DR

Removed the `version: '3.8'` line from the docker-compose.yml file.

### What changed?

Removed the Docker Compose file version declaration (`version: '3.8'`) from the docker-compose.yml file in the trossen_sdk_ui app. The file now starts directly with the `services:` section.

### How to test?

1. Navigate to the `apps/trossen_sdk_ui` directory
2. Run `docker-compose up` to verify that the compose file still works correctly without the version specification
3. Check that all services start up properly

### Why make this change?

Docker Compose now defaults to the latest schema version when no version is specified. Removing the explicit version allows the configuration to automatically use the most appropriate version based on the installed Docker Compose, improving compatibility across different environments.