### PR TITLE
Add Trossen robot configurations and demo applications

### DIFF
--- a/config/robot_configs.json
+++ b/config/robot_configs.json
@@ -1,0 +1,203 @@
+{
+  "trossen_solo_ai": {
+    "type": "trossen_solo_ai",
+    "robot_name": "trossen_solo_ai_v1",
+    "arms": [
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.2",
+        "end_effector": "wxai_v0_leader",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "leader_arm"
+      },
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.4",
+        "end_effector": "wxai_v0_follower",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "follower_arm"
+      }
+    ],
+    "cameras": [
+      {
+        "type": "realsense",
+        "unique_device_id": "",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "encoding": "rgb8",
+        "enable_depth": false,
+        "id": "cam_main"
+      },
+      {
+        "type": "realsense",
+        "unique_device_id": "",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "encoding": "rgb8",
+        "enable_depth": false,
+        "id": "cam_wrist"
+      }
+    ]
+  },
+  "trossen_stationary_ai": {
+    "type": "trossen_stationary_ai",
+    "robot_name": "trossen_stationary_ai_v1",
+    "arms": [
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.2",
+        "end_effector": "wxai_v0_leader",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "left_leader"
+      },
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.3",
+        "end_effector": "wxai_v0_leader",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "right_leader"
+      },
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.4",
+        "end_effector": "wxai_v0_follower",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "left_follower"
+      },
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.5",
+        "end_effector": "wxai_v0_follower",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "right_follower"
+      }
+    ],
+    "cameras": [
+      {
+        "type": "realsense",
+        "unique_device_id": "",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "encoding": "rgb8",
+        "enable_depth": false,
+        "id": "cam_high"
+      },
+      {
+        "type": "realsense",
+        "unique_device_id": "",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "encoding": "rgb8",
+        "enable_depth": false,
+        "id": "cam_low"
+      },
+      {
+        "type": "realsense",
+        "unique_device_id": "",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "encoding": "rgb8",
+        "enable_depth": false,
+        "id": "cam_left_wrist"
+      },
+      {
+        "type": "realsense",
+        "unique_device_id": "",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "encoding": "rgb8",
+        "enable_depth": false,
+        "id": "cam_right_wrist"
+      }
+    ]
+  },
+  "trossen_mobile_ai": {
+    "type": "trossen_mobile_ai",
+    "robot_name": "trossen_mobile_ai_v1",
+    "arms": [
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.2",
+        "end_effector": "wxai_v0_leader",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "left_leader"
+      },
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.3",
+        "end_effector": "wxai_v0_leader",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "right_leader"
+      },
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.4",
+        "end_effector": "wxai_v0_follower",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "left_follower"
+      },
+      {
+        "model": "wxai_v0",
+        "ip_address": "192.168.1.5",
+        "end_effector": "wxai_v0_follower",
+        "clear_error": true,
+        "joint_rate_hz": 200.0,
+        "id": "right_follower"
+      }
+    ],
+    "cameras": [
+      {
+        "type": "realsense",
+        "unique_device_id": "",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "encoding": "rgb8",
+        "enable_depth": false,
+        "id": "cam_high"
+      },
+      {
+        "type": "realsense",
+        "unique_device_id": "",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "encoding": "rgb8",
+        "enable_depth": false,
+        "id": "cam_left_wrist"
+      },
+      {
+        "type": "realsense",
+        "unique_device_id": "",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "encoding": "rgb8",
+        "enable_depth": false,
+        "id": "cam_right_wrist"
+      }
+    ],
+    "mobile_base": {
+      "type": "tracer",
+      "max_linear_velocity": 1.0,
+      "max_angular_velocity": 2.0,
+      "update_rate": 50.0,
+      "id": "mobile_base"
+    }
+  }
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -40,3 +40,15 @@ target_link_libraries(hardware_registry_demo trossen_sdk)
 # Producer registry demo
 add_executable(producer_registry_demo producer_registry_demo.cpp)
 target_link_libraries(producer_registry_demo trossen_sdk)
