### PR TITLE
Add PushProducerRegistry for factory-based push producer management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(trossen_sdk SHARED
   src/hw/camera/mock_synced_producer.cpp
   src/runtime/session_manager.cpp
   src/runtime/producer_registry.cpp
+  src/runtime/push_producer_registry.cpp
   src/utils/app_utils.cpp
 )
 

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -164,6 +164,13 @@ public:
   virtual void stop() = 0;
 
   /**
+   * @brief Get producer metadata
+   *
+   * @return Shared pointer to ProducerMetadata, or nullptr if not applicable
+   */
+  virtual std::shared_ptr<PolledProducer::ProducerMetadata> metadata() const { return nullptr; }
+
+  /**
    * @brief Get producer statistics
    *
    * @return const reference to ProducerStats

--- a/include/trossen_sdk/runtime/push_producer_registry.hpp
+++ b/include/trossen_sdk/runtime/push_producer_registry.hpp
@@ -1,0 +1,129 @@
+/**
+ * @file push_producer_registry.hpp
+ * @brief Factory registry for push producer types
+ */
+
+#ifndef TROSSEN_SDK__RUNTIME__PUSH_PRODUCER_REGISTRY_HPP_
+#define TROSSEN_SDK__RUNTIME__PUSH_PRODUCER_REGISTRY_HPP_
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::runtime {
+
+/**
+ * @brief Static registry for push producer factory functions
+ *
+ * Push producer implementations register themselves at static initialization time.
+ *
+ * Key Design Decision: Factory does NOT take polling period parameter. Push producers manage
+ * their own threads and timing internally. This maintains separation of concerns.
+ */
+class PushProducerRegistry {
+public:
+  /**
+   * @brief Factory function signature for creating push producer instances
+   *
+   * @param hardware Hardware component pointer (may be nullptr for mock producers)
+   * @param config JSON configuration object specific to the producer type
+   * @return Shared pointer to created push producer instance
+   */
+  using FactoryFunc = std::function<std::shared_ptr<hw::PushProducer>(
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config)>;
+
+  /**
+   * @brief Register a push producer factory function
+   *
+   * @param type Push producer type string (e.g., "realsense_depth")
+   * @param factory Factory function that creates push producer instances
+   *
+   * @throws std::runtime_error if type is already registered
+   *
+   * @note This should be called during static initialization, typically using
+   *       REGISTER_PUSH_PRODUCER macro in the producer implementation file.
+   */
+  static void register_producer(const std::string& type, FactoryFunc factory);
+
+  /**
+   * @brief Create a push producer instance by type
+   *
+   * @param type Push producer type string
+   * @param hardware Hardware component
+   * @param config Producer-specific configuration
+   *
+   * @return Shared pointer to created push producer instance
+   *
+   * @throws std::runtime_error if type is not registered
+   *
+   * @note The hardware parameter may be nullptr for producers that do not require hardware
+   *       (e.g. mock producers).
+   */
+  static std::shared_ptr<hw::PushProducer> create(
+    const std::string& type,
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config);
+
+  /**
+   * @brief Check if a push producer type is registered
+   *
+   * @param type Push producer type string
+   * @return true if the type is registered, false otherwise
+   */
+  static bool is_registered(const std::string& type);
+
+  /**
+   * @brief Get list of all registered push producer types
+   *
+   * @return Vector of registered type strings
+   */
+  static std::vector<std::string> get_registered_types();
+
+private:
+  static std::map<std::string, FactoryFunc>& get_registry();
+};
+
+/**
+ * @brief Macro to register a push producer type with the PushProducerRegistry
+ *
+ * Creates a static registrar object that registers the push producer factory function during
+ * static initialization. Use this in your push producer implementation (.cpp) file.
+ *
+ * @param ClassName The push producer class name (e.g., RealsenseDepthProducer)
+ * @param TypeString The type string for this producer (e.g., "realsense_depth")
+ *
+ * Example usage:
+ * @code
+ * // In realsense_depth_producer.cpp namespace trossen::hw::depth {
+ * REGISTER_PUSH_PRODUCER(RealsenseDepthProducer, "realsense_depth")
+ * }
+ * @endcode
+ */
+#define REGISTER_PUSH_PRODUCER(ClassName, TypeString)                                         \
+  namespace {                                                                                  \
+  struct ClassName##PushRegistrar {                                                            \
+    ClassName##PushRegistrar() {                                                               \
+      ::trossen::runtime::PushProducerRegistry::register_producer(                            \
+        TypeString,                                                                            \
+        [](std::shared_ptr<::trossen::hw::HardwareComponent> hw,                              \
+           const nlohmann::json& cfg)                                                          \
+             -> std::shared_ptr<::trossen::hw::PushProducer> {                                \
+          return std::make_shared<ClassName>(hw, cfg);                                         \
+        });                                                                                    \
+    }                                                                                          \
+  };                                                                                           \
+  static ClassName##PushRegistrar ClassName##_push_registrar_instance;                        \
+  }  /* anonymous namespace */
+
+}  // namespace trossen::runtime
+
+#endif  // TROSSEN_SDK__RUNTIME__PUSH_PRODUCER_REGISTRY_HPP_

