### PR TITLE
Add SlateBaseProducer for SLATE mobile base velocity state emission

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(trossen_sdk SHARED
   src/hw/arm/feetech_bus.cpp
   src/hw/arm/so101_teleop_arm_producer.cpp
   src/hw/base/slate_base_component.cpp
+  src/hw/base/slate_base_producer.cpp
   src/hw/camera/opencv_camera_component.cpp
   src/hw/camera/opencv_producer.cpp
   src/hw/camera/mock_producer.cpp

--- a/include/trossen_sdk/hw/base/slate_base_producer.hpp
+++ b/include/trossen_sdk/hw/base/slate_base_producer.hpp
@@ -1,0 +1,113 @@
+/**
+ * @file slate_base_producer.hpp
+ * @brief Producer that emits velocity states from a SLATE mobile base
+ */
+
+#ifndef TROSSEN_SDK__HW__BASE__SLATE_BASE_PRODUCER_HPP_
+#define TROSSEN_SDK__HW__BASE__SLATE_BASE_PRODUCER_HPP_
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "trossen_slate/base_driver.hpp"
+#include "trossen_slate/trossen_slate.hpp"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::hw::base {
+
+/**
+ * @brief Producer that emits velocity states from SLATE mobile base
+ *
+ * Stores linear velocity (x, y) and angular velocity (z) in the JointStateRecord
+ * velocity vector as [vel_x, vel_y, vel_z].
+ */
+class SlateBaseProducer : public ::trossen::hw::PolledProducer {
+public:
+  /**
+   * @brief Configuration parameters for SlateBaseProducer
+   */
+  struct Config {
+    /// @brief Logical stream identifier (e.g. "base_velocity")
+    std::string stream_id{"base"};
+
+    /// @brief Prefer device timestamp if available
+    bool use_device_time{false};
+  };
+
+  /**
+   * @brief Metadata specific to SlateBaseProducer
+   */
+  struct SlateBaseProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// @brief Base model type
+    std::string base_model;
+
+    /**
+     * @brief Get producer info as JSON
+     *
+     * @return JSON object containing producer information
+     */
+    nlohmann::ordered_json get_info() const override {
+      std::cout << "SlateBaseProducerMetadata: " << name << " (" << id << ") - " << description
+                << ", Model: " << base_model << "\n";
+      return nlohmann::ordered_json{};
+    }
+  };
+
+  /**
+   * @brief Construct a SlateBaseProducer from hardware component
+   *
+   * @param hardware Hardware component (must be SlateBaseComponent)
+   * @param config JSON configuration with fields: stream_id, use_device_time
+   * @throws std::invalid_argument if hardware is null or wrong type
+   */
+  SlateBaseProducer(
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config);
+
+  /**
+   * @brief Destructor
+   */
+  ~SlateBaseProducer() override = default;
+
+  /**
+   * @brief Poll the driver for the latest velocity states and emit a JointStateRecord
+   *
+   * Stores velocity data in the velocity vector as [vel_x, vel_y, vel_z].
+   * Position and effort vectors remain empty.
+   *
+   * @param emit Callback to invoke for each produced record
+   */
+  void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  /**
+   * @brief Get producer metadata
+   *
+   * @return const reference to ProducerMetadata
+   */
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<SlateBaseProducerMetadata>(metadata_);
+  }
+
+private:
+  /// @brief Shared pointer to the TrossenSlate driver instance
+  std::shared_ptr<trossen_slate::TrossenSlate> driver_;
+
+  /// @brief Configuration
+  Config cfg_;
+
+  /// @brief Metadata
+  SlateBaseProducerMetadata metadata_;
+
+  /// @brief Cached chassis data
+  base_driver::ChassisData chassis_data_;
+};
+
+}  // namespace trossen::hw::base
+
+#endif  // TROSSEN_SDK__HW__BASE__SLATE_BASE_PRODUCER_HPP_

