### PR TITLE
Add TeleopArmComponent for leader-follower arm teleoperation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(trossen_sdk SHARED
   src/hw/hardware_registry.cpp
   src/hw/active_hardware_registry.cpp
   src/hw/arm/trossen_arm_component.cpp
+  src/hw/arm/teleop_arm_component.cpp
   src/hw/arm/so101_arm_component.cpp
   src/hw/arm/arm_producer.cpp
   src/hw/arm/teleop_arm_producer.cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,6 +30,11 @@ target_link_libraries(backend_registry_demo trossen_sdk)
 add_executable(hardware_registry_demo hardware_registry_demo.cpp)
 target_link_libraries(hardware_registry_demo trossen_sdk)
 
+# Teleop Arm Component demo
+find_package(libtrossen_arm)
+add_executable(teleop_arm_component_demo teleop_arm_component_demo.cpp)
+target_link_libraries(teleop_arm_component_demo trossen_sdk libtrossen_arm)
+
 # Trossen AI Solo demo Async
 # TODO (shantanuparab-tr): This example is broken due to the producer registry changes.
 # We need to update the example to use the new producer registry API.

--- a/examples/teleop_arm_component_demo.cpp
+++ b/examples/teleop_arm_component_demo.cpp
@@ -1,0 +1,90 @@
+/**
+ * @file teleop_arm_component_demo.cpp
+ * @brief Minimal demo showcasing TeleopArmComponent with leader-follower configuration
+ */
+
+#include <iostream>
+
+#include "nlohmann/json.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/arm/teleop_arm_component.hpp"
+
+int main(int argc, char** argv) {
+  // Parse command line arguments
+  std::string leader_ip = "192.168.1.2";
+  std::string follower_ip = "192.168.1.4";
+
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--leader-ip" && i + 1 < argc) {
+      leader_ip = argv[++i];
+    } else if (arg == "--follower-ip" && i + 1 < argc) {
+      follower_ip = argv[++i];
+    } else if (arg == "--help") {
+      std::cout << "Usage: " << argv[0] << " [OPTIONS]\n";
+      std::cout << "Options:\n";
+      std::cout << "  --leader-ip <IP>     Leader arm IP address (default: 192.168.1.2)\n";
+      std::cout << "  --follower-ip <IP>   Follower arm IP address (default: 192.168.1.4)\n";
+      std::cout << "  --help               Show this help message\n";
+      return 0;
+    }
+  }
+
+  std::cout << "\nTeleop Arm Component Demo\n";
+  std::cout << "==========================\n\n";
+
+  // Create TeleopArmComponent from configuration
+  std::cout << "1. Creating TeleopArmComponent...\n";
+
+  nlohmann::json teleop_config = {
+    {"leader", {
+      {"ip_address", leader_ip},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_leader"}
+    }},
+    {"follower", {
+      {"ip_address", follower_ip},
+      {"model", "wxai_v0"},
+      {"end_effector", "wxai_v0_follower"}
+    }}
+  };
+
+  try {
+    // Create and auto-register the component
+    auto teleop_component = trossen::hw::HardwareRegistry::create(
+      "teleop_arm", "teleop_arm_pair", teleop_config);
+    std::cout << "   ✓ Created and registered\n";
+
+    // Retrieve from active registry and get drivers
+    std::cout << "\n2. Accessing drivers...\n";
+    auto retrieved = trossen::hw::ActiveHardwareRegistry::get_as<
+      trossen::hw::arm::TeleopArmComponent>("teleop_arm_pair");
+
+    auto drivers = retrieved->get_hardware();
+    std::cout << "   ✓ Leader driver: "
+              << (drivers.leader ? "available" : "unavailable") << "\n";
+    std::cout << "   ✓ Follower driver: "
+              << (drivers.follower ? "available" : "unavailable") << "\n";
+
+    // Read joint positions once
+    std::cout << "\n3. Reading joint positions...\n";
+    auto leader_output = drivers.leader->get_robot_output();
+    auto follower_output = drivers.follower->get_robot_output();
+
+    std::cout << "   Leader:   " << leader_output.joint.all.positions.size() << " joints\n";
+    std::cout << "   Follower: " << follower_output.joint.all.positions.size() << " joints\n";
+
+    // Cleanup
+    trossen::hw::ActiveHardwareRegistry::clear();
+    std::cout << "\n✓ Demo complete!\n\n";
+  } catch (const std::exception& e) {
+    std::cerr << "   ✗ Error: " << e.what() << "\n";
+    std::cerr << "\nNote: Ensure arms are connected at:\n";
+    std::cerr << "  Leader:   " << leader_ip << "\n";
+    std::cerr << "  Follower: " << follower_ip << "\n\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/include/trossen_sdk/hw/arm/teleop_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_arm_component.hpp
@@ -1,0 +1,115 @@
+/**
+ * @file teleop_arm_component.hpp
+ * @brief Hardware component wrapper for teleoperation with Trossen Robotics arms
+ */
+
+#ifndef TROSSEN_SDK__HW__ARM__TELEOP_ARM_COMPONENT_HPP_
+#define TROSSEN_SDK__HW__ARM__TELEOP_ARM_COMPONENT_HPP_
+
+#include <memory>
+#include <string>
+
+#include "libtrossen_arm/trossen_arm.hpp"
+
+#include "trossen_sdk/hw/hardware_component.hpp"
+
+namespace trossen::hw::arm {
+
+/**
+ * @brief Hardware component for teleoperation with Trossen Robotics robot arms
+ *
+ * Wraps two trossen_arm::TrossenArmDriver instances (leader and follower)
+ * and provides JSON configuration for teleoperation scenarios.
+ */
+class TeleopArmComponent : public HardwareComponent {
+public:
+  /**
+   * @brief Constructor
+   *
+   * @param identifier Component identifier
+   */
+  explicit TeleopArmComponent(std::string identifier) : HardwareComponent(identifier) {}
+  ~TeleopArmComponent() override = default;
+
+  /**
+   * @brief Configure the teleop arm pair from JSON
+   *
+   * Expected JSON format:
+   * {
+   *   "leader": {
+   *     "ip_address": "192.168.1.100",
+   *     "model": "wxai_v0",
+   *     "end_effector": "wxai_v0_leader"
+   *   },
+   *   "follower": {
+   *     "ip_address": "192.168.1.101",
+   *     "model": "wxai_v0",
+   *     "end_effector": "wxai_v0_follower"
+   *   }
+   * }
+   *
+   * @param config JSON configuration object
+   * @throws std::runtime_error if configuration fails
+   */
+  void configure(const nlohmann::json& config) override;
+
+  /**
+   * @brief Get the type string for this hardware component
+   *
+   * @return Type identifier
+   */
+  std::string get_type() const override { return "teleop_arm"; }
+
+  /**
+   * @brief Get human-readable component information
+   *
+   * @return JSON object with component details
+   */
+  nlohmann::json get_info() const override;
+
+  /**
+   * @brief Structure to hold both leader and follower drivers
+   */
+  struct TeleopDrivers {
+    std::shared_ptr<trossen_arm::TrossenArmDriver> leader;
+    std::shared_ptr<trossen_arm::TrossenArmDriver> follower;
+  };
+
+  /**
+   * @brief Get the underlying hardware driver instances
+   *
+   * @return Structure containing both leader and follower drivers
+   */
+  TeleopDrivers get_hardware() {
+    return {leader_driver_, follower_driver_};
+  }
+
+private:
+  /// @brief Leader arm driver
+  std::shared_ptr<trossen_arm::TrossenArmDriver> leader_driver_;
+
+  /// @brief Follower arm driver
+  std::shared_ptr<trossen_arm::TrossenArmDriver> follower_driver_;
+
+  /// @brief Leader arm model
+  std::string leader_model_str_;
+
+  /// @brief Leader end effector type
+  std::string leader_end_effector_str_;
+
+  /// @brief Leader IP address
+  std::string leader_ip_address_;
+
+  /// @brief Follower arm model
+  std::string follower_model_str_;
+
+  /// @brief Follower end effector type
+  std::string follower_end_effector_str_;
+
+  /// @brief Follower IP address
+  std::string follower_ip_address_;
+};
+
+}  // namespace trossen::hw::arm
+
+#endif  // TROSSEN_SDK__HW__ARM__TELEOP_ARM_COMPONENT_HPP_

--- a/src/hw/arm/teleop_arm_component.cpp
+++ b/src/hw/arm/teleop_arm_component.cpp
@@ -1,0 +1,133 @@
+/**
+ * @file teleop_arm_component.cpp
+ * @brief Implementation of TeleopArmComponent
+ */
+
+#include "trossen_sdk/hw/arm/teleop_arm_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include <stdexcept>
+#include <string>
+
+namespace trossen::hw::arm {
+
+void TeleopArmComponent::configure(const nlohmann::json& config) {
+  // Extract leader configuration
+  if (!config.contains("leader")) {
+    throw std::runtime_error("TeleopArmComponent: 'leader' configuration is required");
+  }
+  const auto& leader_config = config.at("leader");
+
+  // Parse leader IP address
+  if (!leader_config.contains("ip_address")) {
+    throw std::runtime_error("TeleopArmComponent: 'ip_address' is required in leader config");
+  }
+  leader_ip_address_ = leader_config.at("ip_address").get<std::string>();
+
+  // Parse leader model
+  if (!leader_config.contains("model")) {
+    throw std::runtime_error("TeleopArmComponent: 'model' is required in leader config");
+  }
+  leader_model_str_ = leader_config.at("model").get<std::string>();
+  trossen_arm::Model leader_model;
+  if (leader_model_str_ == "wxai_v0") {
+    leader_model = trossen_arm::Model::wxai_v0;
+  } else {
+    throw std::runtime_error("TeleopArmComponent: Unknown leader model: " + leader_model_str_);
+  }
+
+  // Parse leader end effector
+  if (!leader_config.contains("end_effector")) {
+    throw std::runtime_error("TeleopArmComponent: 'end_effector' is required in leader config");
+  }
+  trossen_arm::EndEffector leader_end_effector;
+  leader_end_effector_str_ = leader_config.at("end_effector").get<std::string>();
+  if (leader_end_effector_str_ == "wxai_v0_leader") {
+    leader_end_effector = trossen_arm::StandardEndEffector::wxai_v0_leader;
+  } else if (leader_end_effector_str_ == "wxai_v0_follower") {
+    leader_end_effector = trossen_arm::StandardEndEffector::wxai_v0_follower;
+  } else {
+    throw std::runtime_error(
+      "TeleopArmComponent: Unknown leader end_effector: " + leader_end_effector_str_);
+  }
+
+  // Extract follower configuration
+  if (!config.contains("follower")) {
+    throw std::runtime_error("TeleopArmComponent: 'follower' configuration is required");
+  }
+  const auto& follower_config = config.at("follower");
+
+  // Parse follower IP address
+  if (!follower_config.contains("ip_address")) {
+    throw std::runtime_error("TeleopArmComponent: 'ip_address' is required in follower config");
+  }
+  follower_ip_address_ = follower_config.at("ip_address").get<std::string>();
+
+  // Parse follower model
+  if (!follower_config.contains("model")) {
+    throw std::runtime_error("TeleopArmComponent: 'model' is required in follower config");
+  }
+  follower_model_str_ = follower_config.at("model").get<std::string>();
+  trossen_arm::Model follower_model;
+  if (follower_model_str_ == "wxai_v0") {
+    follower_model = trossen_arm::Model::wxai_v0;
+  } else {
+    throw std::runtime_error(
+      "TeleopArmComponent: Unknown follower model: " + follower_model_str_);
+  }
+
+  // Parse follower end effector
+  if (!follower_config.contains("end_effector")) {
+    throw std::runtime_error(
+      "TeleopArmComponent: 'end_effector' is required in follower config");
+  }
+  trossen_arm::EndEffector follower_end_effector;
+  follower_end_effector_str_ = follower_config.at("end_effector").get<std::string>();
+  if (follower_end_effector_str_ == "wxai_v0_leader") {
+    follower_end_effector = trossen_arm::StandardEndEffector::wxai_v0_leader;
+  } else if (follower_end_effector_str_ == "wxai_v0_follower") {
+    follower_end_effector = trossen_arm::StandardEndEffector::wxai_v0_follower;
+  } else {
+    throw std::runtime_error(
+      "TeleopArmComponent: Unknown follower end_effector: " + follower_end_effector_str_);
+  }
+
+  // Create and configure leader driver
+  leader_driver_ = std::make_shared<trossen_arm::TrossenArmDriver>();
+  try {
+    leader_driver_->configure(leader_model, leader_end_effector, leader_ip_address_, true);
+  } catch (const std::exception& e) {
+    throw std::runtime_error(
+      "TeleopArmComponent: Failed to configure leader driver: " + std::string(e.what()));
+  }
+
+  // Create and configure follower driver
+  follower_driver_ = std::make_shared<trossen_arm::TrossenArmDriver>();
+  try {
+    follower_driver_->configure(follower_model, follower_end_effector, follower_ip_address_, true);
+  } catch (const std::exception& e) {
+    throw std::runtime_error(
+      "TeleopArmComponent: Failed to configure follower driver: " + std::string(e.what()));
+  }
+}
+
+nlohmann::json TeleopArmComponent::get_info() const {
+  nlohmann::json info = {
+    {"type", "teleop_arm"},
+    {"leader", {
+      {"ip_address", leader_ip_address_},
+      {"model", leader_model_str_},
+      {"end_effector", leader_end_effector_str_}
+    }},
+    {"follower", {
+      {"ip_address", follower_ip_address_},
+      {"model", follower_model_str_},
+      {"end_effector", follower_end_effector_str_}
+    }}
+  };
+
+  return info;
+}
+
+REGISTER_HARDWARE(TeleopArmComponent, "teleop_arm")
+
+}  // namespace trossen::hw::arm


### PR DESCRIPTION
### TL;DR

Added a new `TeleopArmComponent` class to support leader-follower arm teleoperation configurations.

### What changed?

- Created a new `TeleopArmComponent` class that manages a pair of Trossen robotic arms in a leader-follower configuration
- Added header file (`teleop_arm_component.hpp`) and implementation file (`teleop_arm_component.cpp`)
- Implemented JSON-based configuration for the component
- Added a demo application (`teleop_arm_component_demo.cpp`) that shows how to use the component
- Updated build files to include the new component and demo

### How to test?

Run the new demo application:

```bash
./teleop_arm_component_demo --leader-ip 192.168.1.2 --follower-ip 192.168.1.4
```

The demo will:
1. Create a TeleopArmComponent with the specified IP addresses
2. Connect to both leader and follower arms
3. Read and display joint positions from both arms

You can use the `--help` flag to see usage instructions.

### Why make this change?

This component simplifies the setup and management of teleoperation scenarios by encapsulating both leader and follower arms in a single hardware component. It provides a clean interface for applications that need to work with paired arms, reducing boilerplate code and standardizing the configuration process.

PS: The demo file can be deleted later