### PR TITLE
Add push producer lifecycle support to SessionManager with unit tests

### DIFF
--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "trossen_sdk/hw/producer_base.hpp"
-#include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp"
 #include "trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp"
 #include "trossen_sdk/io/sink.hpp"
@@ -341,7 +340,7 @@ private:
   mutable std::mutex episode_mutex_;
 
   /// @brief Current sink instance (per episode)
-  std::unique_ptr<io::Sink> current_sink_;
+  std::shared_ptr<io::Sink> current_sink_;
 
   /// @brief Current backend instance (per episode)
   std::shared_ptr<io::Backend> current_backend_;

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "trossen_sdk/hw/producer_base.hpp"
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp"
 #include "trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp"
 #include "trossen_sdk/io/sink.hpp"
@@ -76,6 +77,18 @@ public:
     std::shared_ptr<hw::PolledProducer> producer,
     std::chrono::milliseconds poll_period,
     const Scheduler::TaskOptions& opts = {});
+
+  /**
+   * @brief Register a push producer to be started during episodes
+   *
+   * Push producers manage their own threads. They are started after the sink is
+   * created and before the scheduler, stopped before the scheduler during episode end.
+   *
+   * @param producer Shared pointer to push producer
+   *
+   * Must be called before start_episode().
+   */
+  void add_push_producer(std::shared_ptr<hw::PushProducer> producer);
 
   /**
    * @brief Start a new episode
@@ -345,6 +358,14 @@ private:
 
   /// @brief Registered producers (persists across episodes)
   std::vector<ProducerTask> producer_tasks_;
+
+  /// @brief Push producer registration info
+  struct PushProducerEntry {
+    std::shared_ptr<hw::PushProducer> producer;
+  };
+
+  /// @brief Registered push producers (persists across episodes)
+  std::vector<PushProducerEntry> push_producer_entries_;
 
   /**
    * @brief Create backend instance for the given episode

--- a/src/backends/lerobot_v2/lerobot_v2_backend.cpp
+++ b/src/backends/lerobot_v2/lerobot_v2_backend.cpp
@@ -328,7 +328,7 @@ nlohmann::ordered_json compute_fixed_size_list_stats(
 // ============================================================================
 
 LeRobotV2Backend::LeRobotV2Backend(
-  ProducerMetadataList metadata = {})
+  ProducerMetadataList metadata)
   : io::Backend(), metadata_(std::move(metadata))
 {
   // This allows us to access the global configuration for the LeRobotV2 backend

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -167,20 +167,32 @@ bool SessionManager::start_episode() {
   }
 
   // Create sink with the backend
-  current_sink_ = std::make_unique<io::Sink>(current_backend_);
+  current_sink_ = std::make_shared<io::Sink>(current_backend_);
   current_sink_->start();
 
   // Capture initial record count for this episode (for stats delta calculation)
   episode_start_record_count_ = current_sink_->processed_count();
 
   // Start push producers (own threads, emit into current sink)
-  auto* sink_ptr = current_sink_.get();
+  // Capture shared_ptr to ensure Sink lifetime outlives any in-flight emit callbacks
+  std::shared_ptr<io::Sink> sink_shared = current_sink_;
   for (const auto& ppe : push_producer_entries_) {
-    ppe.producer->start([sink_ptr](std::shared_ptr<data::RecordBase> rec) {
+    bool started = ppe.producer->start([sink_shared](std::shared_ptr<data::RecordBase> rec) {
       if (rec) {
-        sink_ptr->enqueue(std::move(rec));
+        sink_shared->enqueue(std::move(rec));
       }
     });
+    if (!started) {
+      std::cerr << "Failed to start push producer; aborting episode startup." << std::endl;
+      // Stop any push producers that were already started
+      for (const auto& cleanup_ppe : push_producer_entries_) {
+        cleanup_ppe.producer->stop();
+      }
+      current_sink_->stop();
+      current_sink_.reset();
+      current_backend_.reset();
+      return false;
+    }
   }
 
   // Create and configure scheduler
@@ -269,16 +281,13 @@ void SessionManager::stop_episode() {
     scheduler_.reset();
   }
 
-  // Get the final record count before stopping sink
-  if (current_sink_) {
-    final_records_written_ = current_sink_->processed_count() - episode_start_record_count_;
-  } else {
-    final_records_written_ = 0;
-  }
-  // Stop sink - drain queue and write all pending records
+  // Stop sink - drain queue and write all pending records; count after drain for accuracy
   if (current_sink_) {
     current_sink_->stop();
+    final_records_written_ = current_sink_->processed_count() - episode_start_record_count_;
     current_sink_.reset();
+  } else {
+    final_records_written_ = 0;
   }
 
   // Close backend - flush and finalize the file episode

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -89,6 +89,19 @@ void SessionManager::add_producer(
     });
 }
 
+void SessionManager::add_push_producer(std::shared_ptr<hw::PushProducer> producer) {
+  if (!producer) {
+    throw std::invalid_argument("Cannot add null push producer");
+  }
+
+  if (episode_active_) {
+    throw std::runtime_error(
+      "Cannot add push producers while episode is active. Add before start_episode().");
+  }
+
+  push_producer_entries_.push_back(PushProducerEntry{.producer = std::move(producer)});
+}
+
 bool SessionManager::start_episode() {
   // Guard: already active
   if (episode_active_) {
@@ -110,6 +123,15 @@ bool SessionManager::start_episode() {
       producer_metadata.push_back(polled_producer->metadata());
     }
   }
+
+  // Collect metadata from push producers
+  for (const auto& ppe : push_producer_entries_) {
+    auto meta = ppe.producer->metadata();
+    if (meta) {
+      producer_metadata.push_back(meta);
+    }
+  }
+
   // Create backend
   try {
     current_backend_ = create_backend(producer_metadata);
@@ -150,6 +172,16 @@ bool SessionManager::start_episode() {
 
   // Capture initial record count for this episode (for stats delta calculation)
   episode_start_record_count_ = current_sink_->processed_count();
+
+  // Start push producers (own threads, emit into current sink)
+  auto* sink_ptr = current_sink_.get();
+  for (const auto& ppe : push_producer_entries_) {
+    ppe.producer->start([sink_ptr](std::shared_ptr<data::RecordBase> rec) {
+      if (rec) {
+        sink_ptr->enqueue(std::move(rec));
+      }
+    });
+  }
 
   // Create and configure scheduler
   scheduler_ = std::make_unique<Scheduler>();
@@ -226,7 +258,12 @@ void SessionManager::stop_episode() {
 
   std::cout << "Stopping episode " << next_episode_index_ << "..." << std::endl;
 
-  // Stop scheduler first - prevent new records from being generated
+  // Stop push producers first (they push to the sink; must stop before draining)
+  for (const auto& ppe : push_producer_entries_) {
+    ppe.producer->stop();
+  }
+
+  // Stop scheduler - prevent new records from being generated
   if (scheduler_) {
     scheduler_->stop();
     scheduler_.reset();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,10 @@ add_executable(test_push_producer_base test_push_producer_base.cpp)
 target_link_libraries(test_push_producer_base PRIVATE trossen_sdk GTest::gtest_main)
 add_test(NAME test_push_producer_base COMMAND test_push_producer_base)
 
+add_executable(test_session_manager_push_producer test_session_manager_push_producer.cpp)
+target_link_libraries(test_session_manager_push_producer PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_session_manager_push_producer COMMAND test_session_manager_push_producer)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -40,3 +44,4 @@ gtest_discover_tests(test_null_backend)
 gtest_discover_tests(test_backend_registry)
 gtest_discover_tests(test_push_producer_registry)
 gtest_discover_tests(test_push_producer_base)
+gtest_discover_tests(test_session_manager_push_producer)

--- a/tests/test_session_manager_push_producer.cpp
+++ b/tests/test_session_manager_push_producer.cpp
@@ -1,0 +1,186 @@
+/**
+ * @file test_session_manager_push_producer.cpp
+ * @brief Unit tests for SessionManager push producer lifecycle
+ *
+ * Tests the add_push_producer() validation, push producer start/stop ordering
+ * during episodes, and interaction with the NullBackend.
+ */
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
+
+using trossen::data::ImageRecord;
+using trossen::data::RecordBase;
+using trossen::hw::PushProducer;
+using trossen::runtime::SessionManager;
+
+// ============================================================================
+// Mock push producer that tracks lifecycle events
+// ============================================================================
+
+class LifecycleMockPushProducer : public PushProducer {
+public:
+  LifecycleMockPushProducer() = default;
+  ~LifecycleMockPushProducer() override { stop(); }
+
+  bool start(
+    const std::function<void(std::shared_ptr<RecordBase>)>& emit) override
+  {
+    if (running_.load()) {
+      return false;
+    }
+    ++start_count_;
+    running_.store(true);
+    emit_ = emit;
+
+    // Emit a few records so the sink has something
+    for (int i = 0; i < records_per_episode_; ++i) {
+      auto rec = std::make_shared<ImageRecord>();
+      rec->seq = seq_++;
+      rec->id = "mock_cam";
+      rec->width = 640;
+      rec->height = 480;
+      rec->channels = 3;
+      rec->encoding = "bgr8";
+      rec->image = cv::Mat(480, 640, CV_8UC3, cv::Scalar(0));
+      emit(rec);
+      ++stats_.produced;
+    }
+    return true;
+  }
+
+  void stop() override {
+    if (!running_.load()) {
+      return;
+    }
+    ++stop_count_;
+    running_.store(false);
+  }
+
+  int start_count() const { return start_count_; }
+  int stop_count() const { return stop_count_; }
+  bool is_running() const { return running_.load(); }
+
+  int records_per_episode_{3};
+
+private:
+  std::atomic<bool> running_{false};
+  std::function<void(std::shared_ptr<RecordBase>)> emit_;
+  int start_count_{0};
+  int stop_count_{0};
+};
+
+// ============================================================================
+// Test fixture: loads minimal GlobalConfig with null backend
+// ============================================================================
+
+class SessionManagerPushProducerTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    // Load a minimal config that provides session_manager + null backend
+    nlohmann::json config = {
+      {"session_manager", {
+        {"type", "session_manager"},
+        {"max_duration", 10.0},
+        {"max_episodes", 100},
+        {"backend_type", "null"}
+      }}
+    };
+
+    try {
+      trossen::configuration::GlobalConfig::instance().load_from_json(config);
+    } catch (const std::exception& e) {
+      // May already be loaded from a previous test suite — acceptable
+      std::cerr << "Config load note: " << e.what() << std::endl;
+    }
+  }
+};
+
+// ============================================================================
+// add_push_producer() validation tests
+// ============================================================================
+
+TEST_F(SessionManagerPushProducerTest, AddNullPushProducerThrows) {
+  SessionManager sm;
+  EXPECT_THROW(sm.add_push_producer(nullptr), std::invalid_argument);
+}
+
+TEST_F(SessionManagerPushProducerTest, AddPushProducerBeforeEpisodeSucceeds) {
+  SessionManager sm;
+  auto producer = std::make_shared<LifecycleMockPushProducer>();
+  EXPECT_NO_THROW(sm.add_push_producer(producer));
+}
+
+// ============================================================================
+// Push producer lifecycle during episodes
+// ============================================================================
+
+TEST_F(SessionManagerPushProducerTest, PushProducerStartedOnEpisodeStart) {
+  SessionManager sm;
+  auto producer = std::make_shared<LifecycleMockPushProducer>();
+  sm.add_push_producer(producer);
+
+  EXPECT_EQ(producer->start_count(), 0);
+
+  bool ok = sm.start_episode();
+  ASSERT_TRUE(ok);
+
+  EXPECT_EQ(producer->start_count(), 1);
+  EXPECT_TRUE(producer->is_running());
+
+  sm.stop_episode();
+}
+
+TEST_F(SessionManagerPushProducerTest, PushProducerStoppedOnEpisodeStop) {
+  SessionManager sm;
+  auto producer = std::make_shared<LifecycleMockPushProducer>();
+  sm.add_push_producer(producer);
+
+  sm.start_episode();
+  sm.stop_episode();
+
+  EXPECT_EQ(producer->stop_count(), 1);
+  EXPECT_FALSE(producer->is_running());
+}
+
+TEST_F(SessionManagerPushProducerTest, MultipleEpisodesStartStopPushProducer) {
+  SessionManager sm;
+  auto producer = std::make_shared<LifecycleMockPushProducer>();
+  sm.add_push_producer(producer);
+
+  // Episode 1
+  ASSERT_TRUE(sm.start_episode());
+  EXPECT_EQ(producer->start_count(), 1);
+  sm.stop_episode();
+  EXPECT_EQ(producer->stop_count(), 1);
+
+  // Episode 2
+  ASSERT_TRUE(sm.start_episode());
+  EXPECT_EQ(producer->start_count(), 2);
+  sm.stop_episode();
+  EXPECT_EQ(producer->stop_count(), 2);
+}
+
+TEST_F(SessionManagerPushProducerTest, PushProducerRecordsReachBackend) {
+  SessionManager sm;
+  auto producer = std::make_shared<LifecycleMockPushProducer>();
+  producer->records_per_episode_ = 5;
+  sm.add_push_producer(producer);
+
+  sm.start_episode();
+  sm.stop_episode();
+
+  EXPECT_EQ(producer->stats().produced, 5);
+}