--- a/src/runtime/push_producer_registry.cpp
+++ b/src/runtime/push_producer_registry.cpp
@@ -1,0 +1,63 @@
+/**
+ * @file push_producer_registry.cpp
+ * @brief Implementation of PushProducerRegistry
+ */
+
+#include <iostream>
+
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
+
+namespace trossen::runtime {
+
+std::map<std::string, PushProducerRegistry::FactoryFunc>&
+PushProducerRegistry::get_registry() {
+  static std::map<std::string, FactoryFunc> registry;
+  return registry;
+}
+
+void PushProducerRegistry::register_producer(const std::string& type, FactoryFunc factory) {
+  auto& registry = get_registry();
+
+  if (registry.find(type) != registry.end()) {
+    throw std::runtime_error("Push producer type already registered: " + type);
+  }
+
+  registry[type] = factory;
+  std::cout << "Registered push producer type: " << type << std::endl;
+}
+
+std::shared_ptr<hw::PushProducer> PushProducerRegistry::create(
+  const std::string& type,
+  std::shared_ptr<hw::HardwareComponent> hardware,
+  const nlohmann::json& config)
+{
+  auto& registry = get_registry();
+  auto it = registry.find(type);
+
+  if (it == registry.end()) {
+    throw std::runtime_error("Push producer type not registered: " + type);
+  }
+
+  // Call factory function
+  auto producer = it->second(hardware, config);
+
+  if (!producer) {
+    throw std::runtime_error("Failed to create push producer of type: " + type);
+  }
+
+  return producer;
+}
+
+bool PushProducerRegistry::is_registered(const std::string& type) {
+  return get_registry().find(type) != get_registry().end();
+}
+
+std::vector<std::string> PushProducerRegistry::get_registered_types() {
+  std::vector<std::string> types;
+  for (const auto& [type, _] : get_registry()) {
+    types.push_back(type);
+  }
+  return types;
+}
+
+}  // namespace trossen::runtime

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,9 +24,19 @@ add_executable(test_backend_registry test_backend_registry.cpp)
 target_link_libraries(test_backend_registry PRIVATE trossen_sdk GTest::gtest_main)
 add_test(NAME test_backend_registry COMMAND test_backend_registry)
 
+add_executable(test_push_producer_registry test_push_producer_registry.cpp)
+target_link_libraries(test_push_producer_registry PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_push_producer_registry COMMAND test_push_producer_registry)
+
+add_executable(test_push_producer_base test_push_producer_base.cpp)
+target_link_libraries(test_push_producer_base PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_push_producer_base COMMAND test_push_producer_base)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
 gtest_discover_tests(test_record)
 gtest_discover_tests(test_null_backend)
 gtest_discover_tests(test_backend_registry)
+gtest_discover_tests(test_push_producer_registry)
+gtest_discover_tests(test_push_producer_base)

