### PR TITLE
Add TeleopSolo and TeleopStationary arm producers for different configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ add_library(trossen_sdk SHARED
   src/hw/arm/so101_arm_component.cpp
   src/hw/arm/arm_producer.cpp
   src/hw/arm/teleop_arm_producer.cpp
+  src/hw/arm/teleop_solo_arm_producer.cpp
+  src/hw/arm/teleop_stationary_arm_producer.cpp
   src/hw/arm/mock_joint_producer.cpp
   src/hw/arm/teleop_mock_joint_producer.cpp
   src/hw/arm/so101_arm_driver.cpp

--- a/examples/teleop_arm_component_demo.cpp
+++ b/examples/teleop_arm_component_demo.cpp
@@ -1,41 +1,10 @@
 /**
  * @file teleop_arm_component_demo.cpp
- * @brief Minimal demo showcasing TeleopArmComponent with leader-follower configuration
+ * @brief Demo showcasing TeleopArmComponent with Solo and Stationary producers
  *
- * This demo shows how to:
- *   1. Create a TeleopArmComponent from configuration
- *   2. Access leader and follower drivers
- *   3. Read joint positions
- *
- * USAGE WITH TELEOP ARM PRODUCER:
- * ================================
- * To create a TeleopTrossenArmProducer that records both leader and follower data
- * using the ProducerRegistry pattern:
- *
- * @code
- * // 1. Create a TeleopArmComponent (contains both leader and follower)
- * auto teleop_component = trossen::hw::HardwareRegistry::create(
- *   "teleop_arm", "teleop_arm_pair",
- *   {{"leader", {{"ip_address", "192.168.1.2"},
- *                {"model", "wxai_v0"},
- *                {"end_effector", "wxai_v0_leader"}}},
- *    {"follower", {{"ip_address", "192.168.1.4"},
- *                  {"model", "wxai_v0"},
- *                  {"end_effector", "wxai_v0_follower"}}}});
- *
- * // 2. Create the teleop producer via registry
- * const float arm_rate_hz = 30.0f;
- * auto joint_period = std::chrono::milliseconds(static_cast<int>(1000.0f / arm_rate_hz));
- * nlohmann::json prod_cfg = {
- *   {"stream_id", "teleop_arm/states"},
- *   {"use_device_time", false}
- * };
- * auto producer = trossen::runtime::ProducerRegistry::create(
- *   "teleop_arm", teleop_component, prod_cfg);
- *
- * // 3. Add producer to session manager
- * mgr.add_producer(producer, joint_period);
- * @endcode
+ * Demonstrates:
+ *   1. TeleopSoloArmProducer - Single leader-follower pair
+ *   2. TeleopStationaryArmProducer - Bimanual (2 leaders + 2 followers)
  */
 
 #include <chrono>
@@ -43,128 +12,96 @@
 #include <thread>
 
 #include "nlohmann/json.hpp"
-#include "trossen_sdk/hw/active_hardware_registry.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
-#include "trossen_sdk/hw/arm/teleop_arm_component.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 
-int main(int argc, char** argv) {
-  // Parse command line arguments
-  std::string leader_ip = "192.168.1.2";
-  std::string follower_ip = "192.168.1.4";
-  bool demo_producer = false;
-
-  for (int i = 1; i < argc; ++i) {
-    std::string arg = argv[i];
-    if (arg == "--leader-ip" && i + 1 < argc) {
-      leader_ip = argv[++i];
-    } else if (arg == "--follower-ip" && i + 1 < argc) {
-      follower_ip = argv[++i];
-    } else if (arg == "--demo-producer") {
-      demo_producer = true;
-    } else if (arg == "--help") {
-      std::cout << "Usage: " << argv[0] << " [OPTIONS]\n";
-      std::cout << "Options:\n";
-      std::cout << "  --leader-ip <IP>     Leader arm IP address (default: 192.168.1.2)\n";
-      std::cout << "  --follower-ip <IP>   Follower arm IP address (default: 192.168.1.4)\n";
-      std::cout << "  --demo-producer      Also demonstrate TeleopTrossenArmProducer\n";
-      std::cout << "  --help               Show this help message\n";
-      return 0;
-    }
-  }
-
-  std::cout << "\nTeleop Arm Component Demo\n";
-  std::cout << "==========================\n\n";
-
-  // Create TeleopArmComponent from configuration
-  std::cout << "1. Creating TeleopArmComponent...\n";
-
-  nlohmann::json teleop_config = {
-    {"leader", {
-      {"ip_address", leader_ip},
-      {"model", "wxai_v0"},
-      {"end_effector", "wxai_v0_leader"}
-    }},
-    {"follower", {
-      {"ip_address", follower_ip},
-      {"model", "wxai_v0"},
-      {"end_effector", "wxai_v0_follower"}
-    }}
-  };
+int main() {
+  std::cout << "\nTeleop Arm Component & Producer Demo\n";
+  std::cout << "=====================================\n\n";
 
   try {
-    // Create and auto-register the component
-    auto teleop_component = trossen::hw::HardwareRegistry::create(
-      "teleop_arm", "teleop_arm_pair", teleop_config);
-    std::cout << "   ✓ Created and registered\n";
+    // ==========================================================================
+    // SOLO Producer Demo (Single Leader-Follower Pair)
+    // ==========================================================================
+    std::cout << "SOLO Producer Demo\n";
+    std::cout << "------------------\n";
 
-    // Retrieve from active registry and get drivers
-    std::cout << "\n2. Accessing drivers...\n";
-    auto retrieved = trossen::hw::ActiveHardwareRegistry::get_as<
-      trossen::hw::arm::TeleopArmComponent>("teleop_arm_pair");
+    // Create left arm pair
+    std::cout << "1. Creating left arm TeleopArmComponent\n";
+    nlohmann::json left_config = {
+      {"leader",
+       {{"ip_address", "192.168.1.2"}, {"model", "wxai_v0"}, {"end_effector", "wxai_v0_leader"}}},
+      {"follower",
+       {{"ip_address", "192.168.1.4"}, {"model", "wxai_v0"}, {"end_effector", "wxai_v0_follower"}}}
+    };
 
-    auto drivers = retrieved->get_hardware();
-    std::cout << "   ✓ Leader driver: "
-              << (drivers.leader ? "available" : "unavailable") << "\n";
-    std::cout << "   ✓ Follower driver: "
-              << (drivers.follower ? "available" : "unavailable") << "\n";
+    auto left_component = trossen::hw::HardwareRegistry::create(
+      "teleop_arm", "left_pair", left_config);
+    std::cout << "   ✓ Left arm pair created\n";
 
-    // Read joint positions once
-    std::cout << "\n3. Reading joint positions...\n";
-    auto leader_output = drivers.leader->get_robot_output();
-    auto follower_output = drivers.follower->get_robot_output();
+    // Create solo producer
+    std::cout << "\n2. Creating TeleopSoloArmProducer\n";
+    auto solo_producer = trossen::runtime::ProducerRegistry::create(
+      "teleop_solo", left_component,
+      {{"stream_id", "teleop_solo/states"}, {"use_device_time", false}});
+    std::cout << "   ✓ TeleopSoloArmProducer created\n";
 
-    std::cout << "   Leader:   " << leader_output.joint.all.positions.size() << " joints\n";
-    std::cout << "   Follower: " << follower_output.joint.all.positions.size() << " joints\n";
-
-    // --------------------------------------------------------------------------
-    // OPTIONAL: Demonstrate TeleopTrossenArmProducer
-    // --------------------------------------------------------------------------
-    if (demo_producer) {
-      std::cout << "\n4. Creating TeleopTrossenArmProducer via registry...\n";
-
-      // Create the teleop producer using the existing TeleopArmComponent
-      const float arm_rate_hz = 30.0f;
-      auto joint_period = std::chrono::milliseconds(
-        static_cast<int>(1000.0f / arm_rate_hz));
-
-      nlohmann::json prod_cfg = {
-        {"stream_id", "teleop_arm/states"},
-        {"use_device_time", false}
-      };
-
-      // Reuse the existing teleop_component from step 1
-      auto producer = trossen::runtime::ProducerRegistry::create(
-        "teleop_arm", teleop_component, prod_cfg);
-      std::cout << "   ✓ Created TeleopTrossenArmProducer from existing TeleopArmComponent\n";
-
-      // Test polling the producer a few times
-      std::cout << "\n5. Testing producer polling (3 samples)...\n";
-      int sample_count = 0;
-      auto emit_callback = [&sample_count](std::shared_ptr<trossen::data::RecordBase> rec) {
-        sample_count++;
-        std::cout << "   ✓ Sample " << sample_count << " - Stream ID: " << rec->id
-                  << ", Seq: " << rec->seq << "\n";
-      };
-
-      for (int i = 0; i < 3; ++i) {
-        producer->poll(emit_callback);
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      }
-
-      std::cout << "   Total samples: " << sample_count << "\n";
-      std::cout << "\n   NOTE: In a real application, add the producer to a SessionManager:\n";
-      std::cout << "         mgr.add_producer(producer, joint_period);\n";
+    // Poll solo producer
+    std::cout << "\n3. Polling solo producer (3 samples)\n";
+    int solo_count = 0;
+    for (int i = 0; i < 3; ++i) {
+      solo_producer->poll([&solo_count](auto rec) {
+        std::cout << "   Sample " << ++solo_count << ": seq=" << rec->seq << "\n";
+      });
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    // Cleanup
+    // ==========================================================================
+    // STATIONARY Producer Demo (Bimanual: 2 Leaders + 2 Followers)
+    // ==========================================================================
+    std::cout << "\n\nSTATIONARY Producer Demo\n";
+    std::cout << "------------------------\n";
+
+    // Create right arm pair
+    std::cout << "1. Creating right arm TeleopArmComponent\n";
+    nlohmann::json right_config = {
+      {"leader",
+       {{"ip_address", "192.168.1.3"}, {"model", "wxai_v0"}, {"end_effector", "wxai_v0_leader"}}},
+      {"follower",
+       {{"ip_address", "192.168.1.5"}, {"model", "wxai_v0"}, {"end_effector", "wxai_v0_follower"}}}
+    };
+
+    auto right_component = trossen::hw::HardwareRegistry::create(
+      "teleop_arm", "right_pair", right_config);
+    std::cout << "   ✓ Right arm pair created\n";
+
+    // Create stationary producer
+    std::cout << "\n2. Creating TeleopStationaryArmProducer\n";
+    auto stationary_producer = trossen::runtime::ProducerRegistry::create(
+      "teleop_stationary", nullptr,
+      {{"stream_id", "teleop_stationary/states"},
+       {"use_device_time", false},
+       {"left_id", "left_pair"},
+       {"right_id", "right_pair"}});
+    std::cout << "   ✓ TeleopStationaryArmProducer created\n";
+    std::cout << "   ✓ Producer type: " << stationary_producer->metadata()->type << "\n";
+
+    // Poll stationary producer
+    std::cout << "\n3. Polling stationary producer (3 samples)\n";
+    int stationary_count = 0;
+    for (int i = 0; i < 3; ++i) {
+      stationary_producer->poll([&stationary_count](auto rec) {
+        std::cout << "   Sample " << ++stationary_count << ": seq=" << rec->seq << "\n";
+      });
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    std::cout << "\n✓ Demo complete\n";
+
     trossen::hw::ActiveHardwareRegistry::clear();
-    std::cout << "\n✓ Demo complete!\n\n";
   } catch (const std::exception& e) {
-    std::cerr << "   ✗ Error: " << e.what() << "\n";
-    std::cerr << "\nNote: Ensure arms are connected at:\n";
-    std::cerr << "  Leader:   " << leader_ip << "\n";
-    std::cerr << "  Follower: " << follower_ip << "\n\n";
+    std::cerr << "\n✗ Error: " << e.what() << "\n";
     return 1;
   }
 

--- a/include/trossen_sdk/hw/arm/teleop_solo_arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_solo_arm_producer.hpp
@@ -1,0 +1,95 @@
+/**
+ * @file teleop_solo_arm_producer.hpp
+ * @brief Producer for single leader-follower teleoperation (SOLO configuration)
+ */
+
+#ifndef TROSSEN_SDK__HW__ARM__TELEOP_SOLO_ARM_PRODUCER_HPP
+#define TROSSEN_SDK__HW__ARM__TELEOP_SOLO_ARM_PRODUCER_HPP
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "libtrossen_arm/trossen_arm.hpp"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::hw::arm {
+
+/**
+ * @brief Producer for single leader-follower teleoperation (SOLO configuration)
+ *
+ * Records joint states from one leader and one follower arm.
+ */
+class TeleopSoloArmProducer : public ::trossen::hw::PolledProducer {
+public:
+  struct Config {
+    std::string stream_id{"teleop_solo"};
+    bool use_device_time{true};
+  };
+
+  struct TeleopSoloArmProducerMetadata : public PolledProducer::ProducerMetadata {
+    std::string robot_name;
+    std::vector<std::string> action_feature_names;
+    std::vector<std::string> observation_feature_names;
+    std::string action_dtype;
+    std::string observation_dtype;
+
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      nlohmann::ordered_json action;
+      action["dtype"] = action_dtype;
+      action["shape"] = {static_cast<int>(action_feature_names.size())};
+      action["names"] = action_feature_names;
+
+      nlohmann::ordered_json observation_state;
+      observation_state["dtype"] = observation_dtype;
+      observation_state["shape"] = {static_cast<int>(observation_feature_names.size())};
+      observation_state["names"] = observation_feature_names;
+      features["action"] = action;
+      features["observation.state"] = observation_state;
+      return features;
+    }
+  };
+
+  /**
+   * @brief Construct from TeleopArmComponent (registry pattern)
+   */
+  TeleopSoloArmProducer(
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config);
+
+  /**
+   * @brief Construct directly from drivers
+   */
+  TeleopSoloArmProducer(
+    std::shared_ptr<trossen_arm::TrossenArmDriver> leader_driver,
+    std::shared_ptr<trossen_arm::TrossenArmDriver> follower_driver,
+    Config cfg);
+
+  ~TeleopSoloArmProducer() override = default;
+
+  void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<TeleopSoloArmProducerMetadata>(metadata_);
+  }
+
+private:
+  std::shared_ptr<trossen_arm::TrossenArmDriver> leader_driver_;
+  std::shared_ptr<trossen_arm::TrossenArmDriver> follower_driver_;
+  Config cfg_;
+  std::vector<double> act_d_, obs_d_;
+  trossen_arm::RobotOutput leader_robot_output_;
+  trossen_arm::RobotOutput follower_robot_output_;
+  TeleopSoloArmProducerMetadata metadata_;
+};
+
+}  // namespace trossen::hw::arm
+
+#endif  // TROSSEN_SDK__HW__ARM__TELEOP_SOLO_ARM_PRODUCER_HPP

--- a/include/trossen_sdk/hw/arm/teleop_stationary_arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/teleop_stationary_arm_producer.hpp
@@ -1,0 +1,106 @@
+/**
+ * @file teleop_stationary_arm_producer.hpp
+ * @brief Producer for bimanual teleoperation (STATIONARY configuration)
+ */
+
+#ifndef TROSSEN_SDK__HW__ARM__TELEOP_STATIONARY_ARM_PRODUCER_HPP
+#define TROSSEN_SDK__HW__ARM__TELEOP_STATIONARY_ARM_PRODUCER_HPP
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "libtrossen_arm/trossen_arm.hpp"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::hw::arm {
+
+/**
+ * @brief Producer for bimanual teleoperation (STATIONARY configuration)
+ *
+ * Records joint states from two leader-follower pairs (left and right arms).
+ */
+class TeleopStationaryArmProducer : public ::trossen::hw::PolledProducer {
+public:
+  struct Config {
+    std::string stream_id{"teleop_stationary"};
+    bool use_device_time{true};
+  };
+
+  struct TeleopStationaryArmProducerMetadata : public PolledProducer::ProducerMetadata {
+    std::string robot_name;
+    std::vector<std::string> action_feature_names;
+    std::vector<std::string> observation_feature_names;
+    std::string action_dtype;
+    std::string observation_dtype;
+
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      nlohmann::ordered_json action;
+      action["dtype"] = action_dtype;
+      action["shape"] = {static_cast<int>(action_feature_names.size())};
+      action["names"] = action_feature_names;
+
+      nlohmann::ordered_json observation_state;
+      observation_state["dtype"] = observation_dtype;
+      observation_state["shape"] = {static_cast<int>(observation_feature_names.size())};
+      observation_state["names"] = observation_feature_names;
+      features["action"] = action;
+      features["observation.state"] = observation_state;
+      return features;
+    }
+  };
+
+  /**
+   * @brief Construct from two TeleopArmComponents (registry pattern)
+   *
+   * @param left_hardware TeleopArmComponent for left arm pair
+   * @param right_hardware TeleopArmComponent for right arm pair
+   * @param config JSON configuration
+   */
+  TeleopStationaryArmProducer(
+    std::shared_ptr<hw::HardwareComponent> left_hardware,
+    std::shared_ptr<hw::HardwareComponent> right_hardware,
+    const nlohmann::json& config);
+
+  /**
+   * @brief Construct directly from drivers
+   */
+  TeleopStationaryArmProducer(
+    std::shared_ptr<trossen_arm::TrossenArmDriver> left_leader_driver,
+    std::shared_ptr<trossen_arm::TrossenArmDriver> left_follower_driver,
+    std::shared_ptr<trossen_arm::TrossenArmDriver> right_leader_driver,
+    std::shared_ptr<trossen_arm::TrossenArmDriver> right_follower_driver,
+    Config cfg);
+
+  ~TeleopStationaryArmProducer() override = default;
+
+  void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<TeleopStationaryArmProducerMetadata>(metadata_);
+  }
+
+private:
+  std::shared_ptr<trossen_arm::TrossenArmDriver> left_leader_driver_;
+  std::shared_ptr<trossen_arm::TrossenArmDriver> left_follower_driver_;
+  std::shared_ptr<trossen_arm::TrossenArmDriver> right_leader_driver_;
+  std::shared_ptr<trossen_arm::TrossenArmDriver> right_follower_driver_;
+  Config cfg_;
+  std::vector<double> act_d_, obs_d_;
+  trossen_arm::RobotOutput left_leader_output_;
+  trossen_arm::RobotOutput left_follower_output_;
+  trossen_arm::RobotOutput right_leader_output_;
+  trossen_arm::RobotOutput right_follower_output_;
+  TeleopStationaryArmProducerMetadata metadata_;
+};
+
+}  // namespace trossen::hw::arm
+
+#endif  // TROSSEN_SDK__HW__ARM__TELEOP_STATIONARY_ARM_PRODUCER_HPP

--- a/src/hw/arm/teleop_solo_arm_producer.cpp
+++ b/src/hw/arm/teleop_solo_arm_producer.cpp
@@ -1,0 +1,138 @@
+/**
+ * @file teleop_solo_arm_producer.cpp
+ * @brief Implementation of TeleopSoloArmProducer for single leader-follower teleoperation
+ */
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+#include "trossen_sdk/hw/arm/teleop_solo_arm_producer.hpp"
+#include "trossen_sdk/hw/arm/teleop_arm_component.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+
+namespace trossen::hw::arm {
+
+// Registry-compatible constructor
+TeleopSoloArmProducer::TeleopSoloArmProducer(
+  std::shared_ptr<hw::HardwareComponent> hardware,
+  const nlohmann::json& config)
+{
+  if (!hardware) {
+    throw std::invalid_argument(
+      "TeleopSoloArmProducer: hardware component cannot be null");
+  }
+  auto teleop_component = std::dynamic_pointer_cast<TeleopArmComponent>(hardware);
+  if (!teleop_component) {
+    throw std::invalid_argument(
+      "TeleopSoloArmProducer: hardware must be TeleopArmComponent, got: " +
+      hardware->get_type());
+  }
+
+  auto drivers = teleop_component->get_hardware();
+  leader_driver_ = drivers.leader;
+  follower_driver_ = drivers.follower;
+
+  if (!leader_driver_) {
+    throw std::invalid_argument(
+      "TeleopSoloArmProducer: TeleopArmComponent has null leader driver");
+  }
+  if (!follower_driver_) {
+    throw std::invalid_argument(
+      "TeleopSoloArmProducer: TeleopArmComponent has null follower driver");
+  }
+
+  cfg_.stream_id = config.value("stream_id", "teleop_solo");
+  cfg_.use_device_time = config.value("use_device_time", false);
+
+  act_d_.resize(leader_driver_->get_num_joints());
+  obs_d_.resize(follower_driver_->get_num_joints());
+
+  leader_robot_output_ = leader_driver_->get_robot_output();
+  follower_robot_output_ = follower_driver_->get_robot_output();
+
+  metadata_.type = "teleop_solo";
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "Teleop SOLO Arm Producer";
+  metadata_.description = "Single leader-follower teleoperation for SOLO configuration";
+  metadata_.robot_name = "Trossen SOLO AI";
+  metadata_.action_feature_names =
+    {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
+  metadata_.observation_feature_names =
+    {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
+  metadata_.action_dtype = "float32";
+  metadata_.observation_dtype = "float32";
+}
+
+// Direct driver constructor
+TeleopSoloArmProducer::TeleopSoloArmProducer(
+  std::shared_ptr<trossen_arm::TrossenArmDriver> leader_driver,
+  std::shared_ptr<trossen_arm::TrossenArmDriver> follower_driver,
+  Config cfg)
+  : leader_driver_(std::move(leader_driver)),
+    follower_driver_(std::move(follower_driver)),
+    cfg_(std::move(cfg))
+{
+  if (leader_driver_ && follower_driver_) {
+    act_d_.resize(leader_driver_->get_num_joints());
+    obs_d_.resize(follower_driver_->get_num_joints());
+    leader_robot_output_ = leader_driver_->get_robot_output();
+    follower_robot_output_ = follower_driver_->get_robot_output();
+  }
+
+  metadata_.type = "teleop_solo";
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "Teleop SOLO Arm Producer";
+  metadata_.description = "Single leader-follower teleoperation for SOLO configuration";
+  metadata_.robot_name = "Trossen SOLO AI";
+  metadata_.action_feature_names =
+    {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
+  metadata_.observation_feature_names =
+    {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "gripper"};
+  metadata_.action_dtype = "float32";
+  metadata_.observation_dtype = "float32";
+}
+
+void TeleopSoloArmProducer::poll(
+  const std::function<void(std::shared_ptr<data::RecordBase>)>& emit)
+{
+  if (!leader_driver_ || !follower_driver_) {
+    return;
+  }
+
+  leader_robot_output_ = leader_driver_->get_robot_output();
+  follower_robot_output_ = follower_driver_->get_robot_output();
+  uint64_t device_ts = leader_robot_output_.header.timestamp;
+  act_d_ = leader_robot_output_.joint.all.positions;
+  obs_d_ = follower_robot_output_.joint.all.positions;
+
+  data::Timestamp ts;
+  ts.monotonic = (cfg_.use_device_time && device_ts != 0) ?
+    data::Timespec::from_ns(device_ts) : data::now_mono();
+  ts.realtime = data::now_real();
+
+  auto rec = std::make_shared<data::TeleopJointStateRecord>();
+  rec->ts = ts;
+  rec->seq = seq_++;
+  rec->id = cfg_.stream_id;
+
+  rec->actions.reserve(act_d_.size());
+  rec->actions.clear();
+  rec->observations.reserve(obs_d_.size());
+  rec->observations.clear();
+  for (double v : act_d_) {
+    rec->actions.push_back(static_cast<float>(v));
+  }
+  for (double v : obs_d_) {
+    rec->observations.push_back(static_cast<float>(v));
+  }
+
+  emit(rec);
+  ++stats_.produced;
+}
+
+REGISTER_PRODUCER(TeleopSoloArmProducer, "teleop_solo")
+
+}  // namespace trossen::hw::arm

--- a/src/hw/arm/teleop_stationary_arm_producer.cpp
+++ b/src/hw/arm/teleop_stationary_arm_producer.cpp
@@ -1,0 +1,241 @@
+/**
+ * @file teleop_stationary_arm_producer.cpp
+ * @brief Implementation of TeleopStationaryArmProducer for bimanual teleoperation
+ */
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+#include "trossen_sdk/hw/arm/teleop_stationary_arm_producer.hpp"
+#include "trossen_sdk/hw/arm/teleop_arm_component.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+
+namespace trossen::hw::arm {
+
+// Registry-compatible constructor with custom factory registration
+TeleopStationaryArmProducer::TeleopStationaryArmProducer(
+  std::shared_ptr<hw::HardwareComponent> left_hardware,
+  std::shared_ptr<hw::HardwareComponent> right_hardware,
+  const nlohmann::json& config)
+{
+  // Validate left hardware
+  if (!left_hardware) {
+    throw std::invalid_argument(
+      "TeleopStationaryArmProducer: left hardware component cannot be null");
+  }
+  auto left_teleop = std::dynamic_pointer_cast<TeleopArmComponent>(left_hardware);
+  if (!left_teleop) {
+    throw std::invalid_argument(
+      "TeleopStationaryArmProducer: left hardware must be TeleopArmComponent, got: " +
+      left_hardware->get_type());
+  }
+
+  // Validate right hardware
+  if (!right_hardware) {
+    throw std::invalid_argument(
+      "TeleopStationaryArmProducer: right hardware component cannot be null");
+  }
+  auto right_teleop = std::dynamic_pointer_cast<TeleopArmComponent>(right_hardware);
+  if (!right_teleop) {
+    throw std::invalid_argument(
+      "TeleopStationaryArmProducer: right hardware must be TeleopArmComponent, got: " +
+      right_hardware->get_type());
+  }
+
+  // Extract drivers
+  auto left_drivers = left_teleop->get_hardware();
+  auto right_drivers = right_teleop->get_hardware();
+
+  left_leader_driver_ = left_drivers.leader;
+  left_follower_driver_ = left_drivers.follower;
+  right_leader_driver_ = right_drivers.leader;
+  right_follower_driver_ = right_drivers.follower;
+
+  if (!left_leader_driver_ || !left_follower_driver_ ||
+      !right_leader_driver_ || !right_follower_driver_) {
+    throw std::invalid_argument(
+      "TeleopStationaryArmProducer: all drivers must be non-null");
+  }
+
+  cfg_.stream_id = config.value("stream_id", "teleop_stationary");
+  cfg_.use_device_time = config.value("use_device_time", false);
+
+  // Allocate buffers for both arms (concatenated)
+  size_t left_joints = left_leader_driver_->get_num_joints();
+  size_t right_joints = right_leader_driver_->get_num_joints();
+  act_d_.resize(left_joints + right_joints);
+  obs_d_.resize(left_joints + right_joints);
+
+  left_leader_output_ = left_leader_driver_->get_robot_output();
+  left_follower_output_ = left_follower_driver_->get_robot_output();
+  right_leader_output_ = right_leader_driver_->get_robot_output();
+  right_follower_output_ = right_follower_driver_->get_robot_output();
+
+  metadata_.type = "teleop_stationary";
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "Teleop STATIONARY Arm Producer";
+  metadata_.description =
+      "Bimanual teleoperation for STATIONARY configuration (2 leaders + 2 followers)";
+  metadata_.robot_name = "Trossen STATIONARY AI";
+  metadata_.action_feature_names = {
+    "left_joint1", "left_joint2", "left_joint3", "left_joint4",
+    "left_joint5", "left_joint6", "left_gripper",
+    "right_joint1", "right_joint2", "right_joint3", "right_joint4",
+    "right_joint5", "right_joint6", "right_gripper"
+  };
+  metadata_.observation_feature_names = {
+    "left_joint1", "left_joint2", "left_joint3", "left_joint4",
+    "left_joint5", "left_joint6", "left_gripper",
+    "right_joint1", "right_joint2", "right_joint3", "right_joint4",
+    "right_joint5", "right_joint6", "right_gripper"
+  };
+  metadata_.action_dtype = "float32";
+  metadata_.observation_dtype = "float32";
+}
+
+// Direct driver constructor
+TeleopStationaryArmProducer::TeleopStationaryArmProducer(
+  std::shared_ptr<trossen_arm::TrossenArmDriver> left_leader_driver,
+  std::shared_ptr<trossen_arm::TrossenArmDriver> left_follower_driver,
+  std::shared_ptr<trossen_arm::TrossenArmDriver> right_leader_driver,
+  std::shared_ptr<trossen_arm::TrossenArmDriver> right_follower_driver,
+  Config cfg)
+  : left_leader_driver_(std::move(left_leader_driver)),
+    left_follower_driver_(std::move(left_follower_driver)),
+    right_leader_driver_(std::move(right_leader_driver)),
+    right_follower_driver_(std::move(right_follower_driver)),
+    cfg_(std::move(cfg))
+{
+  if (left_leader_driver_ && left_follower_driver_ &&
+      right_leader_driver_ && right_follower_driver_) {
+    size_t left_joints = left_leader_driver_->get_num_joints();
+    size_t right_joints = right_leader_driver_->get_num_joints();
+    act_d_.resize(left_joints + right_joints);
+    obs_d_.resize(left_joints + right_joints);
+
+    left_leader_output_ = left_leader_driver_->get_robot_output();
+    left_follower_output_ = left_follower_driver_->get_robot_output();
+    right_leader_output_ = right_leader_driver_->get_robot_output();
+    right_follower_output_ = right_follower_driver_->get_robot_output();
+  }
+
+  metadata_.type = "teleop_stationary";
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "Teleop STATIONARY Arm Producer";
+  metadata_.description =
+      "Bimanual teleoperation for STATIONARY configuration (2 leaders + 2 followers)";
+  metadata_.robot_name = "Trossen STATIONARY AI";
+  metadata_.action_feature_names = {
+    "left_joint1", "left_joint2", "left_joint3", "left_joint4",
+    "left_joint5", "left_joint6", "left_gripper",
+    "right_joint1", "right_joint2", "right_joint3", "right_joint4",
+    "right_joint5", "right_joint6", "right_gripper"
+  };
+  metadata_.observation_feature_names = {
+    "left_joint1", "left_joint2", "left_joint3", "left_joint4",
+    "left_joint5", "left_joint6", "left_gripper",
+    "right_joint1", "right_joint2", "right_joint3", "right_joint4",
+    "right_joint5", "right_joint6", "right_gripper"
+  };
+  metadata_.action_dtype = "float32";
+  metadata_.observation_dtype = "float32";
+}
+
+void TeleopStationaryArmProducer::poll(
+  const std::function<void(std::shared_ptr<data::RecordBase>)>& emit)
+{
+  if (!left_leader_driver_ || !left_follower_driver_ ||
+      !right_leader_driver_ || !right_follower_driver_) {
+    return;
+  }
+
+  // Read all outputs
+  left_leader_output_ = left_leader_driver_->get_robot_output();
+  left_follower_output_ = left_follower_driver_->get_robot_output();
+  right_leader_output_ = right_leader_driver_->get_robot_output();
+  right_follower_output_ = right_follower_driver_->get_robot_output();
+
+  uint64_t device_ts = left_leader_output_.header.timestamp;
+
+  // Concatenate left and right positions
+  auto left_leader_pos = left_leader_output_.joint.all.positions;
+  auto right_leader_pos = right_leader_output_.joint.all.positions;
+  auto left_follower_pos = left_follower_output_.joint.all.positions;
+  auto right_follower_pos = right_follower_output_.joint.all.positions;
+
+  act_d_.clear();
+  act_d_.insert(act_d_.end(), left_leader_pos.begin(), left_leader_pos.end());
+  act_d_.insert(act_d_.end(), right_leader_pos.begin(), right_leader_pos.end());
+
+  obs_d_.clear();
+  obs_d_.insert(obs_d_.end(), left_follower_pos.begin(), left_follower_pos.end());
+  obs_d_.insert(obs_d_.end(), right_follower_pos.begin(), right_follower_pos.end());
+
+  data::Timestamp ts;
+  ts.monotonic = (cfg_.use_device_time && device_ts != 0) ?
+    data::Timespec::from_ns(device_ts) : data::now_mono();
+  ts.realtime = data::now_real();
+
+  auto rec = std::make_shared<data::TeleopJointStateRecord>();
+  rec->ts = ts;
+  rec->seq = seq_++;
+  rec->id = cfg_.stream_id;
+
+  rec->actions.reserve(act_d_.size());
+  rec->actions.clear();
+  rec->observations.reserve(obs_d_.size());
+  rec->observations.clear();
+  for (double v : act_d_) {
+    rec->actions.push_back(static_cast<float>(v));
+  }
+  for (double v : obs_d_) {
+    rec->observations.push_back(static_cast<float>(v));
+  }
+
+  emit(rec);
+  ++stats_.produced;
+}
+
+// Custom factory registration for TeleopStationaryArmProducer
+namespace {
+struct TeleopStationaryArmProducerRegistrar {
+  TeleopStationaryArmProducerRegistrar() {
+    trossen::runtime::ProducerRegistry::register_producer(
+      "teleop_stationary",
+      [](std::shared_ptr<trossen::hw::HardwareComponent> hw,
+         const nlohmann::json& cfg) -> std::shared_ptr<trossen::hw::PolledProducer> {
+        // This producer requires two hardware components (left and right pairs)
+        if (!cfg.contains("left_id") || !cfg.contains("right_id")) {
+          throw std::invalid_argument(
+            "TeleopStationaryArmProducer requires 'left_id' and 'right_id' in config");
+        }
+
+        std::string left_id = cfg["left_id"];
+        std::string right_id = cfg["right_id"];
+
+        auto left_hw = trossen::hw::ActiveHardwareRegistry::get(left_id);
+        auto right_hw = trossen::hw::ActiveHardwareRegistry::get(right_id);
+
+        if (!left_hw) {
+          throw std::invalid_argument(
+            "TeleopStationaryArmProducer: left hardware '" + left_id +
+            "' not found in registry");
+        }
+        if (!right_hw) {
+          throw std::invalid_argument(
+            "TeleopStationaryArmProducer: right hardware '" + right_id +
+            "' not found in registry");
+        }
+
+        return std::make_shared<TeleopStationaryArmProducer>(left_hw, right_hw, cfg);
+      });
+  }
+};
+static TeleopStationaryArmProducerRegistrar teleop_stationary_arm_producer_registrar;
+}  // anonymous namespace
+
+}  // namespace trossen::hw::arm


### PR DESCRIPTION
# Add specialized teleop arm producers for Solo and Stationary configurations

### TL;DR

Added two new specialized teleop arm producers for different robot configurations: `TeleopSoloArmProducer` for single leader-follower pairs and `TeleopStationaryArmProducer` for bimanual (2 leaders + 2 followers) setups.

### What changed?

- Added `TeleopSoloArmProducer` for single leader-follower teleoperation
- Added `TeleopStationaryArmProducer` for bimanual teleoperation with two leader-follower pairs
- Updated the teleop arm component demo to showcase both new producers
- Added custom factory registration for the stationary producer to handle its unique initialization requirements
- Both producers implement proper metadata and feature naming for their respective configurations

### How to test?

Run the updated demo application which now demonstrates both producers:

```bash
./teleop_arm_component_demo
```

The demo will:
1. Create a left arm teleop component and demonstrate the Solo producer
2. Create a right arm teleop component and demonstrate the Stationary producer with both arms
3. Poll each producer to show the data collection working

### Why make this change?

These specialized producers support different robot configurations needed for various teleoperation scenarios:

- Solo configuration: Simpler setup with a single leader-follower pair
- Stationary configuration: More complex bimanual setup with two leader-follower pairs

This modular approach allows for cleaner code organization and better support for different hardware configurations while maintaining consistent data collection interfaces.