### PR TITLE
Add TeleopTrossenArmProducer with registry support and expanded documentation

### DIFF
--- a/examples/teleop_arm_component_demo.cpp
+++ b/examples/teleop_arm_component_demo.cpp
@@ -1,19 +1,58 @@
 /**
  * @file teleop_arm_component_demo.cpp
  * @brief Minimal demo showcasing TeleopArmComponent with leader-follower configuration
+ *
+ * This demo shows how to:
+ *   1. Create a TeleopArmComponent from configuration
+ *   2. Access leader and follower drivers
+ *   3. Read joint positions
+ *
+ * USAGE WITH TELEOP ARM PRODUCER:
+ * ================================
+ * To create a TeleopTrossenArmProducer that records both leader and follower data
+ * using the ProducerRegistry pattern:
+ *
+ * @code
+ * // 1. Create a TeleopArmComponent (contains both leader and follower)
+ * auto teleop_component = trossen::hw::HardwareRegistry::create(
+ *   "teleop_arm", "teleop_arm_pair",
+ *   {{"leader", {{"ip_address", "192.168.1.2"},
+ *                {"model", "wxai_v0"},
+ *                {"end_effector", "wxai_v0_leader"}}},
+ *    {"follower", {{"ip_address", "192.168.1.4"},
+ *                  {"model", "wxai_v0"},
+ *                  {"end_effector", "wxai_v0_follower"}}}});
+ *
+ * // 2. Create the teleop producer via registry
+ * const float arm_rate_hz = 30.0f;
+ * auto joint_period = std::chrono::milliseconds(static_cast<int>(1000.0f / arm_rate_hz));
+ * nlohmann::json prod_cfg = {
+ *   {"stream_id", "teleop_arm/states"},
+ *   {"use_device_time", false}
+ * };
+ * auto producer = trossen::runtime::ProducerRegistry::create(
+ *   "teleop_arm", teleop_component, prod_cfg);
+ *
+ * // 3. Add producer to session manager
+ * mgr.add_producer(producer, joint_period);
+ * @endcode
  */
 
+#include <chrono>
 #include <iostream>