--- a/src/hw/base/slate_base_producer.cpp
+++ b/src/hw/base/slate_base_producer.cpp
@@ -1,0 +1,92 @@
+/**
+ * @file slate_base_producer.cpp
+ * @brief Implementation of SlateBaseProducer that emits velocity states from SLATE mobile base
+ */
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+#include "trossen_sdk/hw/base/slate_base_component.hpp"
+#include "trossen_sdk/hw/base/slate_base_producer.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+
+namespace trossen::hw::base {
+
+SlateBaseProducer::SlateBaseProducer(
+  std::shared_ptr<hw::HardwareComponent> hardware,
+  const nlohmann::json& config) {
+  // Validate hardware component
+  if (!hardware) {
+    throw std::invalid_argument("SlateBaseProducer: hardware component cannot be null");
+  }
+
+  // Dynamic cast to SlateBaseComponent
+  auto base_component = std::dynamic_pointer_cast<SlateBaseComponent>(hardware);
+  if (!base_component) {
+    throw std::invalid_argument(
+      "SlateBaseProducer: hardware must be SlateBaseComponent, got: " + hardware->get_type());
+  }
+
+  // Extract driver
+  driver_ = base_component->get_driver();
+  if (!driver_) {
+    throw std::invalid_argument("SlateBaseProducer: SlateBaseComponent has null driver");
+  }
+
+  // Parse JSON config into Config struct
+  cfg_.stream_id = config.value("stream_id", "base");
+  cfg_.use_device_time = config.value("use_device_time", false);
+
+  // Initialize chassis data
+  chassis_data_ = {};
+
+  // Populate metadata
+  metadata_.type = "base";
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "SLATE Base Producer";
+  metadata_.description = "Produces velocity states from SLATE mobile base";
+  metadata_.base_model = "SLATE";
+}
+
+void SlateBaseProducer::poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {
+  if (!driver_) {
+    return;
+  }
+
+  // Read chassis data from driver
+  driver_->read(chassis_data_);
+
+  // Create timestamp
+  data::Timestamp ts;
+  ts.monotonic = data::now_mono();
+  ts.realtime = data::now_real();
+
+  // Create and populate JointStateRecord with velocity data
+  auto rec = std::make_shared<data::JointStateRecord>();
+  rec->ts = ts;
+  rec->seq = seq_++;
+  rec->id = cfg_.stream_id;
+
+  // Store velocities: [linear_x, linear_y, angular_z]
+  rec->velocities.clear();
+  rec->velocities.reserve(3);
+  rec->velocities.push_back(chassis_data_.vel_x);
+  rec->velocities.push_back(chassis_data_.vel_y);
+  rec->velocities.push_back(chassis_data_.vel_z);
+
+  // Leave positions and efforts empty
+  rec->positions.clear();
+  rec->efforts.clear();
+
+  // Emit the record
+  emit(rec);
+
+  // Update statistics
+  stats_.produced++;
+}
+
+// Register producer with registry
+REGISTER_PRODUCER(SlateBaseProducer, "slate_base");
+
+}  // namespace trossen::hw::base

--- a/src/hw/base/slate_base_producer.cpp
+++ b/src/hw/base/slate_base_producer.cpp
@@ -53,7 +53,7 @@ void SlateBaseProducer::poll(const std::function<void(std::shared_ptr<data::Reco
   if (!driver_) {
     return;
   }
-
+  driver_->update_state();
   // Read chassis data from driver
   driver_->read(chassis_data_);
 


### PR DESCRIPTION
### TL;DR

Added `SlateBaseProducer` class to emit velocity states from SLATE mobile base hardware.

### What changed?

- Created `SlateBaseProducer` class that extends `PolledProducer` to read velocity data from SLATE mobile base
- The producer emits `JointStateRecord` objects containing linear velocity (x, y) and angular velocity (z) in the velocities vector
- Added configuration options for stream ID and device timestamp preference
- Implemented metadata structure with base model information
- Registered the producer as "slate_base" in the producer registry
- Added the new source file to CMakeLists.txt build configuration

### How to test?

1. Configure a SLATE base component in your hardware setup
2. Create a `SlateBaseProducer` with the base component and appropriate JSON config containing `stream_id` and `use_device_time` fields
3. Call the `poll()` method and verify it emits `JointStateRecord` objects with velocity data in the format `[vel_x, vel_y, vel_z]`
4. Verify the producer is registered and can be instantiated using the "slate_base" identifier

### Why make this change?

This enables data collection and monitoring of velocity states from SLATE mobile base hardware by providing a standardized producer interface that integrates with the existing hardware component system.