### PR TITLE
Add producer metadata collection and MCAP dataset info generation

### DIFF
--- a/include/trossen_sdk/hw/arm/arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/arm_producer.hpp
@@ -52,8 +52,6 @@ public:
     /**
      * @brief Get producer info as JSON (LeRobot feature format)
      *
-     * For a single-arm (solo) setup, the arm acts as both action and observation source.
-     *
      * @return JSON object with "action" and "observation.state" feature entries
      */
     nlohmann::ordered_json get_info() const override {

--- a/include/trossen_sdk/hw/arm/arm_producer.hpp
+++ b/include/trossen_sdk/hw/arm/arm_producer.hpp
@@ -50,15 +50,33 @@ public:
     std::string gripper_type;
 
     /**
-     * @brief Get producer info as JSON
+     * @brief Get producer info as JSON (LeRobot feature format)
      *
-     * @return JSON object containing producer information
+     * For a single-arm (solo) setup, the arm acts as both action and observation source.
+     *
+     * @return JSON object with "action" and "observation.state" feature entries
      */
     nlohmann::ordered_json get_info() const override {
-      // TODO(shantanuparab-tr): Implement JSON output when needed
-      std::cout << "TrossenArmProducerMetadata: " << name << " (" << id << ") - " << description
-                << ", Model: " << arm_model << ", Gripper: " << gripper_type << "\n";
-      return nlohmann::ordered_json{};
+      int n = static_cast<int>(joint_names.size());
+      nlohmann::ordered_json features;
+      features["action"]["dtype"] = "float32";
+      features["action"]["shape"] = nlohmann::json::array({n});
+      features["action"]["names"] = joint_names;
+      features["observation.state"]["dtype"] = "float32";
+      features["observation.state"]["shape"] = nlohmann::json::array({n});
+      features["observation.state"]["names"] = joint_names;
+      return features;
+    }
+
+    /**
+     * @brief Get per-stream dataset metadata for MCAP recording
+     *
+     * @return JSON with "streams.<stream_id>.joint_names"
+     */
+    nlohmann::ordered_json get_stream_info() const override {
+      nlohmann::ordered_json info;
+      info["streams"][id]["joint_names"] = joint_names;
+      return info;
     }
   };
 

--- a/include/trossen_sdk/hw/base/slate_base_producer.hpp
+++ b/include/trossen_sdk/hw/base/slate_base_producer.hpp
@@ -54,9 +54,19 @@ public:
      * @return JSON object containing producer information
      */
     nlohmann::ordered_json get_info() const override {
-      std::cout << "SlateBaseProducerMetadata: " << name << " (" << id << ") - " << description
-                << ", Model: " << base_model << "\n";
       return nlohmann::ordered_json{};
+    }
+
+    /**
+     * @brief Get per-stream dataset metadata for MCAP recording
+     *
+     * @return JSON indicating a mobile base is present with its velocity feature names
+     */
+    nlohmann::ordered_json get_stream_info() const override {
+      nlohmann::ordered_json info;
+      info["has_mobile_base"] = true;
+      info["base_velocity_names"] = nlohmann::json::array({"linear_vel", "angular_vel"});
+      return info;
     }
   };
 

--- a/include/trossen_sdk/hw/camera/opencv_producer.hpp
+++ b/include/trossen_sdk/hw/camera/opencv_producer.hpp
@@ -116,6 +116,25 @@ public:
       features["observation.images." + id] = camera_feature;
       return features;
     }
