### PR TITLE
Support multiple joint state streams in MCAP backend

### DIFF
--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -137,9 +137,11 @@ private:
     const std::unordered_map<std::string, std::string>& metadata);
 
   /**
-   * @brief Ensure the joint state channel exists
+   * @brief Ensure the joint state channel exists for a given stream ID
+   *
+   * @param stream_id Stream identifier (e.g., "leader_left", "follower_right")
    */
-  void ensure_jointstate_channel();
+  void ensure_jointstate_channel(const std::string& stream_id);
 
   /**
    * @brief Write an image record
@@ -187,8 +189,8 @@ private:
   /// @brief Helper to identify depth encodings
   static bool is_depth_encoding(const std::string& enc);
 
-  /// @brief Joint state channel
-  std::optional<foxglove::RawChannel> joint_channel_;
+  /// @brief Map of joint state channels by stream ID
+  std::unordered_map<std::string, foxglove::RawChannel> joint_channels_;
 
   /// @brief Statistics about written records
   Stats stats_{};

--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -123,16 +123,18 @@ private:
    * @brief Ensure an image channel exists for the given camera name
    *
    * @param camera_name Name of the camera (used as stream ID)
+   * @return Pointer to the channel, or nullptr on failure
    */
-  void ensure_image_channel(const std::string& camera_name);
+  foxglove::RawChannel* ensure_image_channel(const std::string& camera_name);
 
   /**
    * @brief Ensure an image channel exists for the given camera name, with additional metadata
    *
    * @param camera_name Name of the camera (used as stream ID)
    * @param metadata Key/value pairs to add to the MCAP Channel metadata map
+   * @return Pointer to the channel, or nullptr on failure
    */
