### PR TITLE
Add depth image support for RealSense cameras and LeRobot V2 backend

### DIFF
--- a/examples/realsense_rgb/config.json
+++ b/examples/realsense_rgb/config.json
@@ -1,0 +1,33 @@
+{
+  "robot_name": "realsense_rgb",
+  "hardware": {
+    "cameras": [
+      {
+        "id": "cam_high",
+        "type": "realsense_camera",
+        "serial_number": "000000000000",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "use_depth": false
+      }
+    ]
+  },
+  "producers": [
+    {
+      "type": "realsense_camera",
+      "hardware_id": "cam_high",
+      "stream_id": "cam_high",
+      "encoding": "bgr8",
+      "use_device_time": true,
+      "timeout_ms": 3000
+    }
+  ],
+  "session": {
+    "backend_type": "TrossenMCAP",
+    "max_duration": 30
+  },
+  "mcap_backend": {
+    "root": "data/realsense_rgb"
+  }
+}

--- a/examples/realsense_rgb/config_depth.json
+++ b/examples/realsense_rgb/config_depth.json
@@ -1,0 +1,34 @@
+{
+  "robot_name": "realsense_rgb_depth",
+  "hardware": {
+    "cameras": [
+      {
+        "id": "cam_high",
+        "type": "realsense_camera",
+        "serial_number": "000000000000",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "use_depth": true,
+        "align_depth_to_color": true
+      }
+    ]
+  },
+  "producers": [
+    {
+      "type": "realsense_camera",
+      "hardware_id": "cam_high",
+      "stream_id": "cam_high",
+      "encoding": "bgr8",
+      "use_device_time": true,
+      "timeout_ms": 3000
+    }
+  ],
+  "session": {
+    "backend_type": "TrossenMCAP",
+    "max_duration": 30
+  },
+  "mcap_backend": {
+    "root": "data/realsense_rgb_depth"
+  }
+}

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -46,6 +46,7 @@
 #include "trossen_sdk/hw/hardware_registry.hpp"
 #include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 
 #include "trossen_sdk/utils/app_utils.hpp"
@@ -263,16 +264,26 @@ int main(int argc, char** argv) {
         prod_cfg.to_registry_json());
       mgr.add_producer(base_prod, period);
       std::cout << "  [ok] Mobile base producer (" << prod_cfg.poll_rate_hz << " Hz)\n";
-    } else if (prod_cfg.type == "realsense_camera" || prod_cfg.type == "opencv_camera") {
+    } else if (camera_components.count(prod_cfg.hardware_id)) {
       const auto* cam = camera_cfg_map.at(prod_cfg.hardware_id);
-      auto prod = trossen::runtime::ProducerRegistry::create(
-        prod_cfg.type,
-        camera_components.at(prod_cfg.hardware_id),
-        prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
-      mgr.add_producer(prod, period);
-      std::cout << "  [ok] Camera producer [" << prod_cfg.stream_id << "] ("
-                << prod_cfg.poll_rate_hz << " Hz, "
-                << cam->width << "x" << cam->height << ")\n";
+      if (trossen::runtime::PushProducerRegistry::is_registered(prod_cfg.type)) {
+        auto prod = trossen::runtime::PushProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_push_producer(prod);
+        std::cout << "  [ok] Camera producer (push) [" << prod_cfg.stream_id << "] ("
+                  << cam->width << "x" << cam->height << ")\n";
+      } else {
+        auto prod = trossen::runtime::ProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_producer(prod, period);
+        std::cout << "  [ok] Camera producer [" << prod_cfg.stream_id << "] ("
+                  << prod_cfg.poll_rate_hz << " Hz, "
+                  << cam->width << "x" << cam->height << ")\n";
+      }
     }
   }
 

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -41,6 +41,7 @@
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 
 #include "trossen_sdk/utils/app_utils.hpp"