+
+    /**
+     * @brief Get per-stream dataset metadata for MCAP recording
+     *
+     * @return JSON with "cameras.<camera_id>" containing width, height, fps, etc.
+     */
+    nlohmann::ordered_json get_stream_info() const override {
+      nlohmann::ordered_json info;
+      info["cameras"][id] = {
+          {"width", width},
+          {"height", height},
+          {"fps", fps},
+          {"channels", channels},
+          {"codec", codec},
+          {"pix_fmt", pix_fmt},
+          {"is_depth_map", is_depth_map},
+          {"has_audio", has_audio}};
+      return info;
+    }
   };
 
   /**

--- a/include/trossen_sdk/hw/camera/realsense_depth_producer.hpp
+++ b/include/trossen_sdk/hw/camera/realsense_depth_producer.hpp
@@ -109,6 +109,25 @@ public:
       features["observation.images." + id] = camera_feature;
       return features;
     }
+
+    /**
+     * @brief Get per-stream dataset metadata for MCAP recording
+     *
+     * @return JSON with "cameras.<camera_id>" containing width, height, fps, etc.
+     */
+    nlohmann::ordered_json get_stream_info() const override {
+      nlohmann::ordered_json info;
+      info["cameras"][id] = {
+          {"width", width},
+          {"height", height},
+          {"fps", fps},
+          {"channels", channels},
+          {"codec", codec},
+          {"pix_fmt", pix_fmt},
+          {"is_depth_map", is_depth_map},
+          {"has_audio", has_audio}};
+      return info;
+    }
   };
 
   /**

--- a/include/trossen_sdk/hw/camera/realsense_producer.hpp
+++ b/include/trossen_sdk/hw/camera/realsense_producer.hpp
@@ -113,6 +113,25 @@ public:
       features["observation.images." + id] = camera_feature;
       return features;
     }
+
+    /**
+     * @brief Get per-stream dataset metadata for MCAP recording
+     *
+     * @return JSON with "cameras.<camera_id>" containing width, height, fps, etc.
+     */
+    nlohmann::ordered_json get_stream_info() const override {
+      nlohmann::ordered_json info;
+      info["cameras"][id] = {
+          {"width", width},
+          {"height", height},
+          {"fps", fps},
+          {"channels", channels},
+          {"codec", codec},
+          {"pix_fmt", pix_fmt},
+          {"is_depth_map", is_depth_map},
+          {"has_audio", has_audio}};
+      return info;
+    }
   };
 
   /**

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -80,9 +80,26 @@ public:
     /**
      * @brief Get producer info as JSON
      *
+     * Features JSON for use in LeRobot info.json (e.g. action, observation.state, camera features).
+     *
      * @return JSON object containing producer information
      */
     virtual nlohmann::ordered_json get_info() const {
+      return nlohmann::ordered_json{};
+    }
+
+    /**
+     * @brief Get per-stream dataset metadata for MCAP recording
+     *
+     * Returns a JSON object with stream and sensor info for use as MCAP file-level metadata.
+     * The object may contain:
+     *   - "streams": { "<stream_id>": { "joint_names": [...] } }
+     *   - "cameras": { "<camera_id>": { "width", "height", "fps", "channels", ... } }
+     *   - "has_mobile_base": true
+     *
+     * @return JSON object with dataset stream/sensor metadata, or empty if not applicable
+     */
+    virtual nlohmann::ordered_json get_stream_info() const {
       return nlohmann::ordered_json{};
     }
   };

--- a/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp
@@ -221,6 +221,9 @@ private:
 
   /// @brief Statistics about written records
   Stats stats_{};
+
+  /// @brief Cached producer metadata for writing dataset info to MCAP on open
+  ProducerMetadataList producer_metadata_;
 };
 
 }  // namespace trossen::io::backends

--- a/scripts/trossen_mcap_to_lerobot_v2.cpp
+++ b/scripts/trossen_mcap_to_lerobot_v2.cpp
@@ -595,6 +595,33 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
     return 1;
   }
 
+  // Read trossen_sdk_recording metadata (contains dataset_info with joint names, camera specs)
+  nlohmann::json mcap_dataset_info;
+  auto* data_source = reader.dataSource();
+  const auto& meta_indexes = reader.metadataIndexes();
+  auto range = meta_indexes.equal_range("trossen_sdk_recording");
+  for (auto it = range.first; it != range.second; ++it) {
+    mcap::Record raw_record;
+    auto rs = mcap::McapReader::ReadRecord(*data_source, it->second.offset, &raw_record);
+    if (!rs.ok()) continue;
+    mcap::Metadata meta_record;
+    rs = mcap::McapReader::ParseMetadata(raw_record, &meta_record);
+    if (!rs.ok()) continue;
+    auto info_it = meta_record.metadata.find("dataset_info");
+    if (info_it != meta_record.metadata.end()) {
+      try {
+        mcap_dataset_info = nlohmann::json::parse(info_it->second);
+        std::cout << "  ✓ Found MCAP dataset_info metadata\n";
+        if (mcap_dataset_info.contains("robot_name")) {
+          cfg.robot_name = mcap_dataset_info["robot_name"].get<std::string>();
+          std::cout << "    Robot name from MCAP: " << cfg.robot_name << "\n";
+        }
+      } catch (const std::exception& e) {
+        std::cerr << "  Warning: Failed to parse dataset_info metadata: " << e.what() << "\n";
+      }
+    }
+  }
+
   std::map<mcap::ChannelId, std::string> channel_id_to_stream;
   std::map<mcap::ChannelId, std::string> camera_channels;
   mcap::ChannelId slate_base_channel_id = 0;