-  void ensure_image_channel_with_metadata(
+  foxglove::RawChannel* ensure_image_channel_with_metadata(
     const std::string& camera_name,
     const std::unordered_map<std::string, std::string>& metadata);
 
@@ -140,8 +142,9 @@ private:
    * @brief Ensure the joint state channel exists for a given stream ID
    *
    * @param stream_id Stream identifier (e.g., "leader_left", "follower_right")
+   * @return Pointer to the channel, or nullptr on failure
    */
-  void ensure_jointstate_channel(const std::string& stream_id);
+  foxglove::RawChannel* ensure_jointstate_channel(const std::string& stream_id);
 
   /**
    * @brief Write an image record

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -148,6 +148,8 @@ void McapBackend::close() {
       std::cerr << "Failed to close MCAP writer: " << foxglove::strerror(st) << "\n";
     }
   }
+  joint_channels_.clear();
+  image_channels_.clear();
   opened_ = false;
 }
 
@@ -190,11 +192,10 @@ void McapBackend::write_batch(std::span<const data::RecordBase* const> records) 
   }
 }
 
-void McapBackend::ensure_jointstate_channel(const std::string& stream_id) {
-  // Check if the channel already exists for this stream
+foxglove::RawChannel* McapBackend::ensure_jointstate_channel(const std::string& stream_id) {
   auto it = joint_channels_.find(stream_id);
   if (it != joint_channels_.end()) {
-    return;
+    return &it->second;
   }
 
   // Create schema
@@ -215,23 +216,23 @@ void McapBackend::ensure_jointstate_channel(const std::string& stream_id) {
   if (!channel_result.has_value()) {
     std::cerr << "Failed to create joint state channel for " << stream_id << ": "
               << foxglove::strerror(channel_result.error()) << "\n";
-    return;
+    return nullptr;
   }
 
-  joint_channels_.emplace(stream_id, std::move(channel_result.value()));
+  auto [inserted_it, _] = joint_channels_.emplace(stream_id, std::move(channel_result.value()));
+  return &inserted_it->second;
 }
 
-void McapBackend::ensure_image_channel(const std::string& camera_name) {
-  // Color path: delegate to generalized ensure with minimal metadata
-  ensure_image_channel_with_metadata(camera_name, { {"stream_type", "color"} });
+foxglove::RawChannel* McapBackend::ensure_image_channel(const std::string& camera_name) {
+  return ensure_image_channel_with_metadata(camera_name, { {"stream_type", "color"} });
 }
 
-void McapBackend::ensure_image_channel_with_metadata(
+foxglove::RawChannel* McapBackend::ensure_image_channel_with_metadata(
   const std::string& camera_name,
   const std::unordered_map<std::string, std::string>& metadata) {
   auto it = image_channels_.find(camera_name);
   if (it != image_channels_.end()) {
-    return;  // already exists
+    return &it->second;
   }
 
   // Use Foxglove SDK's built-in RawImage schema
@@ -251,20 +252,16 @@ void McapBackend::ensure_image_channel_with_metadata(
   if (!channel_result.has_value()) {
     std::cerr << "Failed to create image channel: "
               << foxglove::strerror(channel_result.error()) << "\n";
-    return;
+    return nullptr;
   }
 
-  image_channels_.emplace(camera_name, std::move(channel_result.value()));
+  auto [inserted_it, _] = image_channels_.emplace(camera_name, std::move(channel_result.value()));
+  return &inserted_it->second;
 }
 
 void McapBackend::write_jointstate_record(const data::JointStateRecord& js) {
-  // Ensure channel exists for this stream
-  ensure_jointstate_channel(js.id);
-
-  // Look up the channel for this stream
-  auto it = joint_channels_.find(js.id);
-  if (it == joint_channels_.end()) {
-    std::cerr << "Failed to find joint state channel for stream: " << js.id << "\n";
+  auto* channel = ensure_jointstate_channel(js.id);
+  if (!channel) {
     return;
   }
 
@@ -291,7 +288,7 @@ void McapBackend::write_jointstate_record(const data::JointStateRecord& js) {
   std::string payload;
   out.SerializeToString(&payload);
 
-  auto st = it->second.log(
+  auto st = channel->log(
     reinterpret_cast<const std::byte*>(payload.data()),
     payload.size(),
     js.ts.realtime.to_ns());
@@ -308,6 +305,7 @@ void McapBackend::write_image_record(const data::ImageRecord& img) {
   // Determine if this is a depth frame based on encoding or topic
   const bool depth =
     is_depth_encoding(img.encoding) || is_depth_topic(mcapdefs::image_topic(img.id));
+  foxglove::RawChannel* channel = nullptr;
   if (depth) {
     // Depth metadata; attempt to parse scale if provided in encoding (future) - for now leave
     // blank
@@ -324,9 +322,12 @@ void McapBackend::write_image_record(const data::ImageRecord& img) {
     } else if (img.encoding == "32FC1") {
       md["depth_encoding_semantics"] = "float_m";
     }
-    ensure_image_channel_with_metadata(img.id, md);
+    channel = ensure_image_channel_with_metadata(img.id, md);
   } else {
-    ensure_image_channel(img.id);
+    channel = ensure_image_channel(img.id);
+  }
+  if (!channel) {
+    return;
   }
   foxglove::schemas::RawImage imsg;
   imsg.timestamp = foxglove::schemas::Timestamp{
@@ -359,7 +360,7 @@ void McapBackend::write_image_record(const data::ImageRecord& img) {
     return;
   }
 
-  auto st = image_channels_.at(img.id).log(
+  auto st = channel->log(
     reinterpret_cast<const std::byte*>(payload.data()),
     encoded_len,
     img.ts.realtime.to_ns());

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -136,8 +136,8 @@ void McapBackend::close() {
     return;
   }
   // Close channels
-  if (joint_channel_) {
-    joint_channel_->close();
+  for (auto& [stream_id, channel] : joint_channels_) {
+    channel.close();
   }
   for (auto& [name, channel] : image_channels_) {
     channel.close();
@@ -190,9 +190,10 @@ void McapBackend::write_batch(std::span<const data::RecordBase* const> records) 
   }
 }
 
-void McapBackend::ensure_jointstate_channel() {
-  // Check if the channel already exists
-  if (joint_channel_.has_value()) {
+void McapBackend::ensure_jointstate_channel(const std::string& stream_id) {
+  // Check if the channel already exists for this stream
+  auto it = joint_channels_.find(stream_id);
+  if (it != joint_channels_.end()) {
     return;
   }
 
@@ -203,21 +204,21 @@ void McapBackend::ensure_jointstate_channel() {
   schema.data = reinterpret_cast<const std::byte*>(schema_data_.data());
   schema.data_len = schema_data_.size();
 
-  // Create channel
+  // Create channel with stream-specific topic
   auto channel_result = foxglove::RawChannel::create(
-    mcapdefs::joint_state_topic(cfg_->robot_name),
+    mcapdefs::joint_state_topic(stream_id),
     "protobuf",
     schema,
     context_,
     std::nullopt);
 
   if (!channel_result.has_value()) {
-    std::cerr << "Failed to create joint state channel: "
+    std::cerr << "Failed to create joint state channel for " << stream_id << ": "
               << foxglove::strerror(channel_result.error()) << "\n";
     return;
   }
 
-  joint_channel_ = std::move(channel_result.value());
+  joint_channels_.emplace(stream_id, std::move(channel_result.value()));
 }
 
 void McapBackend::ensure_image_channel(const std::string& camera_name) {
@@ -257,7 +258,16 @@ void McapBackend::ensure_image_channel_with_metadata(
 }
 
 void McapBackend::write_jointstate_record(const data::JointStateRecord& js) {
-  ensure_jointstate_channel();
+  // Ensure channel exists for this stream
+  ensure_jointstate_channel(js.id);
+
+  // Look up the channel for this stream
+  auto it = joint_channels_.find(js.id);
+  if (it == joint_channels_.end()) {
+    std::cerr << "Failed to find joint state channel for stream: " << js.id << "\n";
+    return;
+  }
+
   trossen_sdk::msg::JointState out;
   auto* ts = out.mutable_ts();
 
@@ -281,13 +291,14 @@ void McapBackend::write_jointstate_record(const data::JointStateRecord& js) {
   std::string payload;
   out.SerializeToString(&payload);
 
-  auto st = joint_channel_->log(
+  auto st = it->second.log(
     reinterpret_cast<const std::byte*>(payload.data()),
     payload.size(),
     js.ts.realtime.to_ns());
 
   if (st != foxglove::FoxgloveError::Ok) {
-    std::cerr << "Failed to write joint state: " << foxglove::strerror(st) << "\n";
+    std::cerr << "Failed to write joint state for " << js.id << ": "
+              << foxglove::strerror(st) << "\n";
   } else {
     ++stats_.joint_states_written;
   }


### PR DESCRIPTION
### TL;DR

Modified joint state channel handling to support multiple streams by using stream IDs instead of a single shared channel.

### What changed?

- Changed `ensure_jointstate_channel()` to accept a `stream_id` parameter for creating stream-specific channels
- Replaced single `joint_channel_` optional with `joint_channels_` map that stores channels by stream ID
- Updated `write_jointstate_record()` to look up the appropriate channel based on the record's stream ID
- Modified channel closing logic to iterate through all joint state channels in the map
- Enhanced error messages to include stream ID context

### How to test?

1. Create joint state records with different stream IDs (e.g., "leader_left", "follower_right")
2. Verify that separate MCAP channels are created for each unique stream ID
3. Confirm that joint state data is written to the correct channel based on the record's stream ID
4. Test that all channels are properly closed when the backend shuts down

### Why make this change?

This change enables support for multiple robot streams or arm configurations by creating dedicated joint state channels for each stream identifier, rather than using a single shared channel that could cause data conflicts or organization issues.