--- a/tests/test_session_manager_push_producer.cpp
+++ b/tests/test_session_manager_push_producer.cpp
@@ -8,7 +8,9 @@
 
 #include <atomic>
 #include <functional>
+#include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -183,4 +185,5 @@ TEST_F(SessionManagerPushProducerTest, PushProducerRecordsReachBackend) {
   sm.stop_episode();
 
   EXPECT_EQ(producer->stats().produced, 5);
+  EXPECT_EQ(sm.stats().records_written_current, 5);
 }


### PR DESCRIPTION
### TL;DR

Added support for push producers in SessionManager with automatic lifecycle management during episodes.

### What changed?

- Added `add_push_producer()` method to SessionManager for registering push producers that manage their own threads
- Push producers are automatically started after sink creation and stopped before scheduler shutdown during episodes
- Push producers emit records directly into the sink via callback mechanism
- Added validation to prevent adding null producers or adding producers during active episodes
- Push producer metadata is collected and included in backend creation

### How to test?

Run the new test suite:
```bash
./test_session_manager_push_producer
```

The tests verify:
- Null producer validation
- Proper start/stop lifecycle during episodes
- Multiple episode handling
- Record emission to backend

### Why make this change?

This enables hardware components that produce data asynchronously (like cameras or sensors) to integrate seamlessly with the session recording system. Push producers can run independently while still participating in the episode lifecycle and having their data captured by the configured backend.