### PR TITLE
Add hardware configuration types for arm, camera, and mobile base components

### DIFF
--- a/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
@@ -1,0 +1,54 @@
+/**
+ * @file arm_config.hpp
+ * @brief Configuration for a robot arm hardware component
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__ARM_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__ARM_CONFIG_HPP_
+
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Configuration for a single robot arm (TrossenArmComponent)
+ *
+ * JSON format:
+ * {
+ *   "ip_address": "192.168.1.3",
+ *   "model": "wxai_v0",
+ *   "end_effector": "wxai_v0_leader"
+ * }
+ */
+struct ArmConfig {
+  /// @brief Network IP address of the arm controller
+  std::string ip_address{"192.168.1.2"};
+
+  /// @brief Robot model identifier (e.g. "wxai_v0")
+  std::string model{"wxai_v0"};
+
+  /// @brief End effector type (e.g. "wxai_v0_follower", "wxai_v0_leader")
+  std::string end_effector{"wxai_v0_follower"};
+
+  static ArmConfig from_json(const nlohmann::json& j) {
+    ArmConfig c;
+    if (j.contains("ip_address")) j.at("ip_address").get_to(c.ip_address);
+    if (j.contains("model")) j.at("model").get_to(c.model);
+    if (j.contains("end_effector")) j.at("end_effector").get_to(c.end_effector);
+    return c;
+  }
+
+  nlohmann::json to_json() const {
+    return nlohmann::json{
+      {"ip_address", ip_address},
+      {"model", model},
+      {"end_effector", end_effector}
+    };
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__ARM_CONFIG_HPP_

--- a/include/trossen_sdk/configuration/types/hardware/camera_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/camera_config.hpp
@@ -1,0 +1,116 @@
+/**
+ * @file camera_config.hpp
+ * @brief Configuration for a camera hardware component
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__CAMERA_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__CAMERA_CONFIG_HPP_
+
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Configuration for a single camera (RealsenseCameraComponent or OpenCvCameraComponent)
+ *
+ * The @p type field selects which hardware component is created via HardwareRegistry.
+ * Use @c "realsense_camera" for Intel RealSense cameras and @c "opencv_camera" for
+ * any V4L2 / USB webcam accessible through OpenCV.
+ *
+ * JSON format (RealSense):
+ * @code
+ * {
+ *   "id": "camera_0",
+ *   "type": "realsense_camera",
+ *   "serial_number": "128422271347",
+ *   "width": 640,
+ *   "height": 480,
+ *   "fps": 30,
+ *   "use_depth": false,
+ *   "force_hardware_reset": false
+ * }
+ * @endcode
+ *
+ * JSON format (OpenCV):
+ * @code
+ * {
+ *   "id": "camera_0",
+ *   "type": "opencv_camera",
+ *   "device_index": 0,
+ *   "width": 640,
+ *   "height": 480,
+ *   "fps": 30,
+ *   "backend": "v4l2"
+ * }
+ * @endcode
+ */
+struct CameraConfig {
+  /// @brief Hardware registry key — "realsense_camera" or "opencv_camera"
+  std::string type{"realsense_camera"};
+
+  /// @brief Logical camera identifier used as stream_id (e.g. "camera_0", "wrist_cam")
+  std::string id{"camera_0"};
+
+  /// @brief Camera serial number (RealSense only)
+  std::string serial_number{""};
+
+  /// @brief OpenCV device index (OpenCV only)
+  int device_index{0};
+
+  /// @brief OpenCV capture backend — "v4l2" or "any" (OpenCV only)
+  std::string backend{""};
+
+  /// @brief Capture width in pixels
+  int width{640};
+
+  /// @brief Capture height in pixels
+  int height{480};
+
+  /// @brief Capture frame rate
+  int fps{30};
+
+  /// @brief Enable depth stream alongside color (RealSense only)
+  bool use_depth{false};
+
+  /// @brief Force hardware reset on open (RealSense only)
+  bool force_hardware_reset{false};
+
+  static CameraConfig from_json(const nlohmann::json& j) {
+    CameraConfig c;
+    if (j.contains("type")) j.at("type").get_to(c.type);
+    if (j.contains("id")) j.at("id").get_to(c.id);
+    if (j.contains("serial_number")) j.at("serial_number").get_to(c.serial_number);
+    if (j.contains("device_index")) j.at("device_index").get_to(c.device_index);
+    if (j.contains("backend")) j.at("backend").get_to(c.backend);
+    if (j.contains("width")) j.at("width").get_to(c.width);
+    if (j.contains("height")) j.at("height").get_to(c.height);
+    if (j.contains("fps")) j.at("fps").get_to(c.fps);
+    if (j.contains("use_depth")) j.at("use_depth").get_to(c.use_depth);
+    if (j.contains("force_hardware_reset"))
+      j.at("force_hardware_reset").get_to(c.force_hardware_reset);
+    return c;
+  }
+
+  /// @brief Produce JSON suitable for HardwareComponent::configure()
+  nlohmann::json to_json() const {
+    nlohmann::json j{
+      {"serial_number", serial_number},
+      {"device_index", device_index},
+      {"width", width},
+      {"height", height},
+      {"fps", fps},
+      {"use_depth", use_depth},
+      {"force_hardware_reset", force_hardware_reset}
+    };
+    if (!backend.empty()) {
+      j["backend"] = backend;
+    }
+    return j;
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__CAMERA_CONFIG_HPP_

--- a/include/trossen_sdk/configuration/types/hardware/mobile_base_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/mobile_base_config.hpp
@@ -1,0 +1,46 @@
+/**
+ * @file mobile_base_config.hpp
+ * @brief Configuration for a mobile base hardware component
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__MOBILE_BASE_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__MOBILE_BASE_CONFIG_HPP_
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Configuration for the SLATE mobile base (SlateBaseComponent)
+ *
+ * JSON format:
+ * {
+ *   "reset_odometry": false,
+ *   "enable_torque": false
+ * }
+ */
+struct MobileBaseConfig {
+  /// @brief Reset base odometry on startup
+  bool reset_odometry{false};
+
+  /// @brief Enable torque on startup
+  bool enable_torque{false};
+
+  static MobileBaseConfig from_json(const nlohmann::json& j) {
+    MobileBaseConfig c;
+    if (j.contains("reset_odometry")) j.at("reset_odometry").get_to(c.reset_odometry);
+    if (j.contains("enable_torque")) j.at("enable_torque").get_to(c.enable_torque);
+    return c;
+  }
+
+  nlohmann::json to_json() const {
+    return nlohmann::json{
+      {"reset_odometry", reset_odometry},
+      {"enable_torque", enable_torque}
+    };
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__MOBILE_BASE_CONFIG_HPP_


### PR DESCRIPTION
### TL;DR

Added configuration structures for robot hardware components including arms, cameras, and mobile bases with JSON serialization support.

### What changed?

Created three new header files defining configuration structures:

- **ArmConfig** (`arm_config.hpp`): Configures robot arm components with IP address, model identifier, and end effector type. Defaults to IP "192.168.1.2", model "wxai_v0", and end effector "wxai_v0_follower".

- **CameraConfig** (`camera_config.hpp`): Supports both RealSense and OpenCV cameras with type selection via hardware registry. Includes camera-specific settings like serial number for RealSense, device index for OpenCV, resolution (640x480), frame rate (30fps), and optional depth streaming.

- **MobileBaseConfig** (`mobile_base_config.hpp`): Configures SLATE mobile base with options to reset odometry and enable torque on startup (both disabled by default).

All structures include `from_json()` and `to_json()` methods for nlohmann::json serialization and provide comprehensive documentation with JSON format examples.

### How to test?

1. Include the new headers in your project
2. Create JSON configuration objects matching the documented formats
3. Use `from_json()` to deserialize configuration from JSON
4. Use `to_json()` to serialize configuration back to JSON
5. Verify default values are applied when JSON fields are missing

### Why make this change?

These configuration structures provide a standardized way to configure different hardware components in the Trossen SDK, enabling flexible hardware setup through JSON configuration files while maintaining type safety and clear documentation of available options.