@@ -227,16 +228,26 @@ int main(int argc, char** argv) {
       mgr.add_producer(prod, period);
       std::cout << "  [ok] Arm producer [" << prod_cfg.stream_id << "] ("
                 << prod_cfg.poll_rate_hz << " Hz)\n";
-    } else if (prod_cfg.type == "realsense_camera" || prod_cfg.type == "opencv_camera") {
+    } else if (camera_components.count(prod_cfg.hardware_id)) {
       const auto* cam = camera_cfg_map.at(prod_cfg.hardware_id);
-      auto prod = trossen::runtime::ProducerRegistry::create(
-        prod_cfg.type,
-        camera_components.at(prod_cfg.hardware_id),
-        prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
-      mgr.add_producer(prod, period);
-      std::cout << "  [ok] Camera producer [" << prod_cfg.stream_id << "] ("
-                << prod_cfg.poll_rate_hz << " Hz, "
-                << cam->width << "x" << cam->height << ")\n";
+      if (trossen::runtime::PushProducerRegistry::is_registered(prod_cfg.type)) {
+        auto prod = trossen::runtime::PushProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_push_producer(prod);
+        std::cout << "  [ok] Camera producer (push) [" << prod_cfg.stream_id << "] ("
+                  << cam->width << "x" << cam->height << ")\n";
+      } else {
+        auto prod = trossen::runtime::ProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_producer(prod, period);
+        std::cout << "  [ok] Camera producer [" << prod_cfg.stream_id << "] ("
+                  << prod_cfg.poll_rate_hz << " Hz, "
+                  << cam->width << "x" << cam->height << ")\n";
+      }
     }
   }
 

--- a/examples/trossen_stationary_ai/config.json
+++ b/examples/trossen_stationary_ai/config.json
@@ -31,7 +31,7 @@
         "width":         640,
         "height":        480,
         "fps":           30,
-        "use_depth":     true
+        "use_depth":     false
       },
       {
         "id":            "camera_low",
@@ -39,7 +39,7 @@
         "width":         640,
         "height":        480,
         "fps":           30,
-        "use_depth":     true
+        "use_depth":     false
       },
       {
         "id":            "camera_left_wrist",
@@ -47,7 +47,7 @@
         "width":         640,
         "height":        480,
         "fps":           30,
-        "use_depth":     true
+        "use_depth":     false
       },
       {
         "id":            "camera_right_wrist",
@@ -55,7 +55,7 @@
         "width":         640,
         "height":        480,
         "fps":           30,
-        "use_depth":     true
+        "use_depth":     false
       }
     ]
   },

--- a/examples/trossen_stationary_ai/config.json
+++ b/examples/trossen_stationary_ai/config.json
@@ -30,28 +30,32 @@
         "serial_number": "128422271347",
         "width":         640,
         "height":        480,
-        "fps":           30
+        "fps":           30,
+        "use_depth":     true
       },
       {
         "id":            "camera_low",
         "serial_number": "218622270304",
         "width":         640,
         "height":        480,
-        "fps":           30
+        "fps":           30,
+        "use_depth":     true
       },
       {
         "id":            "camera_left_wrist",
         "serial_number": "218622274938",
         "width":         640,
         "height":        480,
-        "fps":           30
+        "fps":           30,
+        "use_depth":     true
       },
       {
         "id":            "camera_right_wrist",
         "serial_number": "130322272628",
         "width":         640,
         "height":        480,
-        "fps":           30
+        "fps":           30,
+        "use_depth":     true
       }
     ]
   },

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -42,6 +42,7 @@
 #include "trossen_sdk/hw/hardware_registry.hpp"
 #include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 
 #include "trossen_sdk/utils/app_utils.hpp"
