### PR TITLE
Add Odometry2D support for SLATE mobile base tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ set(TROSSEN_PROTO_PATH ${CMAKE_CURRENT_SOURCE_DIR}/include/trossen_sdk/io/backen
 set(PROTOBUF_IMPORT_DIRS ${TROSSEN_PROTO_PATH})
 set(TROSSEN_PROTO_FILES
   ${TROSSEN_PROTO_PATH}/JointState.proto
+  ${TROSSEN_PROTO_PATH}/Odometry2D.proto
   ${TROSSEN_PROTO_PATH}/RawImage.proto
   ${TROSSEN_PROTO_PATH}/RobotDescription.proto
   ${TROSSEN_PROTO_PATH}/Timestamp.proto

--- a/examples/mcap_to_lerobot.cpp
+++ b/examples/mcap_to_lerobot.cpp
@@ -580,11 +580,15 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
     std::string topic = channel_ptr->topic;
     std::cout << "    - Topic: '" << topic << "'\n";
 
-    size_t odom_pos = topic.find("/odometry_2d/state");
+    size_t odom_pos = topic.find("/odom/state");
     if (odom_pos != std::string::npos) {
+      std::string stream_id = topic.substr(0, odom_pos);
+      if (!stream_id.empty() && stream_id[0] == '/') {
+        stream_id = stream_id.substr(1);
+      }
       slate_base_channel_id = channel_id;
       has_slate_base = true;
-      std::cout << "    ✓ Found odometry 2D stream for mobile robot\n";
+      std::cout << "    ✓ Found odometry stream for mobile robot: " << stream_id << "\n";
       continue;
     }
 

--- a/examples/mcap_to_lerobot.cpp
+++ b/examples/mcap_to_lerobot.cpp
@@ -684,8 +684,8 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
       }
       Odometry2DMessage msg;
       msg.timestamp_ns = messageView.message.logTime;
-      msg.vel_x = static_cast<double>(odom_msg.vel_x());
-      msg.vel_theta = static_cast<double>(odom_msg.vel_theta());
+      msg.vel_x = static_cast<double>(odom_msg.twist().linear_x());
+      msg.vel_theta = static_cast<double>(odom_msg.twist().angular_z());
       slate_base_messages.push_back(msg);
       ++total_messages;
       continue;

--- a/examples/mcap_to_lerobot.cpp
+++ b/examples/mcap_to_lerobot.cpp
@@ -38,6 +38,7 @@
 
 #include "./demo_utils.hpp"
 #include "JointState.pb.h"
+#include "Odometry2D.pb.h"
 #include "RawImage.pb.h"
 #include "mcap/reader.hpp"
 #include "nlohmann/json.hpp"
@@ -53,6 +54,12 @@ struct JointStateMessage {
   std::vector<double> positions;
   std::vector<double> velocities;
   std::string stream_id;
+};
+
+struct Odometry2DMessage {
+  uint64_t timestamp_ns{0};
+  double vel_x{0.0};
+  double vel_theta{0.0};
 };
 
 /**
@@ -573,6 +580,14 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
     std::string topic = channel_ptr->topic;
     std::cout << "    - Topic: '" << topic << "'\n";
 
+    size_t odom_pos = topic.find("/odometry_2d/state");
+    if (odom_pos != std::string::npos) {
+      slate_base_channel_id = channel_id;
+      has_slate_base = true;
+      std::cout << "    ✓ Found odometry 2D stream for mobile robot\n";
+      continue;
+    }
+
     size_t pos = topic.find("/joints/state");
     if (pos != std::string::npos) {
       std::string stream_id = topic.substr(0, pos);
@@ -582,12 +597,7 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
       }
       channel_id_to_stream[channel_id] = stream_id;
 
-      // Check if this is the slate_base stream
-      if (stream_id == "slate_base") {
-        slate_base_channel_id = channel_id;
-        has_slate_base = true;
-        std::cout << "    ✓ Found slate_base stream for mobile robot\n";
-      } else if (stream_id.find("leader") != std::string::npos) {
+      if (stream_id.find("leader") != std::string::npos) {
         detected_leader_streams.push_back(stream_id);
         std::cout << "    ✓ Detected leader stream: " << stream_id << "\n";
       } else if (stream_id.find("follower") != std::string::npos) {
@@ -653,7 +663,7 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
 
   std::cout << "\nParsing joint state messages...\n";
   std::map<std::string, std::vector<JointStateMessage>> messages_by_stream;
-  std::vector<JointStateMessage> slate_base_messages;
+  std::vector<Odometry2DMessage> slate_base_messages;
   std::map<std::string, size_t> camera_image_counts;
   std::map<std::string, std::vector<uint64_t>> camera_timestamps;
 
@@ -665,6 +675,22 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
   size_t total_images = 0;
 
   for (const auto& messageView : reader.readMessages(onProblem)) {
+    if (has_slate_base && messageView.channel->id == slate_base_channel_id) {
+      trossen_sdk::msg::Odometry2D odom_msg;
+      if (!odom_msg.ParseFromArray(reinterpret_cast<const char*>(messageView.message.data),
+                                   messageView.message.dataSize)) {
+        std::cerr << "Warning: Failed to parse Odometry2D message\n";
+        continue;
+      }
+      Odometry2DMessage msg;
+      msg.timestamp_ns = messageView.message.logTime;
+      msg.vel_x = static_cast<double>(odom_msg.vel_x());
+      msg.vel_theta = static_cast<double>(odom_msg.vel_theta());
+      slate_base_messages.push_back(msg);
+      ++total_messages;
+      continue;
+    }
+
     auto joint_it = channel_id_to_stream.find(messageView.channel->id);
     if (joint_it != channel_id_to_stream.end()) {
       const std::string& stream_id = joint_it->second;
@@ -686,12 +712,7 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
         msg.velocities.push_back(static_cast<double>(v));
       }
 
-      // Store slate_base messages separately
-      if (has_slate_base && messageView.channel->id == slate_base_channel_id) {
-        slate_base_messages.push_back(msg);
-      } else {
-        messages_by_stream[stream_id].push_back(msg);
-      }
+      messages_by_stream[stream_id].push_back(msg);
       ++total_messages;
       continue;
     }
@@ -940,11 +961,9 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
           std::abs(static_cast<int64_t>(
               slate_base_messages[slate_base_idx].timestamp_ns - timestamp_ns)) <=
               static_cast<int64_t>(tolerance_ns)) {
-        const auto& velocities = slate_base_messages[slate_base_idx].velocities;
-        if (velocities.size() >= 2) {
-          base_velocities.push_back(velocities[0]);  // linear velocity
-          base_velocities.push_back(velocities[2]);  // angular velocity
-        }
+        const auto& odom = slate_base_messages[slate_base_idx];
+        base_velocities.push_back(odom.vel_x);      // linear velocity
+        base_velocities.push_back(odom.vel_theta);  // angular velocity
       }
 
       // If we didn't get base velocities, use zeros

--- a/include/trossen_sdk/data/record.hpp
+++ b/include/trossen_sdk/data/record.hpp
@@ -172,35 +172,28 @@ struct TeleopJointStateRecord : public RecordBase {
 };
 
 /**
- * @brief 2D odometry state (pose + velocity).
- *
- * Pose fields mirror Nav2 nav_msgs/Odometry convention:
- *   x, y      – position in the odom frame (metres)
- *   theta     – heading angle (radians)
- *
- * Velocity fields are body-frame twists:
- *   vel_x     – linear velocity along x (m/s)
- *   vel_y     – linear velocity along y (m/s)
- *   vel_theta – angular velocity around z (rad/s)
+ * @brief 2D odometry state (pose + velocity), mirroring nav_msgs/Odometry.
  */
 struct Odometry2DRecord : public RecordBase {
-  /// @brief Odometry x position (m)
-  float pose_x{0.f};
+  /// @brief 2D pose in the odom frame.
+  struct Pose {
+    /// @brief Position along x-axis (m)
+    float x{0.f};
+    /// @brief Position along y-axis (m)
+    float y{0.f};
+    /// @brief Heading angle (rad)
+    float theta{0.f};
+  } pose;
 
-  /// @brief Odometry y position (m)
-  float pose_y{0.f};
-
-  /// @brief Odometry heading angle (rad)
-  float pose_theta{0.f};
-
-  /// @brief Linear velocity along x (m/s)
-  float vel_x{0.f};
-
-  /// @brief Linear velocity along y (m/s)
-  float vel_y{0.f};
-
-  /// @brief Angular velocity around z (rad/s)
-  float vel_theta{0.f};
+  /// @brief Body-frame twist.
+  struct Twist {
+    /// @brief Linear velocity along x (m/s)
+    float linear_x{0.f};
+    /// @brief Linear velocity along y (m/s)
+    float linear_y{0.f};
+    /// @brief Angular velocity around z (rad/s)
+    float angular_z{0.f};
+  } twist;
 };
 
 /**

--- a/include/trossen_sdk/data/record.hpp
+++ b/include/trossen_sdk/data/record.hpp
@@ -172,6 +172,38 @@ struct TeleopJointStateRecord : public RecordBase {
 };
 
 /**
+ * @brief 2D odometry state (pose + velocity).
+ *
+ * Pose fields mirror Nav2 nav_msgs/Odometry convention:
+ *   x, y      – position in the odom frame (metres)
+ *   theta     – heading angle (radians)
+ *
+ * Velocity fields are body-frame twists:
+ *   vel_x     – linear velocity along x (m/s)
+ *   vel_y     – linear velocity along y (m/s)
+ *   vel_theta – angular velocity around z (rad/s)
+ */
+struct Odometry2DRecord : public RecordBase {
+  /// @brief Odometry x position (m)
+  float pose_x{0.f};
+
+  /// @brief Odometry y position (m)
+  float pose_y{0.f};
+
+  /// @brief Odometry heading angle (rad)
+  float pose_theta{0.f};
+
+  /// @brief Linear velocity along x (m/s)
+  float vel_x{0.f};
+
+  /// @brief Linear velocity along y (m/s)
+  float vel_y{0.f};
+
+  /// @brief Angular velocity around z (rad/s)
+  float vel_theta{0.f};
+};
+
+/**
  * @brief Image frame payload.
  */
 struct ImageRecord : public RecordBase {

--- a/include/trossen_sdk/hw/base/slate_base_producer.hpp
+++ b/include/trossen_sdk/hw/base/slate_base_producer.hpp
@@ -77,10 +77,10 @@ public:
   ~SlateBaseProducer() override = default;
 
   /**
-   * @brief Poll the driver for the latest state and emit a MobileBaseRecord.
+   * @brief Poll the driver for the latest state and emit an Odometry2DRecord.
    *
    * Reads odom_x/y/z (pose) and vel_x/y/z (body-frame velocity) from the
-   * SLATE driver and populates a MobileBaseRecord.
+   * SLATE driver and populates a Odometry2DRecord.
    *
    * @param emit Callback to invoke for each produced record
    */

--- a/include/trossen_sdk/hw/base/slate_base_producer.hpp
+++ b/include/trossen_sdk/hw/base/slate_base_producer.hpp
@@ -22,10 +22,11 @@
 namespace trossen::hw::base {
 
 /**
- * @brief Producer that emits velocity states from SLATE mobile base
+ * @brief Producer that emits 2D pose and velocity from the SLATE mobile base.
  *
- * Stores linear velocity (x, y) and angular velocity (z) in the JointStateRecord
- * velocity vector as [vel_x, vel_y, vel_z].
+ * Reads odometry (odom_x, odom_y, odom_z) and body-frame velocity
+ * (vel_x, vel_y, vel_z) from the SLATE driver and emits an Odometry2DRecord
+ * per poll cycle.
  */
 class SlateBaseProducer : public ::trossen::hw::PolledProducer {
 public:
@@ -76,10 +77,10 @@ public:
   ~SlateBaseProducer() override = default;
 
   /**
-   * @brief Poll the driver for the latest velocity states and emit a JointStateRecord
+   * @brief Poll the driver for the latest state and emit a MobileBaseRecord.
    *
-   * Stores velocity data in the velocity vector as [vel_x, vel_y, vel_z].
-   * Position and effort vectors remain empty.
+   * Reads odom_x/y/z (pose) and vel_x/y/z (body-frame velocity) from the
+   * SLATE driver and populates a MobileBaseRecord.
    *
    * @param emit Callback to invoke for each produced record
    */

--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -189,10 +189,10 @@ private:
   std::optional<foxglove::McapWriter> writer_;
 
   /// @brief Serialised FileDescriptorSet for the JointState protobuf schema
-  std::string schema_data_;
+  std::string schema_data_js_;
 
   /// @brief Serialised FileDescriptorSet for the Odometry2D protobuf schema
-  std::string odometry_2d_schema_data_;
+  std::string schema_data_odom2d_;
 
   /// @brief Output file path
   std::filesystem::path path_;

--- a/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_backend.hpp
@@ -43,6 +43,9 @@ public:
     /// @brief Number of joint state records written
     uint64_t joint_states_written{0};
 
+    /// @brief Number of 2D odometry records written
+    uint64_t odometry_2d_written{0};
+
     /// @brief Number of image records written
     uint64_t images_written{0};
 
@@ -147,6 +150,13 @@ private:
   foxglove::RawChannel* ensure_jointstate_channel(const std::string& stream_id);
 
   /**
+   * @brief Ensure the 2D odometry channel exists for a given stream ID
+   *
+   * @param stream_id Stream identifier (e.g., "base")
+   */
+  void ensure_odometry_2d_channel(const std::string& stream_id);
+
+  /**
    * @brief Write an image record
    *
    * @param img Image record to write
@@ -161,6 +171,13 @@ private:
   void write_jointstate_record(const data::JointStateRecord& js);
 
   /**
+   * @brief Write a 2D odometry record
+   *
+   * @param odom 2D odometry record to write
+   */
+  void write_odometry_2d_record(const data::Odometry2DRecord& odom);
+
+  /**
    * @brief Register protobuf schemas once
    */
   void register_schemas_once();
@@ -171,8 +188,11 @@ private:
   /// @brief Foxglove MCAP writer instance
   std::optional<foxglove::McapWriter> writer_;
 
-  /// @brief Protobuf schema for images
+  /// @brief Serialised FileDescriptorSet for the JointState protobuf schema
   std::string schema_data_;
+
+  /// @brief Serialised FileDescriptorSet for the Odometry2D protobuf schema
+  std::string odometry_2d_schema_data_;
 
   /// @brief Output file path
   std::filesystem::path path_;
@@ -194,6 +214,9 @@ private:
 
   /// @brief Map of joint state channels by stream ID
   std::unordered_map<std::string, foxglove::RawChannel> joint_channels_;
+
+  /// @brief Map of 2D odometry channels by stream ID
+  std::unordered_map<std::string, foxglove::RawChannel> odometry_2d_channels_;
 
   /// @brief Statistics about written records
   Stats stats_{};

--- a/include/trossen_sdk/io/backends/mcap/mcap_schemas.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_schemas.hpp
@@ -52,7 +52,7 @@ inline std::string joint_state_topic(const std::string& robot_name) {
  * @return Topic name for the 2D odometry stream
  */
 inline std::string odometry_2d_topic(const std::string& stream_id) {
-  return stream_id + "/odometry_2d/state";
+  return stream_id + "/odom/state";
 }
 
 }  // namespace trossen::mcapdefs

--- a/include/trossen_sdk/io/backends/mcap/mcap_schemas.hpp
+++ b/include/trossen_sdk/io/backends/mcap/mcap_schemas.hpp
@@ -45,6 +45,16 @@ inline std::string joint_state_topic(const std::string& robot_name) {
   return robot_name + "/joints/state";
 }
 
+/**
+ * @brief Get topic name for 2D odometry stream
+ *
+ * @param stream_id Stream identifier (e.g., "base")
+ * @return Topic name for the 2D odometry stream
+ */
+inline std::string odometry_2d_topic(const std::string& stream_id) {
+  return stream_id + "/odometry_2d/state";
+}
+
 }  // namespace trossen::mcapdefs
 
 #endif  // TROSSEN_SDK__IO__BACKENDS__MCAP__MCAP_SCHEMAS_HPP_

--- a/include/trossen_sdk/io/backends/mcap/proto/Odometry2D.proto
+++ b/include/trossen_sdk/io/backends/mcap/proto/Odometry2D.proto
@@ -3,8 +3,31 @@ package trossen_sdk.msg;
 
 import "Timestamp.proto";
 
-// 2D odometry state: pose and body-frame velocity.
-// Follows Nav2 nav_msgs/Odometry conventions.
+// 2D pose: position (x, y) and heading angle (theta).
+message Pose2D {
+  // Position along x-axis (m)
+  float x = 1;
+
+  // Position along y-axis (m)
+  float y = 2;
+
+  // Heading angle (rad)
+  float theta = 3;
+}
+
+// 2D body-frame twist: linear velocities and angular velocity.
+message Twist2D {
+  // Linear velocity along x (m/s)
+  float linear_x = 1;
+
+  // Linear velocity along y (m/s)
+  float linear_y = 2;
+
+  // Angular velocity around z (rad/s)
+  float angular_z = 3;
+}
+
+// 2D odometry state (pose + velocity), mirroring nav_msgs/Odometry.
 message Odometry2D {
   // Dual (monotonic + realtime) timestamp of the record
   trossen_sdk.Timestamp ts = 1;
@@ -12,21 +35,9 @@ message Odometry2D {
   // Sequence number of the record
   uint64 seq = 2;
 
-  // Odometry x position (m)
-  float pose_x = 3;
+  // Pose in the odom frame
+  Pose2D pose = 3;
 
-  // Odometry y position (m)
-  float pose_y = 4;
-
-  // Odometry heading angle (rad)
-  float pose_theta = 5;
-
-  // Linear velocity along x (m/s)
-  float vel_x = 6;
-
-  // Linear velocity along y (m/s)
-  float vel_y = 7;
-
-  // Angular velocity around z (rad/s)
-  float vel_theta = 8;
+  // Body-frame twist
+  Twist2D twist = 4;
 }

--- a/include/trossen_sdk/io/backends/mcap/proto/Odometry2D.proto
+++ b/include/trossen_sdk/io/backends/mcap/proto/Odometry2D.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+package trossen_sdk.msg;
+
+import "Timestamp.proto";
+
+// 2D odometry state: pose and body-frame velocity.
+// Follows Nav2 nav_msgs/Odometry conventions.
+message Odometry2D {
+  // Dual (monotonic + realtime) timestamp of the record
+  trossen_sdk.Timestamp ts = 1;
+
+  // Sequence number of the record
+  uint64 seq = 2;
+
+  // Odometry x position (m)
+  float pose_x = 3;
+
+  // Odometry y position (m)
+  float pose_y = 4;
+
+  // Odometry heading angle (rad)
+  float pose_theta = 5;
+
+  // Linear velocity along x (m/s)
+  float vel_x = 6;
+
+  // Linear velocity along y (m/s)
+  float vel_y = 7;
+
+  // Angular velocity around z (rad/s)
+  float vel_theta = 8;
+}

--- a/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen/trossen_backend.hpp
@@ -221,6 +221,13 @@ private:
   void write_joint_state(const data::RecordBase& base);
 
   /**
+   * @brief Write a 2D odometry record to disk
+   *
+   * @param odom 2D odometry record to write
+   */
+  void write_odometry_2d(const data::Odometry2DRecord& odom);
+
+  /**
    * @brief Write an image record to disk
    *
    * @param base Record to write (will be dynamic_cast to ImageRecord)
@@ -283,6 +290,8 @@ private:
   std::filesystem::path images_root_;
   std::ofstream joint_csv_;
   bool header_written_{false};
+  std::ofstream odometry_2d_csv_;
+  bool odometry_2d_header_written_{false};
   std::mutex write_mutex_;
   std::mutex open_mutex_;
   bool opened_{false};

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -215,8 +215,8 @@ foxglove::RawChannel* McapBackend::ensure_jointstate_channel(const std::string& 
   foxglove::Schema schema;
   schema.name = "trossen_sdk.msg.JointState";
   schema.encoding = "protobuf";
-  schema.data = reinterpret_cast<const std::byte*>(schema_data_.data());
-  schema.data_len = schema_data_.size();
+  schema.data = reinterpret_cast<const std::byte*>(schema_data_js_.data());
+  schema.data_len = schema_data_js_.size();
 
   // Create channel with stream-specific topic
   auto channel_result = foxglove::RawChannel::create(
@@ -323,8 +323,8 @@ void McapBackend::ensure_odometry_2d_channel(const std::string& stream_id) {
   foxglove::Schema schema;
   schema.name = "trossen_sdk.msg.Odometry2D";
   schema.encoding = "protobuf";
-  schema.data = reinterpret_cast<const std::byte*>(odometry_2d_schema_data_.data());
-  schema.data_len = odometry_2d_schema_data_.size();
+  schema.data = reinterpret_cast<const std::byte*>(schema_data_odom2d_.data());
+  schema.data_len = schema_data_odom2d_.size();
 
   auto channel_result = foxglove::RawChannel::create(
     mcapdefs::odometry_2d_topic(stream_id),
@@ -500,9 +500,9 @@ void McapBackend::register_schemas_once() {
     return blob;
   };
 
-  schema_data_ = build_schema_blob(
+  schema_data_js_ = build_schema_blob(
     "trossen_sdk/io/backends/mcap/proto/JointState.proto");
-  odometry_2d_schema_data_ = build_schema_blob(
+  schema_data_odom2d_ = build_schema_blob(
     "trossen_sdk/io/backends/mcap/proto/Odometry2D.proto");
 }
 

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -363,12 +363,16 @@ void McapBackend::write_odometry_2d_record(const data::Odometry2DRecord& odom) {
   real->set_nanos(odom.ts.realtime.nsec);
 
   out.set_seq(odom.seq);
-  out.set_pose_x(odom.pose_x);
-  out.set_pose_y(odom.pose_y);
-  out.set_pose_theta(odom.pose_theta);
-  out.set_vel_x(odom.vel_x);
-  out.set_vel_y(odom.vel_y);
-  out.set_vel_theta(odom.vel_theta);
+
+  auto* pose = out.mutable_pose();
+  pose->set_x(odom.pose.x);
+  pose->set_y(odom.pose.y);
+  pose->set_theta(odom.pose.theta);
+
+  auto* twist = out.mutable_twist();
+  twist->set_linear_x(odom.twist.linear_x);
+  twist->set_linear_y(odom.twist.linear_y);
+  twist->set_angular_z(odom.twist.angular_z);
 
   std::string payload;
   out.SerializeToString(&payload);

--- a/src/backends/mcap/mcap_backend.cpp
+++ b/src/backends/mcap/mcap_backend.cpp
@@ -12,6 +12,7 @@
 #include "opencv2/imgcodecs.hpp"
 
 #include "JointState.pb.h"
+#include "Odometry2D.pb.h"
 #include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/mcap/mcap_backend.hpp"
@@ -139,6 +140,9 @@ void McapBackend::close() {
   for (auto& [stream_id, channel] : joint_channels_) {
     channel.close();
   }
+  for (auto& [stream_id, channel] : odometry_2d_channels_) {
+    channel.close();
+  }
   for (auto& [name, channel] : image_channels_) {
     channel.close();
   }
@@ -174,6 +178,11 @@ void McapBackend::write(const data::RecordBase& record) {
     write_jointstate_record(*js);
     return;
   }
+
+  if (auto mb = dynamic_cast<const data::Odometry2DRecord*>(&record)) {
+    write_odometry_2d_record(*mb);
+    return;
+  }
 }
 
 void McapBackend::write_batch(std::span<const data::RecordBase* const> records) {
@@ -187,6 +196,10 @@ void McapBackend::write_batch(std::span<const data::RecordBase* const> records) 
     }
     if (auto js = dynamic_cast<const data::JointStateRecord*>(r)) {
       write_jointstate_record(*js);
+      continue;
+    }
+    if (auto mb = dynamic_cast<const data::Odometry2DRecord*>(r)) {
+      write_odometry_2d_record(*mb);
       continue;
     }
   }
@@ -301,6 +314,78 @@ void McapBackend::write_jointstate_record(const data::JointStateRecord& js) {
   }
 }
 
+void McapBackend::ensure_odometry_2d_channel(const std::string& stream_id) {
+  auto it = odometry_2d_channels_.find(stream_id);
+  if (it != odometry_2d_channels_.end()) {
+    return;
+  }
+
+  foxglove::Schema schema;
+  schema.name = "trossen_sdk.msg.Odometry2D";
+  schema.encoding = "protobuf";
+  schema.data = reinterpret_cast<const std::byte*>(odometry_2d_schema_data_.data());
+  schema.data_len = odometry_2d_schema_data_.size();
+
+  auto channel_result = foxglove::RawChannel::create(
+    mcapdefs::odometry_2d_topic(stream_id),
+    "protobuf",
+    schema,
+    context_,
+    std::nullopt);
+
+  if (!channel_result.has_value()) {
+    std::cerr << "Failed to create odometry 2D channel for " << stream_id << ": "
+              << foxglove::strerror(channel_result.error()) << "\n";
+    return;
+  }
+
+  odometry_2d_channels_.emplace(stream_id, std::move(channel_result.value()));
+}
+
+void McapBackend::write_odometry_2d_record(const data::Odometry2DRecord& odom) {
+  ensure_odometry_2d_channel(odom.id);
+
+  auto it = odometry_2d_channels_.find(odom.id);
+  if (it == odometry_2d_channels_.end()) {
+    std::cerr << "Failed to find odometry 2D channel for stream: " << odom.id << "\n";
+    return;
+  }
+
+  trossen_sdk::msg::Odometry2D out;
+  auto* ts = out.mutable_ts();
+
+  auto* mono = ts->mutable_monotonic();
+  mono->set_seconds(odom.ts.monotonic.sec);
+  mono->set_nanos(odom.ts.monotonic.nsec);
+
+  auto* real = ts->mutable_realtime();
+  real->set_seconds(odom.ts.realtime.sec);
+  real->set_nanos(odom.ts.realtime.nsec);
+
+  out.set_seq(odom.seq);
+  out.set_pose_x(odom.pose_x);
+  out.set_pose_y(odom.pose_y);
+  out.set_pose_theta(odom.pose_theta);
+  out.set_vel_x(odom.vel_x);
+  out.set_vel_y(odom.vel_y);
+  out.set_vel_theta(odom.vel_theta);
+
+  std::string payload;
+  out.SerializeToString(&payload);
+
+  auto st = it->second.log(
+    reinterpret_cast<const std::byte*>(payload.data()),
+    payload.size(),
+    odom.ts.realtime.to_ns());
+
+  if (st != foxglove::FoxgloveError::Ok) {
+    std::cerr << "Failed to write odometry 2D record for " << odom.id << ": "
+              << foxglove::strerror(st) << "\n";
+  } else {
+    ++stats_.odometry_2d_written;
+  }
+}
+
 void McapBackend::write_image_record(const data::ImageRecord& img) {
   // Determine if this is a depth frame based on encoding or topic
   const bool depth =
@@ -377,47 +462,44 @@ void McapBackend::write_image_record(const data::ImageRecord& img) {
 }
 
 void McapBackend::register_schemas_once() {
-  // Build descriptor set from generated pool, including transitive dependencies
   const auto* pool = google::protobuf::DescriptorPool::generated_pool();
-  google::protobuf::FileDescriptorSet set;
 
-  const char* roots[] = {
-    "trossen_sdk/io/backends/mcap/proto/JointState.proto",
-  };
+  // Helper: build a self-contained FileDescriptorSet for one root .proto file
+  auto build_schema_blob = [&](const char* proto_path) -> std::string {
+    google::protobuf::FileDescriptorSet set;
+    std::unordered_set<std::string> visited;
 
-  std::unordered_set<std::string> visited;
-  std::function<void(const google::protobuf::FileDescriptor*)> add_with_deps;
-  add_with_deps = [&](const google::protobuf::FileDescriptor* fd) {
+    std::function<void(const google::protobuf::FileDescriptor*)> add_with_deps;
+    add_with_deps = [&](const google::protobuf::FileDescriptor* fd) {
+      if (!fd || !visited.insert(fd->name()).second) {
+        return;
+      }
+      for (int i = 0; i < fd->dependency_count(); ++i) {
+        add_with_deps(fd->dependency(i));
+      }
+      fd->CopyTo(set.add_file());
+    };
+
+    const google::protobuf::FileDescriptor* fd = pool->FindFileByName(proto_path);
     if (!fd) {
-      return;
-    }
-    if (!visited.insert(fd->name()).second){
-      // already added
-       return;
-    }
-    // Recurse first so dependencies appear earlier (order not strictly required)
-    for (int i = 0; i < fd->dependency_count(); ++i) {
-      add_with_deps(fd->dependency(i));
-    }
-    fd->CopyTo(set.add_file());
-  };
-
-  for (auto* fname : roots) {
-    const google::protobuf::FileDescriptor* fd = pool->FindFileByName(fname);
-    if (!fd) {
-      // Try basename fallback if the compiler emitted only the base name
-      std::string base(fname);
+      // Basename fallback: compiler may have stripped the directory prefix
+      std::string base(proto_path);
       if (auto pos = base.find_last_of('/'); pos != std::string::npos) {
         base = base.substr(pos + 1);
       }
       fd = pool->FindFileByName(base);
     }
     add_with_deps(fd);
-  }
 
-  std::string blob;
-  set.SerializeToString(&blob);
-  schema_data_ = blob;
+    std::string blob;
+    set.SerializeToString(&blob);
+    return blob;
+  };
+
+  schema_data_ = build_schema_blob(
+    "trossen_sdk/io/backends/mcap/proto/JointState.proto");
+  odometry_2d_schema_data_ = build_schema_blob(
+    "trossen_sdk/io/backends/mcap/proto/Odometry2D.proto");
 }
 
 bool McapBackend::is_depth_topic(const std::string& topic) {

--- a/src/backends/trossen/trossen_backend.cpp
+++ b/src/backends/trossen/trossen_backend.cpp
@@ -198,19 +198,19 @@ void TrossenBackend::write_odometry_2d(const data::Odometry2DRecord& mb) {
     odometry_2d_csv_
       << "monotonic_ns,realtime_ns,id,"
       << "pose_x,pose_y,pose_theta,"
-      << "vel_x,vel_y,vel_theta\n";
+      << "twist_linear_x,twist_linear_y,twist_angular_z\n";
     odometry_2d_header_written_ = true;
   }
   odometry_2d_csv_
     << mb.ts.monotonic.to_ns() << ','
     << mb.ts.realtime.to_ns()  << ','
     << mb.id                   << ','
-    << std::setprecision(6) << mb.pose_x     << ','
-    << std::setprecision(6) << mb.pose_y     << ','
-    << std::setprecision(6) << mb.pose_theta << ','
-    << std::setprecision(6) << mb.vel_x      << ','
-    << std::setprecision(6) << mb.vel_y      << ','
-    << std::setprecision(6) << mb.vel_theta  << '\n';
+    << std::setprecision(6) << mb.pose.x     << ','
+    << std::setprecision(6) << mb.pose.y     << ','
+    << std::setprecision(6) << mb.pose.theta << ','
+    << std::setprecision(6) << mb.twist.linear_x  << ','
+    << std::setprecision(6) << mb.twist.linear_y  << ','
+    << std::setprecision(6) << mb.twist.angular_z << '\n';
 }
 
 void TrossenBackend::write_image(const data::RecordBase& base) {

--- a/src/backends/trossen/trossen_backend.cpp
+++ b/src/backends/trossen/trossen_backend.cpp
@@ -102,6 +102,13 @@ bool TrossenBackend::open() {
     return false;
   }
   header_written_ = false;
+
+  odometry_2d_csv_.open((root_ / "odometry_2d.csv").string(), std::ios::out | std::ios::trunc);
+  if (!odometry_2d_csv_) {
+    std::cerr << "Failed to open mobile_base.csv\n";
+    return false;
+  }
+  odometry_2d_header_written_ = false;
   // Cache queue policy derived members
   max_image_queue_cached_ = cfg_->max_image_queue;
 
@@ -121,10 +128,10 @@ void TrossenBackend::write(const data::RecordBase& record) {
   // Decide type by RTTI (simple approach for now)
   if (auto js = dynamic_cast<const data::JointStateRecord*>(&record)) {
     write_joint_state(*js);
+  } else if (auto mb = dynamic_cast<const data::Odometry2DRecord*>(&record)) {
+    write_odometry_2d(*mb);
   } else if (auto img = dynamic_cast<const data::ImageRecord*>(&record)) {
     write_image(*img);
-  } else {
-    // Unknown type ignored for now
   }
 }
 
@@ -136,6 +143,8 @@ void TrossenBackend::write_batch(std::span<const data::RecordBase* const> record
     }
     if (auto js = dynamic_cast<const data::JointStateRecord*>(r)) {
       write_joint_state(*js);
+    } else if (auto mb = dynamic_cast<const data::Odometry2DRecord*>(r)) {
+      write_odometry_2d(*mb);
     } else if (auto img = dynamic_cast<const data::ImageRecord*>(r)) {
       write_image(*img);
     }
@@ -144,12 +153,14 @@ void TrossenBackend::write_batch(std::span<const data::RecordBase* const> record
 
 void TrossenBackend::flush() {
   if (joint_csv_) joint_csv_.flush();
+  if (odometry_2d_csv_) odometry_2d_csv_.flush();
 }
 
 void TrossenBackend::close() {
   std::lock_guard<std::mutex> lock(open_mutex_);
   if (!opened_) return;
   if (joint_csv_.is_open()) joint_csv_.close();
+  if (odometry_2d_csv_.is_open()) odometry_2d_csv_.close();
   // Stop image worker
   image_worker_running_ = false;
   image_queue_cv_.notify_all();
@@ -180,6 +191,26 @@ void TrossenBackend::write_joint_state(const data::RecordBase& base) {
              << vecToStr(js.positions) << ','
              << vecToStr(js.velocities) << ','
              << vecToStr(js.efforts) << '\n';
+}
+
+void TrossenBackend::write_odometry_2d(const data::Odometry2DRecord& mb) {
+  if (!odometry_2d_header_written_) {
+    odometry_2d_csv_
+      << "monotonic_ns,realtime_ns,id,"
+      << "pose_x,pose_y,pose_theta,"
+      << "vel_x,vel_y,vel_theta\n";
+    odometry_2d_header_written_ = true;
+  }
+  odometry_2d_csv_
+    << mb.ts.monotonic.to_ns() << ','
+    << mb.ts.realtime.to_ns()  << ','
+    << mb.id                   << ','
+    << std::setprecision(6) << mb.pose_x     << ','
+    << std::setprecision(6) << mb.pose_y     << ','
+    << std::setprecision(6) << mb.pose_theta << ','
+    << std::setprecision(6) << mb.vel_x      << ','
+    << std::setprecision(6) << mb.vel_y      << ','
+    << std::setprecision(6) << mb.vel_theta  << '\n';
 }
 
 void TrossenBackend::write_image(const data::RecordBase& base) {

--- a/src/hw/base/slate_base_producer.cpp
+++ b/src/hw/base/slate_base_producer.cpp
@@ -62,22 +62,19 @@ void SlateBaseProducer::poll(const std::function<void(std::shared_ptr<data::Reco
   ts.monotonic = data::now_mono();
   ts.realtime = data::now_real();
 
-  // Create and populate JointStateRecord with velocity data
-  auto rec = std::make_shared<data::JointStateRecord>();
+  // Populate Odometry2DRecord with pose (odom) and body-frame velocity
+  auto rec = std::make_shared<data::Odometry2DRecord>();
   rec->ts = ts;
   rec->seq = seq_++;
   rec->id = cfg_.stream_id;
 
-  // Store velocities: [linear_x, linear_y, angular_z]
-  rec->velocities.clear();
-  rec->velocities.reserve(3);
-  rec->velocities.push_back(chassis_data_.vel_x);
-  rec->velocities.push_back(chassis_data_.vel_y);
-  rec->velocities.push_back(chassis_data_.vel_z);
+  rec->pose_x     = chassis_data_.odom_x;
+  rec->pose_y     = chassis_data_.odom_y;
+  rec->pose_theta = chassis_data_.odom_z;
 
-  // Leave positions and efforts empty
-  rec->positions.clear();
-  rec->efforts.clear();
+  rec->vel_x     = chassis_data_.vel_x;
+  rec->vel_y     = chassis_data_.vel_y;
+  rec->vel_theta = chassis_data_.vel_z;
 
   // Emit the record
   emit(rec);

--- a/src/hw/base/slate_base_producer.cpp
+++ b/src/hw/base/slate_base_producer.cpp
@@ -68,13 +68,13 @@ void SlateBaseProducer::poll(const std::function<void(std::shared_ptr<data::Reco
   rec->seq = seq_++;
   rec->id = cfg_.stream_id;
 
-  rec->pose_x     = chassis_data_.odom_x;
-  rec->pose_y     = chassis_data_.odom_y;
-  rec->pose_theta = chassis_data_.odom_z;
+  rec->pose.x     = chassis_data_.odom_x;
+  rec->pose.y     = chassis_data_.odom_y;
+  rec->pose.theta = chassis_data_.odom_z;
 
-  rec->vel_x     = chassis_data_.vel_x;
-  rec->vel_y     = chassis_data_.vel_y;
-  rec->vel_theta = chassis_data_.vel_z;
+  rec->twist.linear_x  = chassis_data_.vel_x;
+  rec->twist.linear_y  = chassis_data_.vel_y;
+  rec->twist.angular_z = chassis_data_.vel_z;
 
   // Emit the record
   emit(rec);


### PR DESCRIPTION
### TL;DR

Added dedicated 2D odometry support for mobile base data recording and playback, replacing the previous approach of storing velocity data in joint state records.

### What changed?

- Added new `Odometry2DRecord` struct to store pose (x, y, theta) and velocity (vel_x, vel_y, vel_theta) data
- Created `Odometry2D.proto` protobuf schema for serialization
- Updated `SlateBaseProducer` to emit `Odometry2DRecord` instead of `JointStateRecord` with velocity data
- Modified MCAP backend to handle odometry records with dedicated channels using `/odometry_2d/state` topic naming
- Updated Trossen backend to write odometry data to separate `odometry_2d.csv` file
- Fixed `mcap_to_lerobot.cpp` to parse odometry messages correctly and extract `vel_x` and `vel_theta` directly

### How to test?

1. Record data from a SLATE mobile base using the updated producer
2. Verify that odometry data appears in both MCAP files (on `/odometry_2d/state` topics) and CSV files (`odometry_2d.csv`)
3. Test the `mcap_to_lerobot` conversion tool with recorded mobile base data to ensure proper velocity extraction
4. Check that pose and velocity fields are populated correctly in the output formats

### Why make this change?

The previous approach of storing mobile base velocity data in joint state records was semantically incorrect and made data processing more complex. Mobile base odometry data (pose + velocity) has different semantics than joint states and deserves its own dedicated record type. This change provides cleaner separation of concerns, more intuitive data access, and better alignment with robotics conventions like Nav2's odometry messages.