--- a/tests/test_push_producer_base.cpp
+++ b/tests/test_push_producer_base.cpp
@@ -1,0 +1,208 @@
+/**
+ * @file test_push_producer_base.cpp
+ * @brief Unit tests for PushProducer base class contract
+ *
+ * Tests the abstract PushProducer interface contract using a minimal concrete
+ * implementation to verify default behavior, statistics tracking, and
+ * start/stop lifecycle semantics.
+ */
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+using trossen::data::ImageRecord;
+using trossen::data::RecordBase;
+using trossen::hw::PushProducer;
+using trossen::hw::ProducerStats;
+
+// Minimal concrete PushProducer that emits a configurable number of records on start()
+class TestPushProducer : public PushProducer {
+public:
+  TestPushProducer() = default;
+  ~TestPushProducer() override { stop(); }
+
+  bool start(
+    const std::function<void(std::shared_ptr<RecordBase>)>& emit) override
+  {
+    if (running_.load()) {
+      return false;  // already running
+    }
+    running_.store(true);
+    done_.store(false);
+
+    thread_ = std::thread([this, emit]() {
+      for (int i = 0; i < records_to_emit_ && running_.load(); ++i) {
+        auto rec = std::make_shared<ImageRecord>();
+        rec->seq = seq_++;
+        rec->id = "test_stream";
+        emit(rec);
+        ++stats_.produced;
+      }
+      done_.store(true);
+    });
+    return true;
+  }
+
+  void stop() override {
+    running_.store(false);
+    if (thread_.joinable()) {
+      thread_.join();
+    }
+  }
+
+  /// @brief Block until the producer thread finishes emitting all records
+  void wait_until_done() {
+    while (!done_.load()) {
+      std::this_thread::yield();
+    }
+  }
+
+  // Expose for test configuration
+  int records_to_emit_{0};
+
+private:
+  std::atomic<bool> running_{false};
+  std::atomic<bool> done_{true};
+  std::thread thread_;
+};
+
+// ============================================================================
+// Default behavior tests
+// ============================================================================
+
+TEST(PushProducerBaseTest, DefaultMetadataReturnsNullptr) {
+  TestPushProducer producer;
+  EXPECT_EQ(producer.metadata(), nullptr);
+}
+
+TEST(PushProducerBaseTest, DefaultStatsAreZero) {
+  TestPushProducer producer;
+  const auto& s = producer.stats();
+
+  EXPECT_EQ(s.produced, 0);
+  EXPECT_EQ(s.dropped, 0);
+  EXPECT_EQ(s.warmup_discarded, 0);
+}
+
+// ============================================================================
+// Lifecycle tests
+// ============================================================================
+
+TEST(PushProducerBaseTest, StartAndStopWithNoEmits) {
+  TestPushProducer producer;
+  producer.records_to_emit_ = 0;
+
+  std::vector<std::shared_ptr<RecordBase>> received;
+  bool ok = producer.start([&](std::shared_ptr<RecordBase> r) {
+    received.push_back(std::move(r));
+  });
+
+  EXPECT_TRUE(ok);
+  producer.stop();
+
+  EXPECT_EQ(received.size(), 0);
+  EXPECT_EQ(producer.stats().produced, 0);
+}
+
+TEST(PushProducerBaseTest, StartEmitsRecordsAndStop) {
+  TestPushProducer producer;
+  producer.records_to_emit_ = 5;
+
+  std::vector<std::shared_ptr<RecordBase>> received;
+  bool ok = producer.start([&](std::shared_ptr<RecordBase> r) {
+    received.push_back(std::move(r));
+  });
+
+  EXPECT_TRUE(ok);
+  producer.wait_until_done();
+  producer.stop();
+
+  EXPECT_EQ(received.size(), 5);
+  EXPECT_EQ(producer.stats().produced, 5);
+}
+
+TEST(PushProducerBaseTest, DoubleStartReturnsFalse) {
+  TestPushProducer producer;
+  producer.records_to_emit_ = 100;  // emit enough to keep the thread alive
+
+  bool first = producer.start([](std::shared_ptr<RecordBase>) {});
+  EXPECT_TRUE(first);
+
+  bool second = producer.start([](std::shared_ptr<RecordBase>) {});
+  EXPECT_FALSE(second);
+
+  producer.stop();
+}
+
+TEST(PushProducerBaseTest, StopIsIdempotent) {
+  TestPushProducer producer;
+  producer.records_to_emit_ = 3;
+
+  producer.start([](std::shared_ptr<RecordBase>) {});
+  producer.stop();
+
+  // Second stop should be a no-op (must not crash or throw)
+  EXPECT_NO_THROW(producer.stop());
+  EXPECT_NO_THROW(producer.stop());
+}
+
+TEST(PushProducerBaseTest, StatsAccumulateAcrossLifecycles) {
+  TestPushProducer producer;
+
+  // First lifecycle
+  producer.records_to_emit_ = 3;
+  producer.start([](std::shared_ptr<RecordBase>) {});
+  producer.wait_until_done();
+  producer.stop();
+  EXPECT_EQ(producer.stats().produced, 3);
+
+  // Second lifecycle (stats are cumulative — not reset by stop)
+  producer.records_to_emit_ = 2;
+  producer.start([](std::shared_ptr<RecordBase>) {});
+  producer.wait_until_done();
+  producer.stop();
+  EXPECT_EQ(producer.stats().produced, 5);
+}
+
+// ============================================================================
+// Emit callback tests
+// ============================================================================
+
+TEST(PushProducerBaseTest, EmittedRecordsHaveCorrectSequence) {
+  TestPushProducer producer;
+  producer.records_to_emit_ = 3;
+
+  std::vector<uint64_t> seqs;
+  producer.start([&](std::shared_ptr<RecordBase> r) {
+    seqs.push_back(r->seq);
+  });
+  producer.wait_until_done();
+  producer.stop();
+
+  ASSERT_EQ(seqs.size(), 3);
+  EXPECT_EQ(seqs[0], 0);
+  EXPECT_EQ(seqs[1], 1);
+  EXPECT_EQ(seqs[2], 2);
+}
+
+TEST(PushProducerBaseTest, EmittedRecordsHaveCorrectId) {
+  TestPushProducer producer;
+  producer.records_to_emit_ = 1;
+
+  std::string received_id;
+  producer.start([&](std::shared_ptr<RecordBase> r) {
+    received_id = r->id;
+  });
+  producer.wait_until_done();
+  producer.stop();
+
+  EXPECT_EQ(received_id, "test_stream");
+}