@@ -229,16 +230,26 @@ int main(int argc, char** argv) {
       mgr.add_producer(prod, period);
       std::cout << "  [ok] Arm producer [" << prod_cfg.stream_id << "] ("
                 << prod_cfg.poll_rate_hz << " Hz)\n";
-    } else if (prod_cfg.type == "realsense_camera" || prod_cfg.type == "opencv_camera") {
+    } else if (camera_components.count(prod_cfg.hardware_id)) {
       const auto* cam = camera_cfg_map.at(prod_cfg.hardware_id);
-      auto prod = trossen::runtime::ProducerRegistry::create(
-        prod_cfg.type,
-        camera_components.at(prod_cfg.hardware_id),
-        prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
-      mgr.add_producer(prod, period);
-      std::cout << "  [ok] Camera producer [" << prod_cfg.stream_id << "] ("
-                << prod_cfg.poll_rate_hz << " Hz, "
-                << cam->width << "x" << cam->height << ")\n";
+      if (trossen::runtime::PushProducerRegistry::is_registered(prod_cfg.type)) {
+        auto prod = trossen::runtime::PushProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_push_producer(prod);
+        std::cout << "  [ok] Camera producer (push) [" << prod_cfg.stream_id << "] ("
+                  << cam->width << "x" << cam->height << ")\n";
+      } else {
+        auto prod = trossen::runtime::ProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_producer(prod, period);
+        std::cout << "  [ok] Camera producer [" << prod_cfg.stream_id << "] ("
+                  << prod_cfg.poll_rate_hz << " Hz, "
+                  << cam->width << "x" << cam->height << ")\n";
+      }
     }
   }
 

--- a/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
@@ -98,6 +98,18 @@ inline std::string format_video_filename(int episode_index) {
   return oss.str();
 }
 
+/**
+ * @brief Format a depth image filename (16-bit PNG)
+ *
+ * @param frame_index Frame index (0-based)
+ * @return Formatted depth image filename (e.g., "image_000000.png")
+ */
+inline std::string format_depth_filename(int frame_index) {
+  std::ostringstream oss;
+  oss << "image_" << std::setfill('0') << std::setw(6) << frame_index << ".png";
+  return oss.str();
+}
+
 // ============================================================================
 // LeRobotV2 Statistics and Image Utility Functions
 // ============================================================================

--- a/scripts/trossen_mcap_to_lerobot_v2/config.json
+++ b/scripts/trossen_mcap_to_lerobot_v2/config.json
@@ -9,7 +9,7 @@
     "encode_videos": true,
     "task_name": "perform a generic task",
     "repository_id": "TrossenRoboticsCommunity",
-    "dataset_id": "mcap_converted_dataset",
+    "dataset_id": "mcap_converted_dataset_depth_one_camera",
     "episode_index": 0,
     "chunk_size": 2,
     "robot_name": "trossen_solo_ai",

--- a/scripts/trossen_mcap_to_lerobot_v2/config.json
+++ b/scripts/trossen_mcap_to_lerobot_v2/config.json
@@ -9,7 +9,7 @@
     "encode_videos": true,
     "task_name": "perform a generic task",
     "repository_id": "TrossenRoboticsCommunity",
-    "dataset_id": "mcap_converted_dataset_depth_one_camera",
+    "dataset_id": "mcap_converted_dataset",
     "episode_index": 0,
     "chunk_size": 2,
     "robot_name": "trossen_solo_ai",

--- a/src/backends/lerobot_v2/lerobot_v2_backend.cpp
+++ b/src/backends/lerobot_v2/lerobot_v2_backend.cpp
@@ -1029,6 +1029,29 @@ void LeRobotV2Backend::write_image(const data::RecordBase& base) {
     img_queue_backlog_samples_.fetch_add(1, std::memory_order_relaxed);
   }
   image_queue_cv_.notify_one();