@@ -1350,16 +1377,38 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
       }
     }
 
-    // Build observation.state feature
-    nlohmann::json obs_names = nlohmann::json::array();
-    for (const auto& follower_stream : cfg.follower_streams) {
-      std::string arm_name = follower_stream;
+    // Helper: get joint names for a stream from MCAP metadata, or fall back to positional names
+    auto get_joint_names = [&](const std::string& stream_id, int n) -> nlohmann::json {
+      if (!mcap_dataset_info.empty() &&
+          mcap_dataset_info.contains("streams") &&
+          mcap_dataset_info["streams"].contains(stream_id) &&
+          mcap_dataset_info["streams"][stream_id].contains("joint_names")) {
+        return mcap_dataset_info["streams"][stream_id]["joint_names"];
+      }
+      // Fallback: generate positional names prefixed with arm name (stripped of role prefix)
+      nlohmann::json names = nlohmann::json::array();
+      std::string arm_name = stream_id;
       size_t underscore_pos = arm_name.find('_');
       if (underscore_pos != std::string::npos) {
         arm_name = arm_name.substr(underscore_pos + 1);
       }
-      for (int i = 0; i < joints_per_stream; ++i) {
-        obs_names.push_back(arm_name + "_joint_" + std::to_string(i));
+      for (int i = 0; i < n; ++i) {
+        names.push_back(arm_name + "_joint_" + std::to_string(i));
+      }
+      return names;
+    };
+
+    // Base velocity names (from MCAP metadata or default)
+    std::vector<std::string> base_vel_names = {"linear_vel", "angular_vel"};
+    if (!mcap_dataset_info.empty() && mcap_dataset_info.contains("base_velocity_names")) {
+      base_vel_names = mcap_dataset_info["base_velocity_names"].get<std::vector<std::string>>();
+    }
+
+    // Build observation.state feature
+    nlohmann::json obs_names = nlohmann::json::array();
+    for (const auto& follower_stream : cfg.follower_streams) {
+      for (const auto& n : get_joint_names(follower_stream, joints_per_stream)) {
+        obs_names.push_back(n);
       }
     }
 
@@ -1367,9 +1416,8 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
 
     // Add base velocities at the end if mobile robot
     if (has_slate_base) {
-      obs_names.push_back("linear_vel");
-      obs_names.push_back("angular_vel");
-      obs_state_dim += 2;
+      for (const auto& n : base_vel_names) obs_names.push_back(n);
+      obs_state_dim += static_cast<int>(base_vel_names.size());
     }
 
     features["observation.state"]["dtype"] = "float32";
@@ -1379,13 +1427,8 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
     // Build action feature
     nlohmann::json action_names = nlohmann::json::array();
     for (const auto& leader_stream : cfg.leader_streams) {
-      std::string arm_name = leader_stream;
-      size_t underscore_pos = arm_name.find('_');
-      if (underscore_pos != std::string::npos) {
-        arm_name = arm_name.substr(underscore_pos + 1);
-      }
-      for (int i = 0; i < joints_per_stream; ++i) {
-        action_names.push_back(arm_name + "_joint_" + std::to_string(i));
+      for (const auto& n : get_joint_names(leader_stream, joints_per_stream)) {
+        action_names.push_back(n);
       }
     }
 
@@ -1393,9 +1436,8 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
 
     // Add base velocities at the end if mobile robot
     if (has_slate_base) {
-      action_names.push_back("linear_vel");
-      action_names.push_back("angular_vel");
-      action_dim += 2;
+      for (const auto& n : base_vel_names) action_names.push_back(n);
+      action_dim += static_cast<int>(base_vel_names.size());
     }
     features["action"]["dtype"] = "float32";
     features["action"]["shape"] = nlohmann::json::array({action_dim});
@@ -1405,16 +1447,36 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
     for (const auto& [channel_id, camera_name] : camera_channels) {
       std::string obs_key = "observation.images." + camera_name;
       features[obs_key]["dtype"] = "video";
-      features[obs_key]["shape"] = nlohmann::json::array({480, 640, 3});
       features[obs_key]["names"] = nlohmann::json::array({"height", "width", "channels"});
-      features[obs_key]["info"]["video.fps"] = 30.0;
-      features[obs_key]["info"]["video.height"] = 480;
-      features[obs_key]["info"]["video.width"] = 640;
-      features[obs_key]["info"]["video.channels"] = 3;
-      features[obs_key]["info"]["video.codec"] = "av1";
-      features[obs_key]["info"]["video.pix_fmt"] = "yuv420p";
-      features[obs_key]["info"]["video.is_depth_map"] = false;
-      features[obs_key]["info"]["has_audio"] = false;
+
+      // Use camera specs from MCAP metadata if available, otherwise fall back to defaults
+      if (!mcap_dataset_info.empty() &&
+          mcap_dataset_info.contains("cameras") &&
+          mcap_dataset_info["cameras"].contains(camera_name)) {
+        const auto& cam = mcap_dataset_info["cameras"][camera_name];
+        int h = cam.value("height", 480);
+        int w = cam.value("width", 640);
+        int ch = cam.value("channels", 3);
+        features[obs_key]["shape"] = nlohmann::json::array({h, w, ch});
+        features[obs_key]["info"]["video.fps"] = cam.value("fps", 30);
+        features[obs_key]["info"]["video.height"] = h;
+        features[obs_key]["info"]["video.width"] = w;
+        features[obs_key]["info"]["video.channels"] = ch;
+        features[obs_key]["info"]["video.codec"] = cam.value("codec", "av1");
+        features[obs_key]["info"]["video.pix_fmt"] = cam.value("pix_fmt", "yuv420p");
+        features[obs_key]["info"]["video.is_depth_map"] = cam.value("is_depth_map", false);
+        features[obs_key]["info"]["has_audio"] = cam.value("has_audio", false);
+      } else {
+        features[obs_key]["shape"] = nlohmann::json::array({480, 640, 3});
+        features[obs_key]["info"]["video.fps"] = 30.0;
+        features[obs_key]["info"]["video.height"] = 480;
+        features[obs_key]["info"]["video.width"] = 640;
+        features[obs_key]["info"]["video.channels"] = 3;
+        features[obs_key]["info"]["video.codec"] = "av1";
+        features[obs_key]["info"]["video.pix_fmt"] = "yuv420p";
+        features[obs_key]["info"]["video.is_depth_map"] = false;
+        features[obs_key]["info"]["has_audio"] = false;
+      }
     }
 
     // Add standard metadata features (timestamp, frame_index, episode_index, index, task_index)

--- a/scripts/trossen_mcap_to_lerobot_v2.cpp
+++ b/scripts/trossen_mcap_to_lerobot_v2.cpp
@@ -595,23 +595,44 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
     return 1;
   }
 
-  // Read trossen_sdk_recording metadata (contains dataset_info with joint names, camera specs)
+  // ────────────────────────────────────────────────────────────────────────────
+  // PHASE 1: Extract embedded metadata from MCAP file
+  // ────────────────────────────────────────────────────────────────────────────
+  // The MCAP file may contain a "trossen_sdk_recording" metadata record with a
+  // "dataset_info" JSON blob. This includes:
+  //   - robot_name: e.g., "trossen_solo_ai", "trossen_mobile_ai"
+  //   - streams: per-stream joint names (e.g., streams.leader_left.joint_names)
+  //   - cameras: per-camera specs (height, width, fps, codec)
+  //   - base_velocity_names: names for mobile base velocity dimensions
+  // If present, this metadata is used to populate info.json with accurate names
+  // instead of generic placeholders like "joint_0", "joint_1", etc.
+  // ────────────────────────────────────────────────────────────────────────────
   nlohmann::json mcap_dataset_info;
   auto* data_source = reader.dataSource();
   const auto& meta_indexes = reader.metadataIndexes();
+
+  // Find all metadata records named "trossen_sdk_recording"
   auto range = meta_indexes.equal_range("trossen_sdk_recording");
   for (auto it = range.first; it != range.second; ++it) {
+    // Read the raw record from the MCAP file at the indexed offset
     mcap::Record raw_record;
     auto rs = mcap::McapReader::ReadRecord(*data_source, it->second.offset, &raw_record);
     if (!rs.ok()) continue;
+
+    // Parse the raw record into a structured Metadata object
     mcap::Metadata meta_record;
     rs = mcap::McapReader::ParseMetadata(raw_record, &meta_record);
     if (!rs.ok()) continue;
+
+    // Look for the "dataset_info" key within the metadata key-value pairs
     auto info_it = meta_record.metadata.find("dataset_info");
     if (info_it != meta_record.metadata.end()) {
       try {
+        // Parse the JSON string into our mcap_dataset_info object
         mcap_dataset_info = nlohmann::json::parse(info_it->second);
         std::cout << "  ✓ Found MCAP dataset_info metadata\n";
+
+        // Update robot name from metadata if available
         if (mcap_dataset_info.contains("robot_name")) {
           cfg.robot_name = mcap_dataset_info["robot_name"].get<std::string>();
           std::cout << "    Robot name from MCAP: " << cfg.robot_name << "\n";
@@ -622,12 +643,22 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
     }
   }
 
-  std::map<mcap::ChannelId, std::string> channel_id_to_stream;
-  std::map<mcap::ChannelId, std::string> camera_channels;
-  mcap::ChannelId slate_base_channel_id = 0;
-  bool has_slate_base = false;
-  std::vector<std::string> detected_leader_streams;
-  std::vector<std::string> detected_follower_streams;
+  // ────────────────────────────────────────────────────────────────────────────
+  // PHASE 2: Initialize channel tracking maps for message routing
+  // ────────────────────────────────────────────────────────────────────────────
+  // These maps associate MCAP channel IDs with semantic stream identifiers:
+  //   - channel_id_to_stream: Joint state channels → stream names (e.g., "leader_left")
+  //   - camera_channels: Image channels → camera names (e.g., "cam_high")
+  //   - slate_base_channel_id: Mobile base odometry channel (if present)
+  // The leader/follower vectors accumulate detected arm streams for later use
+  // in determining which streams provide actions vs. observations.
+  // ────────────────────────────────────────────────────────────────────────────
+  std::map<mcap::ChannelId, std::string> channel_id_to_stream;  // Joint channels
+  std::map<mcap::ChannelId, std::string> camera_channels;       // Camera channels
+  mcap::ChannelId slate_base_channel_id = 0;                    // Mobile base channel
+  bool has_slate_base = false;                                  // Is this a mobile robot?
+  std::vector<std::string> detected_leader_streams;             // Teleoperation input arms
+  std::vector<std::string> detected_follower_streams;           // Robot output arms
 
   std::cout << "  Available channels:\n";
   for (const auto& [channel_id, channel_ptr] : reader.channels()) {

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -13,6 +13,7 @@
 
 #include "JointState.pb.h"
 #include "Odometry2D.pb.h"
+#include "nlohmann/json.hpp"
 #include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp"
@@ -23,8 +24,8 @@ namespace trossen::io::backends {
 REGISTER_BACKEND(TrossenMCAPBackend, "trossen_mcap")
 
 TrossenMCAPBackend::TrossenMCAPBackend(
-  const ProducerMetadataList&)
-  : io::Backend() {
+  const ProducerMetadataList& producer_metadata)
+  : io::Backend(), producer_metadata_(producer_metadata) {
   // This allows us to access the global configuration for the TrossenMCAP backend
   // without passing it explicitly.
   cfg_ = trossen::configuration::GlobalConfig::instance()
@@ -119,9 +120,42 @@ bool TrossenMCAPBackend::open() {
   std::map<std::string, std::string> metadata;
   metadata["tool_version"] = trossen::core::version();
   metadata["dataset_id"] = cfg_->dataset_id;
+  metadata["robot_name"] = cfg_->robot_name;
   metadata["episode_index"] = std::to_string(episode_index_);
   auto now = trossen::data::now_real();
   metadata["recording_start_time"] = std::to_string(now.to_ns());
+
+  // Build dataset_info JSON from producer metadata (joint names, camera specs, etc.)
+  nlohmann::ordered_json dataset_info;
+  dataset_info["robot_name"] = cfg_->robot_name;
+
+  for (const auto& producer_meta : producer_metadata_) {
+    if (!producer_meta) continue;
+    nlohmann::ordered_json stream_info = producer_meta->get_stream_info();
+    if (stream_info.empty()) continue;
+
+    // Merge "streams" entries
+    if (stream_info.contains("streams")) {
+      for (auto& [key, val] : stream_info["streams"].items()) {
+        dataset_info["streams"][key] = val;
+      }
+    }
+    // Merge "cameras" entries
+    if (stream_info.contains("cameras")) {
+      for (auto& [key, val] : stream_info["cameras"].items()) {
+        dataset_info["cameras"][key] = val;
+      }
+    }
+    // Mobile base flag
+    if (stream_info.value("has_mobile_base", false)) {
+      dataset_info["has_mobile_base"] = true;
+      if (stream_info.contains("base_velocity_names")) {
+        dataset_info["base_velocity_names"] = stream_info["base_velocity_names"];
+      }
+    }
+  }
+
+  metadata["dataset_info"] = dataset_info.dump();
 
   auto st = writer_->writeMetadata("trossen_sdk_recording", metadata.begin(), metadata.end());
   if (st != foxglove::FoxgloveError::Ok) {

--- a/src/hw/arm/arm_producer.cpp
+++ b/src/hw/arm/arm_producer.cpp
@@ -53,12 +53,12 @@ TrossenArmProducer::TrossenArmProducer(
   metadata_.id = cfg_.stream_id;
   metadata_.name = "Trossen Arm Producer";
   metadata_.description = "Produces joint states from a Trossen Arm via TrossenArmDriver";
-  // TODO(shantanuparab-tr): Extract from driver / User Config
   metadata_.arm_model = "WIDOWX_AI";
-  // TODO(shantanuparab-tr): Extract from driver / User Config
-  metadata_.joint_names = {
-    "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7"};
-  // TODO(shantanuparab-tr): Extract from driver / User Config
+  size_t n = driver_->get_num_joints();
+  metadata_.joint_names.clear();
+  for (size_t i = 0; i < n; ++i) {
+    metadata_.joint_names.push_back("joint_" + std::to_string(i));
+  }
   metadata_.gripper_type = "STANDARD";
 }
 


### PR DESCRIPTION
### TL;DR

Added metadata collection and serialization for MCAP recording to support LeRobot dataset conversion with proper joint names, camera specifications, and mobile base information.

### What changed?

- Added `get_stream_info()` method to all producer classes to return dataset-specific metadata (joint names, camera specs, mobile base info)
- Modified `TrossenArmProducer` to dynamically generate joint names based on driver joint count and return LeRobot-compatible feature format in `get_info()`
- Updated MCAP backend to collect producer metadata on initialization and write it as `dataset_info` in MCAP file metadata
- Enhanced MCAP to LeRobot conversion script to read and utilize the embedded metadata for accurate joint names, camera specifications, and base velocity names instead of using hardcoded fallbacks

### How to test?

1. Record an MCAP file with the updated SDK - verify that `dataset_info` metadata is present in the file
2. Convert the MCAP to LeRobot format and check that the `info.json` contains correct joint names matching the actual robot configuration
3. Test with different camera configurations to ensure camera specifications are properly preserved
4. Verify mobile base recordings include correct velocity field names

### Why make this change?

This change eliminates hardcoded assumptions in the MCAP to LeRobot conversion process by embedding the actual robot configuration metadata directly in MCAP files. This ensures that converted datasets have accurate feature names and specifications that match the recorded robot, making the datasets more reliable and self-documenting for machine learning applications.