+#include <thread>
 
 #include "nlohmann/json.hpp"
 #include "trossen_sdk/hw/active_hardware_registry.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
 #include "trossen_sdk/hw/arm/teleop_arm_component.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
 
 int main(int argc, char** argv) {
   // Parse command line arguments
   std::string leader_ip = "192.168.1.2";
   std::string follower_ip = "192.168.1.4";
+  bool demo_producer = false;
 
   for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
@@ -21,11 +60,14 @@ int main(int argc, char** argv) {
       leader_ip = argv[++i];
     } else if (arg == "--follower-ip" && i + 1 < argc) {
       follower_ip = argv[++i];
+    } else if (arg == "--demo-producer") {
+      demo_producer = true;
     } else if (arg == "--help") {
       std::cout << "Usage: " << argv[0] << " [OPTIONS]\n";
       std::cout << "Options:\n";
       std::cout << "  --leader-ip <IP>     Leader arm IP address (default: 192.168.1.2)\n";
       std::cout << "  --follower-ip <IP>   Follower arm IP address (default: 192.168.1.4)\n";
+      std::cout << "  --demo-producer      Also demonstrate TeleopTrossenArmProducer\n";
       std::cout << "  --help               Show this help message\n";
       return 0;
     }
@@ -74,6 +116,46 @@ int main(int argc, char** argv) {
 
     std::cout << "   Leader:   " << leader_output.joint.all.positions.size() << " joints\n";
     std::cout << "   Follower: " << follower_output.joint.all.positions.size() << " joints\n";
+
+    // --------------------------------------------------------------------------
+    // OPTIONAL: Demonstrate TeleopTrossenArmProducer
+    // --------------------------------------------------------------------------
+    if (demo_producer) {
+      std::cout << "\n4. Creating TeleopTrossenArmProducer via registry...\n";
+
+      // Create the teleop producer using the existing TeleopArmComponent
+      const float arm_rate_hz = 30.0f;
+      auto joint_period = std::chrono::milliseconds(
+        static_cast<int>(1000.0f / arm_rate_hz));
+
+      nlohmann::json prod_cfg = {
+        {"stream_id", "teleop_arm/states"},
+        {"use_device_time", false}
+      };
+
+      // Reuse the existing teleop_component from step 1
+      auto producer = trossen::runtime::ProducerRegistry::create(
+        "teleop_arm", teleop_component, prod_cfg);
+      std::cout << "   ✓ Created TeleopTrossenArmProducer from existing TeleopArmComponent\n";
+
+      // Test polling the producer a few times
+      std::cout << "\n5. Testing producer polling (3 samples)...\n";
+      int sample_count = 0;
+      auto emit_callback = [&sample_count](std::shared_ptr<trossen::data::RecordBase> rec) {
+        sample_count++;
+        std::cout << "   ✓ Sample " << sample_count << " - Stream ID: " << rec->id
+                  << ", Seq: " << rec->seq << "\n";
+      };
+
+      for (int i = 0; i < 3; ++i) {
+        producer->poll(emit_callback);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+
+      std::cout << "   Total samples: " << sample_count << "\n";
+      std::cout << "\n   NOTE: In a real application, add the producer to a SessionManager:\n";
+      std::cout << "         mgr.add_producer(producer, joint_period);\n";
+    }
 
     // Cleanup
     trossen::hw::ActiveHardwareRegistry::clear();

--- a/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_arm_producer.hpp
@@ -13,9 +13,11 @@
 #include <vector>
 
 #include "libtrossen_arm/trossen_arm.hpp"
+#include "nlohmann/json.hpp"
 
 #include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
 #include "trossen_sdk/hw/producer_base.hpp"
 
 namespace trossen::hw::arm {
@@ -79,9 +81,21 @@ public:
   };
 
   /**
-   * @brief Construct a TeleopTrossenArmProducer
+   * @brief Construct a TeleopTrossenArmProducer from TeleopArmComponent (registry pattern)
    *
-   * @param driver Shared pointer to an initialized TrossenArmDriver instance
+   * @param hardware TeleopArmComponent containing leader and follower arms
+   * @param config JSON configuration with fields: stream_id, use_device_time
+   * @throws std::invalid_argument if hardware is null or wrong type
+   */
+  TeleopTrossenArmProducer(
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config);
+
+  /**
+   * @brief Construct a TeleopTrossenArmProducer directly from drivers
+   *
+   * @param leader_driver Shared pointer to an initialized leader TrossenArmDriver instance
+   * @param follower_driver Shared pointer to an initialized follower TrossenArmDriver instance
    * @param cfg Configuration parameters
    */
   TeleopTrossenArmProducer(

--- a/src/hw/arm/teleop_arm_producer.cpp
+++ b/src/hw/arm/teleop_arm_producer.cpp
@@ -7,12 +7,77 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 
 #include "trossen_sdk/hw/arm/teleop_arm_producer.hpp"
+#include "trossen_sdk/hw/arm/teleop_arm_component.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
 
 namespace trossen::hw::arm {
 
+// Registry-compatible constructor
+TeleopTrossenArmProducer::TeleopTrossenArmProducer(
+  std::shared_ptr<hw::HardwareComponent> hardware,
+  const nlohmann::json& config)
+{
+  // Validate hardware component
+  if (!hardware) {
+    throw std::invalid_argument(
+      "TeleopTrossenArmProducer: hardware component cannot be null");
+  }
+  auto teleop_component = std::dynamic_pointer_cast<TeleopArmComponent>(hardware);
+  if (!teleop_component) {
+    throw std::invalid_argument(
+      "TeleopTrossenArmProducer: hardware must be TeleopArmComponent, got: " +
+      hardware->get_type());
+  }
+
+  // Extract leader and follower drivers from TeleopArmComponent
+  auto drivers = teleop_component->get_hardware();
+  leader_driver_ = drivers.leader;
+  follower_driver_ = drivers.follower;
+
+  if (!leader_driver_) {
+    throw std::invalid_argument(
+      "TeleopTrossenArmProducer: TeleopArmComponent has null leader driver");
+  }
+  if (!follower_driver_) {
+    throw std::invalid_argument(
+      "TeleopTrossenArmProducer: TeleopArmComponent has null follower driver");
+  }
+
+  // Parse JSON config
+  cfg_.stream_id = config.value("stream_id", "teleop_arm");
+  cfg_.use_device_time = config.value("use_device_time", false);
+
+  // Preallocate buffers based on number of joints
+  act_d_.resize(leader_driver_->get_num_joints());
+  obs_d_.resize(follower_driver_->get_num_joints());
+
+  // Initial read to populate robot_output state
+  leader_robot_output_ = leader_driver_->get_robot_output();
+  follower_robot_output_ = follower_driver_->get_robot_output();
+
+  // Populate metadata
+  metadata_.type = "teleop_arm";
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "Teleop Trossen Arm Producer";
+  metadata_.description =
+    "Produces teleoperation joint states from leader and follower "
+    "Trossen Arms via TrossenArmDriver";
+  metadata_.robot_name = "Trossen AI Bimanual";
+  metadata_.action_feature_names =
+    {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
+  metadata_.observation_feature_names =
+    {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
+  metadata_.action_dtype = "float32";
+  metadata_.observation_dtype = "float32";
+}
+
+// Direct driver constructor
 TeleopTrossenArmProducer::TeleopTrossenArmProducer(
   std::shared_ptr<trossen_arm::TrossenArmDriver> leader_driver,
   std::shared_ptr<trossen_arm::TrossenArmDriver> follower_driver,
@@ -89,5 +154,8 @@ void TeleopTrossenArmProducer::poll(
   emit(rec);
   ++stats_.produced;
 }
+
+// Register producer with registry
+REGISTER_PRODUCER(TeleopTrossenArmProducer, "teleop_arm")
 
 }  // namespace trossen::hw::arm


### PR DESCRIPTION
### TL;DR

Added registry support for TeleopTrossenArmProducer and enhanced the teleop arm component demo with producer functionality.

### What changed?

- Added a new constructor to `TeleopTrossenArmProducer` that accepts a `HardwareComponent` and JSON configuration
- Implemented the registry-compatible constructor to extract leader and follower drivers from a `TeleopArmComponent`
- Registered the producer with the `ProducerRegistry` using the `REGISTER_PRODUCER` macro
- Enhanced the `teleop_arm_component_demo.cpp` example with:
  - Detailed documentation and usage examples in the header comments
  - Optional producer demonstration with the `--demo-producer` flag
  - Code showing how to create and use a `TeleopTrossenArmProducer` from an existing `TeleopArmComponent`

### How to test?

1. Run the enhanced demo with the producer functionality:
   ```
   ./teleop_arm_component_demo --leader-ip 192.168.1.2 --follower-ip 192.168.1.4 --demo-producer
   ```

2. Test creating a producer via the registry pattern:
   ```cpp
   auto teleop_component = trossen::hw::HardwareRegistry::create("teleop_arm", "teleop_arm_pair", config);
   auto producer = trossen::runtime::ProducerRegistry::create("teleop_arm", teleop_component, prod_cfg);
   ```

### Why make this change?

This change enables the `TeleopTrossenArmProducer` to be created through the registry pattern, making it consistent with other components in the SDK. It simplifies the creation and management of teleop arm producers in applications by allowing them to be instantiated from configuration rather than requiring direct driver access. The enhanced demo provides clear examples of how to use this functionality in real applications.