+
+  // Enqueue depth image if available (written as 16-bit PNG to a parallel depth directory)
+  if (img.has_depth()) {
+    const std::string depth_key = img.id + "_depth";
+    auto depth_it = image_dir_cache_.find(depth_key);
+    if (depth_it == image_dir_cache_.end()) {
+      fs::path depth_dir =
+        images_root_ / (img.id + "_depth") / format_episode_folder(episode_index_);
+      std::error_code ec;
+      fs::create_directories(depth_dir, ec);
+      depth_it = image_dir_cache_.emplace(depth_key, std::move(depth_dir)).first;
+    }
+    const fs::path& depth_dir = depth_it->second;
+    fs::path depth_file_path = depth_dir / format_depth_filename(frame_index);
+
+    auto depth_job = ImageJob{depth_file_path, img.depth_image.value()};
+    {
+      std::lock_guard<std::mutex> lk(image_queue_mutex_);
+      image_queue_.push_back(std::move(depth_job));
+      image_queue_enqueue_times_.push_back(enqueue_time);
+    }
+    image_queue_cv_.notify_one();
+  }
 }
 
 void LeRobotV2Backend::image_worker_loop() {

--- a/src/backends/lerobot_v2/lerobot_v2_backend.cpp
+++ b/src/backends/lerobot_v2/lerobot_v2_backend.cpp
@@ -1047,8 +1047,18 @@ void LeRobotV2Backend::write_image(const data::RecordBase& base) {
     auto depth_job = ImageJob{depth_file_path, img.depth_image.value()};
     {
       std::lock_guard<std::mutex> lk(image_queue_mutex_);
-      image_queue_.push_back(std::move(depth_job));
-      image_queue_enqueue_times_.push_back(enqueue_time);
+      if (max_image_queue_cached_ > 0 && image_queue_.size() >= max_image_queue_cached_) {
+        // Drop depth frame under same policy as color frames
+      } else {
+        image_queue_.push_back(std::move(depth_job));
+        image_queue_enqueue_times_.push_back(enqueue_time);
+        auto qsize = image_queue_.size();
+        img_enqueued_.fetch_add(1, std::memory_order_relaxed);
+        size_t prev = img_queue_high_water_.load(std::memory_order_relaxed);
+        while (qsize > prev && !img_queue_high_water_.compare_exchange_weak(prev, qsize)) {}
+        img_queue_backlog_sum_.fetch_add(qsize, std::memory_order_relaxed);
+        img_queue_backlog_samples_.fetch_add(1, std::memory_order_relaxed);
+      }
     }
     image_queue_cv_.notify_one();
   }

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -374,7 +374,8 @@ foxglove::RawChannel* TrossenMCAPBackend::ensure_odometry_2d_channel(const std::
     return nullptr;
   }
 
-  auto [inserted_it, _] = odometry_2d_channels_.emplace(stream_id, std::move(channel_result.value()));
+  auto [inserted_it, _] = odometry_2d_channels_.emplace(
+    stream_id, std::move(channel_result.value()));
   return &inserted_it->second;
 }
 