--- a/tests/test_push_producer_registry.cpp
+++ b/tests/test_push_producer_registry.cpp
@@ -1,0 +1,198 @@
+/**
+ * @file test_push_producer_registry.cpp
+ * @brief Unit tests for PushProducerRegistry
+ */
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/hw/producer_base.hpp"
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
+
+using trossen::runtime::PushProducerRegistry;
+
+// Minimal concrete PushProducer for testing purposes
+class MockPushProducer : public trossen::hw::PushProducer {
+public:
+  MockPushProducer() = default;
+  ~MockPushProducer() override = default;
+
+  bool start(
+    const std::function<void(std::shared_ptr<trossen::data::RecordBase>)>&) override
+  {
+    return true;
+  }
+
+  void stop() override {}
+};
+
+// ============================================================================
+// Negative-path tests (no registration required)
+// ============================================================================
+
+TEST(PushProducerRegistryTest, IsNotRegisteredForUnknownType) {
+  EXPECT_FALSE(PushProducerRegistry::is_registered("nonexistent_push_type_xyz"));
+}
+
+TEST(PushProducerRegistryTest, CreateThrowsForUnknownType) {
+  EXPECT_THROW(
+    PushProducerRegistry::create("nonexistent_push_type_xyz", nullptr, {}),
+    std::runtime_error);
+}
+
+TEST(PushProducerRegistryTest, GetRegisteredTypesIsCallable) {
+  // Must not throw; may be empty if no hardware types are compiled in
+  std::vector<std::string> types;
+  EXPECT_NO_THROW(types = PushProducerRegistry::get_registered_types());
+}
+
+// ============================================================================
+// Registration tests (register a mock type once per suite)
+// ============================================================================
+
+class PushProducerRegistryRegistrationTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    // Register a mock producer type once; catch if already registered from
+    // a previous test run (static registry persists across test binaries)
+    try {
+      PushProducerRegistry::register_producer(
+        "mock_push_producer_for_test",
+        [](std::shared_ptr<trossen::hw::HardwareComponent>,
+           const nlohmann::json&)
+          -> std::shared_ptr<trossen::hw::PushProducer>
+        {
+          return std::make_shared<MockPushProducer>();
+        });
+    } catch (const std::runtime_error& e) {
+      // Already registered — ignore duplicate in repeated test runs
+    }
+  }
+};
+
+TEST_F(PushProducerRegistryRegistrationTest, IsRegisteredAfterRegister) {
+  EXPECT_TRUE(PushProducerRegistry::is_registered("mock_push_producer_for_test"));
+}
+
+TEST_F(PushProducerRegistryRegistrationTest, CreateReturnsNonNull) {
+  std::shared_ptr<trossen::hw::PushProducer> producer;
+  EXPECT_NO_THROW(
+    producer = PushProducerRegistry::create(
+      "mock_push_producer_for_test", nullptr, {}));
+  ASSERT_NE(producer, nullptr);
+}
+
+TEST_F(PushProducerRegistryRegistrationTest, RegisteredTypeAppearsInList) {
+  auto types = PushProducerRegistry::get_registered_types();
+  bool found = false;
+  for (const auto& t : types) {
+    if (t == "mock_push_producer_for_test") {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST_F(PushProducerRegistryRegistrationTest, DuplicateRegistrationThrows) {
+  EXPECT_THROW(
+    PushProducerRegistry::register_producer(
+      "mock_push_producer_for_test",
+      [](std::shared_ptr<trossen::hw::HardwareComponent>,
+         const nlohmann::json&)
+        -> std::shared_ptr<trossen::hw::PushProducer>
+      {
+        return std::make_shared<MockPushProducer>();
+      }),
+    std::runtime_error);
+}
+
+// ============================================================================
+// Extended negative-path and edge-case tests
+// ============================================================================
+
+TEST(PushProducerRegistryTest, CreateWithEmptyTypeThrows) {
+  EXPECT_THROW(
+    PushProducerRegistry::create("", nullptr, {}),
+    std::runtime_error);
+}
+
+TEST(PushProducerRegistryTest, IsNotRegisteredForEmptyString) {
+  EXPECT_FALSE(PushProducerRegistry::is_registered(""));
+}
+
+// Factory that returns nullptr should be caught by create()
+class PushProducerRegistryNullFactoryTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    try {
+      PushProducerRegistry::register_producer(
+        "null_factory_producer_for_test",
+        [](std::shared_ptr<trossen::hw::HardwareComponent>,
+           const nlohmann::json&)
+          -> std::shared_ptr<trossen::hw::PushProducer>
+        {
+          return nullptr;  // Deliberately returns null
+        });
+    } catch (const std::runtime_error&) {
+      // Already registered
+    }
+  }
+};
+
+TEST_F(PushProducerRegistryNullFactoryTest, CreateThrowsWhenFactoryReturnsNull) {
+  EXPECT_THROW(
+    PushProducerRegistry::create("null_factory_producer_for_test", nullptr, {}),
+    std::runtime_error);
+}
+
+// Test that create() with nullptr hardware works for mock producers
+TEST_F(PushProducerRegistryRegistrationTest, CreateWithNullHardware) {
+  std::shared_ptr<trossen::hw::PushProducer> producer;
+  EXPECT_NO_THROW(
+    producer = PushProducerRegistry::create(
+      "mock_push_producer_for_test", nullptr, {}));
+  ASSERT_NE(producer, nullptr);
+}
+
+// Test that create() with JSON config passes config through
+TEST_F(PushProducerRegistryRegistrationTest, CreateWithConfig) {
+  nlohmann::json config = {{"stream_id", "test_cam"}, {"fps", 30}};
+  std::shared_ptr<trossen::hw::PushProducer> producer;
+  EXPECT_NO_THROW(
+    producer = PushProducerRegistry::create(
+      "mock_push_producer_for_test", nullptr, config));
+  ASSERT_NE(producer, nullptr);
+}
+
+// Test that multiple registered types appear in the list
+TEST_F(PushProducerRegistryRegistrationTest, MultipleMockTypesCanCoexist) {
+  // Register a second type
+  try {
+    PushProducerRegistry::register_producer(
+      "mock_push_producer_second_for_test",
+      [](std::shared_ptr<trossen::hw::HardwareComponent>,
+         const nlohmann::json&)
+        -> std::shared_ptr<trossen::hw::PushProducer>
+      {
+        return std::make_shared<MockPushProducer>();
+      });
+  } catch (const std::runtime_error&) {
+    // Already registered
+  }
+
+  auto types = PushProducerRegistry::get_registered_types();
+  bool found_first = false;
+  bool found_second = false;
+  for (const auto& t : types) {
+    if (t == "mock_push_producer_for_test") found_first = true;
+    if (t == "mock_push_producer_second_for_test") found_second = true;
+  }
+  EXPECT_TRUE(found_first);
+  EXPECT_TRUE(found_second);
+}


### PR DESCRIPTION
### TL;DR

Added a factory registry system for push producers with automatic registration capabilities and comprehensive test coverage.

### What changed?

- Created `PushProducerRegistry` class that manages factory functions for creating push producer instances by type string
- Added `metadata()` method to `PushProducer` base class that returns producer metadata (defaults to nullptr)
- Implemented `REGISTER_PUSH_PRODUCER` macro for automatic static registration of push producer types
- Added comprehensive unit tests covering registry functionality, producer lifecycle, and error conditions

### How to test?

Run the new test suites:
- `test_push_producer_registry` - Tests registry registration, creation, and error handling
- `test_push_producer_base` - Tests push producer interface contract and lifecycle management

The tests cover positive and negative paths including duplicate registration, unknown types, null factories, and multi-producer scenarios.

### Why make this change?

This establishes a plugin-style architecture for push producers, allowing different hardware implementations to register themselves at compile time and be instantiated dynamically by type string. This pattern enables modular hardware support where producers can be added without modifying core registry code, similar to existing patterns in the codebase.