+
+# Trossen AI Solo demo
+add_executable(trossen_solo_ai_demo trossen_solo_ai_demo.cpp)
+target_link_libraries(trossen_solo_ai_demo trossen_sdk)
+
+# Trossen Stationary AI demo
+add_executable(trossen_stationary_ai_demo trossen_stationary_ai_demo.cpp)
+target_link_libraries(trossen_stationary_ai_demo trossen_sdk)
+
+# Trossen Mobile AI demo
+add_executable(trossen_mobile_ai_demo trossen_mobile_ai_demo.cpp)
+target_link_libraries(trossen_mobile_ai_demo trossen_sdk)

--- a/examples/trossen_mobile_ai_demo.cpp
+++ b/examples/trossen_mobile_ai_demo.cpp
@@ -1,0 +1,122 @@
+/**
+ * @file trossen_mobile_ai_demo.cpp
+ * @brief Trossen Mobile AI configuration reader and episode recorder
+ *
+ * This demo reads the Trossen Mobile AI robot configuration and will be used
+ * to record episodes for the mobile robot setup (2 leaders + 2 followers + mobile base).
+ *
+ * Usage:
+ *   ./trossen_mobile_ai_demo
+ *   ./trossen_mobile_ai_demo --config config/robot_configs.json
+ */
+
+#include <iostream>
+#include <string>
+#include <exception>
+
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+#include "trossen_sdk/configuration/types/robots/trossen_mobile_ai_config.hpp"
+
+void print_banner() {
+  std::cout << "\n";
+  std::cout << "═══════════════════════════════════════════════════════════\n";
+  std::cout << "  Trossen Mobile AI - Configuration Reader\n";
+  std::cout << "═══════════════════════════════════════════════════════════\n";
+  std::cout << "\n";
+}
+
+void print_config(const trossen::configuration::TrossenMobileAiConfig& config) {
+  std::cout << "Robot Configuration:\n";
+  std::cout << "  Name: " << config.robot_name << "\n";
+  std::cout << "  Type: " << config.type() << "\n\n";
+
+  std::cout << "Arms (" << config.arms.size() << "):\n";
+  for (size_t i = 0; i < config.arms.size(); ++i) {
+    const auto& arm = config.arms[i];
+    std::cout << "  [" << i << "] Model: " << arm.model << "\n";
+    std::cout << "      IP Address: " << arm.ip_address << "\n";
+    std::cout << "      End Effector: " << arm.end_effector << "\n";
+    std::cout << "      Joint Rate: " << arm.joint_rate_hz << " Hz\n";
+    std::cout << "      Clear Error: " << (arm.clear_error ? "Yes" : "No") << "\n";
+    if (!arm.id.empty()) {
+      std::cout << "      ID: " << arm.id << "\n";
+    }
+    std::cout << "\n";
+  }
+
+  std::cout << "Cameras (" << config.cameras.size() << "):\n";
+  for (size_t i = 0; i < config.cameras.size(); ++i) {
+    const auto& cam = config.cameras[i];
+    std::cout << "  [" << i << "] Type: " << cam.type << "\n";
+    std::cout << "      Device ID: " << cam.unique_device_id << "\n";
+    std::cout << "      Resolution: " << cam.width << "x" << cam.height << "\n";
+    std::cout << "      FPS: " << cam.fps << "\n";
+    std::cout << "      Encoding: " << cam.encoding << "\n";
+    std::cout << "      Use Device Time: " << (cam.use_device_time ? "Yes" : "No") << "\n";
+    if (cam.enable_depth) {
+      std::cout << "      Depth Enabled: Yes\n";
+    }
+    if (!cam.id.empty()) {
+      std::cout << "      ID: " << cam.id << "\n";
+    }
+    std::cout << "\n";
+  }
+
+  if (config.mobile_base.has_value()) {
+    const auto& base = config.mobile_base.value();
+    std::cout << "Mobile Base:\n";
+    std::cout << "  Type: " << base.type << "\n";
+    std::cout << "  Max Linear Velocity: " << base.max_linear_velocity << " m/s\n";
+    std::cout << "  Max Angular Velocity: " << base.max_angular_velocity << " rad/s\n";
+    std::cout << "  Update Rate: " << base.update_rate << " Hz\n";
+    if (!base.id.empty()) {
+      std::cout << "  ID: " << base.id << "\n";
+    }
+    std::cout << "\n";
+  } else {
+    std::cout << "Mobile Base: Not configured\n\n";
+  }
+}
+
+int main(int argc, char** argv) {
+  print_banner();
+
+  // Parse command line arguments
+  std::string config_file = "config/robot_configs.json";
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    if (arg == "--config" && i + 1 < argc) {
+      config_file = argv[++i];
+    } else if (arg == "--help" || arg == "-h") {
+      std::cout << "Usage: " << argv[0] << " [options]\n\n";
+      std::cout << "Options:\n";
+      std::cout << "  --config <file>  Configuration file path "
+                << "(default: config/robot_configs.json)\n";
+      std::cout << "  --help, -h       Show this help message\n";
+      return 0;
+    }
+  }
+
+  try {
+    // Load configuration file
+    std::cout << "Loading configuration from: " << config_file << "\n\n";
+    auto config_json = trossen::configuration::JsonLoader::load(config_file);
+
+    // Parse Trossen Mobile AI configuration
+    auto robot_config = trossen::configuration::TrossenMobileAiConfig::from_json(
+      config_json["trossen_mobile_ai"]);
+
+    // Display configuration
+    print_config(robot_config);
+
+    std::cout << "Configuration loaded successfully!\n";
+    std::cout << "\nNote: Episode recording functionality will be implemented in "
+              << "future versions.\n";
+  } catch (const std::exception& e) {
+    std::cerr << "\nError: " << e.what() << "\n";
+    std::cerr << "Failed to load configuration.\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/examples/trossen_solo_ai_demo.cpp
+++ b/examples/trossen_solo_ai_demo.cpp
@@ -1,0 +1,107 @@
+/**
+ * @file trossen_solo_ai_demo.cpp
+ * @brief Trossen AI Solo configuration reader and episode recorder
+ *
+ * This demo reads the Trossen AI Solo robot configuration and will be used
+ * to record episodes for the solo robot setup (1 leader + 1 follower arm).
+ *
+ * Usage:
+ *   ./trossen_solo_ai_demo
+ *   ./trossen_solo_ai_demo --config config/robot_configs.json
+ */
+
+#include <iostream>
+#include <string>
+#include <exception>
+
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+#include "trossen_sdk/configuration/types/robots/trossen_solo_ai_config.hpp"
+
+void print_banner() {
+  std::cout << "\n";
+  std::cout << "═══════════════════════════════════════════════════════════\n";
+  std::cout << "  Trossen AI Solo - Configuration Reader\n";
+  std::cout << "═══════════════════════════════════════════════════════════\n";
+  std::cout << "\n";
+}
+
+void print_config(const trossen::configuration::TrossenAiSoloConfig& config) {
+  std::cout << "Robot Configuration:\n";
+  std::cout << "  Name: " << config.robot_name << "\n";
+  std::cout << "  Type: " << config.type() << "\n\n";
+
+  std::cout << "Arms (" << config.arms.size() << "):\n";
+  for (size_t i = 0; i < config.arms.size(); ++i) {
+    const auto& arm = config.arms[i];
+    std::cout << "  [" << i << "] Model: " << arm.model << "\n";
+    std::cout << "      IP Address: " << arm.ip_address << "\n";
+    std::cout << "      End Effector: " << arm.end_effector << "\n";
+    std::cout << "      Joint Rate: " << arm.joint_rate_hz << " Hz\n";
+    std::cout << "      Clear Error: " << (arm.clear_error ? "Yes" : "No") << "\n";
+    if (!arm.id.empty()) {
+      std::cout << "      ID: " << arm.id << "\n";
+    }
+    std::cout << "\n";
+  }
+
+  std::cout << "Cameras (" << config.cameras.size() << "):\n";
+  for (size_t i = 0; i < config.cameras.size(); ++i) {
+    const auto& cam = config.cameras[i];
+    std::cout << "  [" << i << "] Type: " << cam.type << "\n";
+    std::cout << "      Device ID: " << cam.unique_device_id << "\n";
+    std::cout << "      Resolution: " << cam.width << "x" << cam.height << "\n";
+    std::cout << "      FPS: " << cam.fps << "\n";
+    std::cout << "      Encoding: " << cam.encoding << "\n";
+    std::cout << "      Use Device Time: " << (cam.use_device_time ? "Yes" : "No") << "\n";
+    if (cam.enable_depth) {
+      std::cout << "      Depth Enabled: Yes\n";
+    }
+    if (!cam.id.empty()) {
+      std::cout << "      ID: " << cam.id << "\n";
+    }
+    std::cout << "\n";
+  }
+}
+
+int main(int argc, char** argv) {
+  print_banner();
+
+  // Parse command line arguments
+  std::string config_file = "config/robot_configs.json";
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    if (arg == "--config" && i + 1 < argc) {
+      config_file = argv[++i];
+    } else if (arg == "--help" || arg == "-h") {
+      std::cout << "Usage: " << argv[0] << " [options]\n\n";
+      std::cout << "Options:\n";
+      std::cout << "  --config <file>  Configuration file path "
+                << "(default: config/robot_configs.json)\n";
+      std::cout << "  --help, -h       Show this help message\n";
+      return 0;
+    }
+  }
+
+  try {
+    // Load configuration file
+    std::cout << "Loading configuration from: " << config_file << "\n\n";
+    auto config_json = trossen::configuration::JsonLoader::load(config_file);
+
+    // Parse Trossen AI Solo configuration
+    auto robot_config = trossen::configuration::TrossenAiSoloConfig::from_json(
+      config_json["trossen_solo_ai"]);
+
+    // Display configuration
+    print_config(robot_config);
+
+    std::cout << "Configuration loaded successfully!\n";
+    std::cout << "\nNote: Episode recording functionality will be "
+              << "implemented in future versions.\n";
+  } catch (const std::exception& e) {
+    std::cerr << "\nError: " << e.what() << "\n";
+    std::cerr << "Failed to load configuration.\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/examples/trossen_stationary_ai_demo.cpp
+++ b/examples/trossen_stationary_ai_demo.cpp
@@ -1,0 +1,107 @@
+/**
+ * @file trossen_stationary_ai_demo.cpp
+ * @brief Trossen Stationary AI configuration reader and episode recorder
+ *
+ * This demo reads the Trossen Stationary AI robot configuration and will be used
+ * to record episodes for the stationary robot setup (2 leaders + 2 followers).
+ *
+ * Usage:
+ *   ./trossen_stationary_ai_demo
+ *   ./trossen_stationary_ai_demo --config config/robot_configs.json
+ */
+
+#include <iostream>
+#include <string>
+#include <exception>
+
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+#include "trossen_sdk/configuration/types/robots/trossen_stationary_ai_config.hpp"
+
+void print_banner() {
+  std::cout << "\n";
+  std::cout << "═══════════════════════════════════════════════════════════\n";
+  std::cout << "  Trossen Stationary AI - Configuration Reader\n";
+  std::cout << "═══════════════════════════════════════════════════════════\n";
+  std::cout << "\n";
+}
+
+void print_config(const trossen::configuration::TrossenStationaryAiConfig& config) {
+  std::cout << "Robot Configuration:\n";
+  std::cout << "  Name: " << config.robot_name << "\n";
+  std::cout << "  Type: " << config.type() << "\n\n";
+
+  std::cout << "Arms (" << config.arms.size() << "):\n";
+  for (size_t i = 0; i < config.arms.size(); ++i) {
+    const auto& arm = config.arms[i];
+    std::cout << "  [" << i << "] Model: " << arm.model << "\n";
+    std::cout << "      IP Address: " << arm.ip_address << "\n";
+    std::cout << "      End Effector: " << arm.end_effector << "\n";
+    std::cout << "      Joint Rate: " << arm.joint_rate_hz << " Hz\n";
+    std::cout << "      Clear Error: " << (arm.clear_error ? "Yes" : "No") << "\n";
+    if (!arm.id.empty()) {
+      std::cout << "      ID: " << arm.id << "\n";
+    }
+    std::cout << "\n";
+  }
+
+  std::cout << "Cameras (" << config.cameras.size() << "):\n";
+  for (size_t i = 0; i < config.cameras.size(); ++i) {
+    const auto& cam = config.cameras[i];
+    std::cout << "  [" << i << "] Type: " << cam.type << "\n";
+    std::cout << "      Device ID: " << cam.unique_device_id << "\n";
+    std::cout << "      Resolution: " << cam.width << "x" << cam.height << "\n";
+    std::cout << "      FPS: " << cam.fps << "\n";
+    std::cout << "      Encoding: " << cam.encoding << "\n";
+    std::cout << "      Use Device Time: " << (cam.use_device_time ? "Yes" : "No") << "\n";
+    if (cam.enable_depth) {
+      std::cout << "      Depth Enabled: Yes\n";
+    }
+    if (!cam.id.empty()) {
+      std::cout << "      ID: " << cam.id << "\n";
+    }
+    std::cout << "\n";
+  }
+}
+
+int main(int argc, char** argv) {
+  print_banner();
+
+  // Parse command line arguments
+  std::string config_file = "config/robot_configs.json";
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    if (arg == "--config" && i + 1 < argc) {
+      config_file = argv[++i];
+    } else if (arg == "--help" || arg == "-h") {
+      std::cout << "Usage: " << argv[0] << " [options]\n\n";
+      std::cout << "Options:\n";
+      std::cout << "  --config <file>  Configuration file path "
+                << "(default: config/robot_configs.json)\n";
+      std::cout << "  --help, -h       Show this help message\n";
+      return 0;
+    }
+  }
+
+  try {
+    // Load configuration file
+    std::cout << "Loading configuration from: " << config_file << "\n\n";
+    auto config_json = trossen::configuration::JsonLoader::load(config_file);
+
+    // Parse Trossen Stationary AI configuration
+    auto robot_config = trossen::configuration::TrossenStationaryAiConfig::from_json(
+      config_json["trossen_stationary_ai"]);
+
+    // Display configuration
+    print_config(robot_config);
+
+    std::cout << "Configuration loaded successfully!\n";
+    std::cout << "\nNote: Episode recording functionality will be "
+              << "implemented in future versions.\n";
+  } catch (const std::exception& e) {
+    std::cerr << "\nError: " << e.what() << "\n";
+    std::cerr << "Failed to load configuration.\n";
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
### TL;DR

Added robot configuration file and demo applications for three Trossen AI robot variants.

### What changed?

- Created a new `robot_configs.json` file with configurations for three robot types:
  - `trossen_solo_ai`: Single leader/follower arm setup with two cameras
  - `trossen_stationary_ai`: Dual leader/follower arm setup (4 arms total) with four cameras
  - `trossen_mobile_ai`: Similar to stationary but with an added mobile base component

- Added three new demo applications to showcase each robot configuration:
  - `trossen_solo_ai_demo.cpp`
  - `trossen_stationary_ai_demo.cpp`
  - `trossen_mobile_ai_demo.cpp`

- Updated `CMakeLists.txt` to build the new demo applications

### How to test?

Run the demo applications with the default configuration:
```
./build/examples/trossen_solo_ai_demo
./build/examples/trossen_stationary_ai_demo
./build/examples/trossen_mobile_ai_demo
```

Or specify a custom configuration file:
```
./trossen_solo_ai_demo --config path/to/config.json
```

Each demo will display the loaded robot configuration details including arms, cameras, and (for mobile variant) base parameters.

### Why make this change?

This change provides standardized configuration files and demo applications for the three Trossen AI robot variants, making it easier to set up and test different robot configurations. The demos serve as a foundation for future episode recording functionality and demonstrate how to load and parse robot configurations from JSON files.