@@ -494,6 +495,60 @@ void TrossenMCAPBackend::write_image_record(const data::ImageRecord& img) {
       ++stats_.depth_images_written;
     } else {
       ++stats_.images_written;
+    }
+  }
+
+  // Write optional depth image to a separate channel when ImageRecord carries depth
+  if (img.has_depth()) {
+    const std::string depth_topic_id = img.id + "_depth";
+    std::unordered_map<std::string, std::string> md;
+    md["stream_type"] = "depth";
+    md["depth_encoding"] = "16UC1";
+    if (img.depth_scale.has_value()) {
+      md["depth_scale_m"] = std::to_string(img.depth_scale.value());
+    }
+
+    foxglove::RawChannel* depth_channel =
+      ensure_image_channel_with_metadata(depth_topic_id, md);
+    if (depth_channel) {
+      foxglove::schemas::RawImage dmsg;
+      dmsg.timestamp = foxglove::schemas::Timestamp{
+        .sec = static_cast<uint32_t>(img.ts.realtime.sec),
+        .nsec = static_cast<uint32_t>(img.ts.realtime.nsec)
+      };
+      dmsg.frame_id = depth_topic_id;
+      dmsg.width = img.width;
+      dmsg.height = img.height;
+      dmsg.encoding = "16UC1";
+      dmsg.step = static_cast<uint32_t>(img.depth_image->step);
+      const std::byte* dptr =
+        reinterpret_cast<const std::byte*>(img.depth_image->data);
+      const size_t dsize = img.depth_image->total() * img.depth_image->elemSize();
+      dmsg.data.assign(dptr, dptr + dsize);
+
+      std::vector<uint8_t> dpayload(TROSSEN_MCAP_INITIAL_ENCODED_BUFFER_SIZE);
+      size_t dencoded_len = 0;
+      auto dencode_result = dmsg.encode(dpayload.data(), dpayload.size(), &dencoded_len);
+
+      if (dencode_result == foxglove::FoxgloveError::BufferTooShort) {
+        dpayload.resize(dencoded_len);
+        dencode_result = dmsg.encode(dpayload.data(), dpayload.size(), &dencoded_len);
+      }
+
+      if (dencode_result != foxglove::FoxgloveError::Ok) {
+        std::cerr << "Failed to encode depth image: "
+                  << foxglove::strerror(dencode_result) << "\n";
+      } else {
+        auto dst = depth_channel->log(
+          reinterpret_cast<const std::byte*>(dpayload.data()),
+          dencoded_len,
+          img.ts.realtime.to_ns());
+        if (dst != foxglove::FoxgloveError::Ok) {
+          std::cerr << "Failed to write depth image: " << foxglove::strerror(dst) << "\n";
+        } else {
+          ++stats_.depth_images_written;
+        }
+      }
     }
   }
 }

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -517,8 +517,8 @@ void TrossenMCAPBackend::write_image_record(const data::ImageRecord& img) {
         .nsec = static_cast<uint32_t>(img.ts.realtime.nsec)
       };
       dmsg.frame_id = depth_topic_id;
-      dmsg.width = img.width;
-      dmsg.height = img.height;
+      dmsg.width = static_cast<uint32_t>(img.depth_image->cols);
+      dmsg.height = static_cast<uint32_t>(img.depth_image->rows);
       dmsg.encoding = "16UC1";
       dmsg.step = static_cast<uint32_t>(img.depth_image->step);
       const std::byte* dptr =

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,10 @@ if(TROSSEN_ENABLE_REALSENSE)
   add_test(NAME test_realsense_push_producer_metadata COMMAND test_realsense_push_producer_metadata)
 endif()
 
+add_executable(test_lerobot_depth_utils test_lerobot_depth_utils.cpp)
+target_link_libraries(test_lerobot_depth_utils PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_lerobot_depth_utils COMMAND test_lerobot_depth_utils)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -55,3 +59,4 @@ gtest_discover_tests(test_session_manager_push_producer)
 if(TROSSEN_ENABLE_REALSENSE)
   gtest_discover_tests(test_realsense_push_producer_metadata)
 endif()
+gtest_discover_tests(test_lerobot_depth_utils)

