### PR TITLE
Add path expansion support for tilde (~) in backend configuration root paths

### DIFF
--- a/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_backend_config.hpp
@@ -42,7 +42,11 @@ struct LeRobotBackendConfig : public BaseConfig {
     LeRobotBackendConfig c;  // All defaults already set by member initializers
 
     // Only override if present in JSON
-    if (j.contains("root")) j.at("root").get_to(c.root);
+    if (j.contains("root")) {
+      std::string raw_root;
+      j.at("root").get_to(raw_root);
+      c.root = trossen::io::backends::expand_user(raw_root).string();
+    }
     if (j.contains("encoder_threads")) j.at("encoder_threads").get_to(c.encoder_threads);
     if (j.contains("max_image_queue")) j.at("max_image_queue").get_to(c.max_image_queue);
     if (j.contains("png_compression_level"))

--- a/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/mcap_backend_config.hpp
@@ -32,7 +32,11 @@ struct McapBackendConfig : public BaseConfig {
     McapBackendConfig c;
 
     // Only override if present in JSON
-    if (j.contains("root")) j.at("root").get_to(c.root);
+    if (j.contains("root")) {
+      std::string raw_root;
+      j.at("root").get_to(raw_root);
+      c.root = trossen::io::backends::expand_user(raw_root).string();
+    }
     if (j.contains("robot_name")) j.at("robot_name").get_to(c.robot_name);
     if (j.contains("chunk_size_bytes")) j.at("chunk_size_bytes").get_to(c.chunk_size_bytes);
     if (j.contains("compression")) j.at("compression").get_to(c.compression);

--- a/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_backend_config.hpp
@@ -27,7 +27,11 @@ struct TrossenBackendConfig : public BaseConfig {
 
   static TrossenBackendConfig from_json(const nlohmann::json& j) {
     TrossenBackendConfig c;
-    if (j.contains("root")) j.at("root").get_to(c.root);
+    if (j.contains("root")) {
+      std::string raw_root;
+      j.at("root").get_to(raw_root);
+      c.root = trossen::io::backends::expand_user(raw_root).string();
+    }
     if (j.contains("encoder_threads")) j.at("encoder_threads").get_to(c.encoder_threads);
     if (j.contains("max_image_queue")) j.at("max_image_queue").get_to(c.max_image_queue);
     if (j.contains("png_compression_level"))

--- a/include/trossen_sdk/io/backend_utils.hpp
+++ b/include/trossen_sdk/io/backend_utils.hpp
@@ -11,6 +11,30 @@
 namespace trossen::io::backends {
 
 /**
+ * @brief Expand a leading ~ in a path to the user's home directory
+ * @param path The path string that may start with ~
+ * @return The expanded path with ~ replaced by $HOME, or the original path
+ *
+ * Analogous to Python's os.path.expanduser(). Only expands a leading "~"
+ * or "~/"; other occurrences of ~ are left unchanged.
+ */
+inline std::filesystem::path expand_user(const std::string& path) {
+  if (path.empty() || path[0] != '~') {
+    return std::filesystem::path(path);
+  }
+  // Only expand bare "~" or "~/..." (not "~user/...")
+  if (path.size() > 1 && path[1] != '/') {
+    return std::filesystem::path(path);
+  }
+  const char* home = std::getenv("HOME");
+  if (!home) {
+    return std::filesystem::path(path);
+  }
+  // "~" → home, "~/foo" → home / "foo"
+  return std::filesystem::path(home) / path.substr(path.size() > 1 ? 2 : 1);
+}
+
+/**
  * @brief Safely get the default root path for dataset storage
  */
 inline std::filesystem::path get_default_root_path() {


### PR DESCRIPTION
### TL;DR

Added support for tilde (`~`) expansion in root path configuration for all backend types.

### What changed?

- Added `expand_user()` function in `backend_utils.hpp` that expands leading `~` or `~/` in paths to the user's home directory using the `$HOME` environment variable
- Modified JSON deserialization in `LeRobotBackendConfig`, `McapBackendConfig`, and `TrossenBackendConfig` to automatically expand tilde paths when parsing the "root" field

### How to test?

1. Create configuration files with root paths using `~` or `~/path/to/data`
2. Verify that the paths are correctly expanded to the full home directory path
3. Test with configurations that don't use tilde to ensure they remain unchanged
4. Test edge cases like paths with `~` not at the beginning (should remain unchanged)

### Why make this change?

This enables users to specify dataset root paths using the familiar `~` shorthand for their home directory in configuration files, making configurations more portable and user-friendly across different systems.