### PR TITLE
Add producer configuration types for arms, cameras, mobile base, and teleoperation

### DIFF
--- a/include/trossen_sdk/configuration/types/producers/arm_producer_config.hpp
+++ b/include/trossen_sdk/configuration/types/producers/arm_producer_config.hpp
@@ -1,0 +1,47 @@
+/**
+ * @file arm_producer_config.hpp
+ * @brief Configuration for an arm joint-state producer
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__ARM_PRODUCER_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__ARM_PRODUCER_CONFIG_HPP_
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Shared settings applied to all arm producers
+ *
+ * JSON format (under "producers.arms"):
+ * {
+ *   "poll_rate_hz": 30.0,
+ *   "use_device_time": false
+ * }
+ */
+struct ArmProducerConfig {
+  /// @brief Polling frequency in Hz
+  float poll_rate_hz{30.0f};
+
+  /// @brief Use hardware device timestamp when available
+  bool use_device_time{false};
+
+  static ArmProducerConfig from_json(const nlohmann::json& j) {
+    ArmProducerConfig c;
+    if (j.contains("poll_rate_hz")) j.at("poll_rate_hz").get_to(c.poll_rate_hz);
+    if (j.contains("use_device_time")) j.at("use_device_time").get_to(c.use_device_time);
+    return c;
+  }
+
+  /// @brief Build the JSON config for ProducerRegistry::create(), given the stream id
+  nlohmann::json to_json(const std::string& stream_id) const {
+    return nlohmann::json{
+      {"stream_id", stream_id},
+      {"use_device_time", use_device_time}
+    };
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__ARM_PRODUCER_CONFIG_HPP_

--- a/include/trossen_sdk/configuration/types/producers/camera_producer_config.hpp
+++ b/include/trossen_sdk/configuration/types/producers/camera_producer_config.hpp
@@ -1,0 +1,63 @@
+/**
+ * @file camera_producer_config.hpp
+ * @brief Configuration for a camera image producer
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__CAMERA_PRODUCER_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__CAMERA_PRODUCER_CONFIG_HPP_
+
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Shared settings applied to all camera producers
+ *
+ * JSON format (under "producers.cameras"):
+ * {
+ *   "poll_rate_hz": 30.0,
+ *   "encoding": "bgr8",
+ *   "use_device_time": true
+ * }
+ */
+struct CameraProducerConfig {
+  /// @brief Polling frequency in Hz
+  float poll_rate_hz{30.0f};
+
+  /// @brief Pixel encoding passed to the producer (e.g. "bgr8", "rgb8", "mono8")
+  std::string encoding{"bgr8"};
+
+  /// @brief Use hardware device timestamp when available
+  bool use_device_time{true};
+
+  static CameraProducerConfig from_json(const nlohmann::json& j) {
+    CameraProducerConfig c;
+    if (j.contains("poll_rate_hz")) j.at("poll_rate_hz").get_to(c.poll_rate_hz);
+    if (j.contains("encoding")) j.at("encoding").get_to(c.encoding);
+    if (j.contains("use_device_time")) j.at("use_device_time").get_to(c.use_device_time);
+    return c;
+  }
+
+  /// @brief Build the JSON config for ProducerRegistry::create(), given camera info
+  nlohmann::json to_json(
+    const std::string& stream_id,
+    int width,
+    int height,
+    int fps) const
+  {
+    return nlohmann::json{
+      {"stream_id", stream_id},
+      {"encoding", encoding},
+      {"use_device_time", use_device_time},
+      {"width", width},
+      {"height", height},
+      {"fps", fps}
+    };
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__CAMERA_PRODUCER_CONFIG_HPP_

--- a/include/trossen_sdk/configuration/types/producers/mobile_base_producer_config.hpp
+++ b/include/trossen_sdk/configuration/types/producers/mobile_base_producer_config.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file mobile_base_producer_config.hpp
+ * @brief Configuration for a mobile base velocity producer
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__MOBILE_BASE_PRODUCER_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__MOBILE_BASE_PRODUCER_CONFIG_HPP_
+
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Settings for the mobile base producer
+ *
+ * JSON format (under "producers.mobile_base"):
+ * {
+ *   "poll_rate_hz": 30.0,
+ *   "use_device_time": false
+ * }
+ */
+struct MobileBaseProducerConfig {
+  /// @brief Polling frequency in Hz
+  float poll_rate_hz{30.0f};
+
+  /// @brief Use hardware device timestamp when available
+  bool use_device_time{false};
+
+  static MobileBaseProducerConfig from_json(const nlohmann::json& j) {
+    MobileBaseProducerConfig c;
+    if (j.contains("poll_rate_hz")) j.at("poll_rate_hz").get_to(c.poll_rate_hz);
+    if (j.contains("use_device_time")) j.at("use_device_time").get_to(c.use_device_time);
+    return c;
+  }
+
+  /// @brief Build the JSON config for ProducerRegistry::create()
+  nlohmann::json to_json(const std::string& stream_id) const {
+    return nlohmann::json{
+      {"stream_id", stream_id},
+      {"use_device_time", use_device_time}
+    };
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__MOBILE_BASE_PRODUCER_CONFIG_HPP_

--- a/include/trossen_sdk/configuration/types/producers/producer_config.hpp
+++ b/include/trossen_sdk/configuration/types/producers/producer_config.hpp
@@ -1,0 +1,93 @@
+/**
+ * @file producer_config.hpp
+ * @brief Configuration for a single data producer
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__PRODUCER_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__PRODUCER_CONFIG_HPP_
+
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Configuration for an individual producer instance
+ *
+ * Each producer entry in the config specifies the hardware component it reads from,
+ * the producer type (which selects the ProducerRegistry factory), the stream ID used
+ * for recording, the polling rate, and any type-specific settings.
+ *
+ * JSON format:
+ * @code
+ * {
+ *   "type":            "trossen_arm",   // producer/hardware registry key
+ *   "hardware_id":     "leader",        // references hardware config id
+ *   "stream_id":       "leader",        // data stream name written to the backend
+ *   "poll_rate_hz":    30.0,
+ *   "use_device_time": false,
+ *   "encoding":        "bgr8"           // camera producers only
+ * }
+ * @endcode
+ *
+ * Known types:
+ *  - "trossen_arm"      — arm joint-state producer
+ *  - "realsense_camera" — Intel RealSense image producer
+ *  - "opencv_camera"    — OpenCV/V4L2 image producer
+ *  - "slate_base"       — SLATE mobile base velocity producer
+ */
+struct ProducerConfig {
+  /// @brief Producer/hardware registry key (e.g. "trossen_arm", "realsense_camera")
+  std::string type;
+
+  /// @brief Id of the hardware component this producer reads from
+  std::string hardware_id;
+
+  /// @brief Stream identifier written to the recording backend
+  std::string stream_id;
+
+  /// @brief Polling frequency in Hz
+  float poll_rate_hz{30.0f};
+
+  /// @brief Use hardware device timestamp when available
+  bool use_device_time{false};
+
+  /// @brief Pixel encoding — camera producers only (e.g. "bgr8", "rgb8", "mono8")
+  std::string encoding{"bgr8"};
+
+  static ProducerConfig from_json(const nlohmann::json& j) {
+    ProducerConfig c;
+    if (j.contains("type"))            j.at("type").get_to(c.type);
+    if (j.contains("hardware_id"))     j.at("hardware_id").get_to(c.hardware_id);
+    if (j.contains("stream_id"))       j.at("stream_id").get_to(c.stream_id);
+    if (j.contains("poll_rate_hz"))    j.at("poll_rate_hz").get_to(c.poll_rate_hz);
+    if (j.contains("use_device_time")) j.at("use_device_time").get_to(c.use_device_time);
+    if (j.contains("encoding"))        j.at("encoding").get_to(c.encoding);
+    return c;
+  }
+
+  /// @brief Build JSON for ProducerRegistry::create() — arm and mobile-base producers
+  nlohmann::json to_registry_json() const {
+    return nlohmann::json{
+      {"stream_id",       stream_id},
+      {"use_device_time", use_device_time}
+    };
+  }
+
+  /// @brief Build JSON for ProducerRegistry::create() — camera producers
+  nlohmann::json to_registry_json(int width, int height, int fps) const {
+    return nlohmann::json{
+      {"stream_id",       stream_id},
+      {"encoding",        encoding},
+      {"use_device_time", use_device_time},
+      {"width",           width},
+      {"height",          height},
+      {"fps",             fps}
+    };
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__PRODUCERS__PRODUCER_CONFIG_HPP_

--- a/include/trossen_sdk/configuration/types/teleop_config.hpp
+++ b/include/trossen_sdk/configuration/types/teleop_config.hpp
@@ -1,0 +1,75 @@
+/**
+ * @file teleop_config.hpp
+ * @brief Configuration for teleoperation setup
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__TELEOP_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__TELEOP_CONFIG_HPP_
+
+#include <string>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief A single leader→follower arm pairing for teleoperation
+ */
+struct TeleoperationPair {
+  /// @brief Key in hardware.arms map for the leader arm
+  std::string leader;
+
+  /// @brief Key in hardware.arms map for the follower arm
+  std::string follower;
+
+  static TeleoperationPair from_json(const nlohmann::json& j) {
+    TeleoperationPair p;
+    if (j.contains("leader")) j.at("leader").get_to(p.leader);
+    if (j.contains("follower")) j.at("follower").get_to(p.follower);
+    return p;
+  }
+};
+
+/**
+ * @brief Teleoperation configuration
+ *
+ * JSON format (under "teleop"):
+ * {
+ *   "enabled": true,
+ *   "rate_hz": 1000.0,
+ *   "pairs": [
+ *     { "leader": "leader_left",  "follower": "follower_left"  },
+ *     { "leader": "leader_right", "follower": "follower_right" }
+ *   ]
+ * }
+ *
+ * The teleop loop mirrors each leader arm's joint positions to its paired follower
+ * at the specified rate. Set "enabled" to false to skip teleop (e.g. replay mode).
+ */
+struct TeleoperationConfig {
+  /// @brief Whether teleoperation is active
+  bool enabled{true};
+
+  /// @brief Teleoperation control loop rate in Hz
+  float rate_hz{1000.0f};
+
+  /// @brief Leader→follower pairings
+  std::vector<TeleoperationPair> pairs;
+
+  static TeleoperationConfig from_json(const nlohmann::json& j) {
+    TeleoperationConfig c;
+    if (j.contains("enabled")) j.at("enabled").get_to(c.enabled);
+    if (j.contains("rate_hz")) j.at("rate_hz").get_to(c.rate_hz);
+    if (j.contains("pairs")) {
+      for (const auto& pair_j : j.at("pairs")) {
+        c.pairs.push_back(TeleoperationPair::from_json(pair_j));
+      }
+    }
+    return c;
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__TELEOP_CONFIG_HPP_


### PR DESCRIPTION
### TL;DR

Added configuration structures for teleoperation and data producers in the Trossen SDK

### What changed?

Added five new header files defining configuration structures:

- `ArmProducerConfig` - Configuration for arm joint-state producers with polling rate and device timestamp options
- `CameraProducerConfig` - Configuration for camera image producers including encoding, dimensions, and FPS settings  
- `MobileBaseProducerConfig` - Configuration for mobile base velocity producers
- `ProducerConfig` - Generic producer configuration supporting multiple hardware types (arms, cameras, mobile bases)
- `TeleoperationConfig` - Configuration for teleoperation setup with leader-follower arm pairs and control loop rate

Each configuration struct includes JSON serialization/deserialization methods and appropriate default values.

### How to test?

1. Include the new header files in your project
2. Create JSON configuration objects matching the documented formats
3. Use the `from_json()` static methods to parse configurations
4. Verify the `to_json()` and `to_registry_json()` methods produce expected output
5. Test with various producer types and teleoperation pair configurations

### Why make this change?

These configuration structures provide a standardized way to configure teleoperation systems and data producers across different hardware components. The JSON-based approach enables flexible configuration management while maintaining type safety and clear documentation of supported options.