--- a/tests/test_lerobot_depth_utils.cpp
+++ b/tests/test_lerobot_depth_utils.cpp
@@ -1,0 +1,79 @@
+/**
+ * @file test_lerobot_depth_utils.cpp
+ * @brief Unit tests for LeRobot V2 depth utility functions
+ *
+ * Tests the format_depth_filename() helper and validates the depth naming
+ * conventions used by the LeRobot V2 backend for depth image storage.
+ */
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp"
+
+using trossen::io::backends::format_depth_filename;
+using trossen::io::backends::format_image_filename;
+
+// ============================================================================
+// format_depth_filename() tests
+// ============================================================================
+
+TEST(LeRobotDepthUtilsTest, DepthFilenameFrame0) {
+  EXPECT_EQ(format_depth_filename(0), "image_000000.png");
+}
+
+TEST(LeRobotDepthUtilsTest, DepthFilenameFrame1) {
+  EXPECT_EQ(format_depth_filename(1), "image_000001.png");
+}
+
+TEST(LeRobotDepthUtilsTest, DepthFilenameFrame999999) {
+  EXPECT_EQ(format_depth_filename(999999), "image_999999.png");
+}
+
+TEST(LeRobotDepthUtilsTest, DepthFilenameFrame42) {
+  EXPECT_EQ(format_depth_filename(42), "image_000042.png");
+}
+
+// Depth uses PNG (lossless 16-bit), not JPEG
+TEST(LeRobotDepthUtilsTest, DepthFilenameExtensionIsPng) {
+  std::string name = format_depth_filename(0);
+  EXPECT_GT(name.size(), 4u);
+  EXPECT_EQ(name.substr(name.size() - 4), ".png");
+}
+
+// ============================================================================
+// format_image_filename() vs format_depth_filename() consistency
+// ============================================================================
+
+// Color and depth filenames should differ in extension (jpg vs png)
+TEST(LeRobotDepthUtilsTest, ColorAndDepthExtensionsDiffer) {
+  std::string color = format_image_filename(0);
+  std::string depth = format_depth_filename(0);
+
+  // Both should have the same frame index prefix
+  EXPECT_EQ(color.substr(0, color.rfind('.')), depth.substr(0, depth.rfind('.')));
+
+  // Extensions should differ (color=jpg, depth=png for lossless 16-bit)
+  std::string color_ext = color.substr(color.rfind('.'));
+  std::string depth_ext = depth.substr(depth.rfind('.'));
+  EXPECT_NE(color_ext, depth_ext);
+}
+
+// ============================================================================
+// Depth naming convention: underscore-delimited IDs
+// ============================================================================
+
+// This is a convention test, not a function test — validates the design decision
+// that depth stream IDs use "_depth" suffix, not "/depth"
+TEST(LeRobotDepthUtilsTest, DepthIdConventionUsesUnderscore) {
+  // Simulate what the backend does (from lerobot_v2_backend.cpp):
+  // const std::string depth_key = img.id + "_depth";
+  const std::string cam_id = "cam_wrist";
+  const std::string depth_key = cam_id + "_depth";
+
+  EXPECT_EQ(depth_key, "cam_wrist_depth");
+
+  // Must NOT use path-style separator (breaks LeRobot flatten_dict)
+  EXPECT_EQ(depth_key.find('/'), std::string::npos);
+}


### PR DESCRIPTION
### TL;DR

Added depth image support to the Trossen SDK, enabling RealSense cameras to capture and store both RGB and depth data in MCAP and LeRobot V2 formats.

### What changed?

- Added RealSense RGB example configurations with optional depth capture (`config.json` and `config_depth.json`)
- Integrated push producer registry support for camera producers in all AI platform examples
- Enhanced MCAP backend to write depth images to separate channels with 16UC1 encoding and optional depth scale metadata
- Extended LeRobot V2 backend to save depth images as 16-bit PNG files in parallel directory structure using `_depth` suffix
- Updated stationary AI configuration to enable depth capture for all four cameras
- Added comprehensive unit tests for depth filename formatting utilities

### How to test?

1. Use the new RealSense RGB example configurations to test depth capture
2. Run existing AI platform examples with RealSense cameras - they now support both polling and push-based camera producers
3. Verify MCAP files contain separate depth channels when depth is enabled
4. Check LeRobot V2 output includes depth image directories with 16-bit PNG files
5. Run the new `test_lerobot_depth_utils` test suite

### Why make this change?

This enhancement enables the Trossen SDK to capture richer sensor data by supporting depth information alongside RGB images. The depth data is crucial for robotics applications requiring 3D perception, spatial understanding, and manipulation tasks. The implementation maintains backward compatibility while providing flexible depth capture options across different storage backends.