### PR TITLE
Remove stale 'trossen' backend assertion from backend registry test

### DIFF
--- a/tests/test_backend_registry.cpp
+++ b/tests/test_backend_registry.cpp
@@ -51,7 +51,6 @@ TEST_F(BackendRegistryTest, CommonBackendsAreRegistered) {
   EXPECT_TRUE(BackendRegistry::is_registered("lerobot_v2"));
   EXPECT_TRUE(BackendRegistry::is_registered("trossen_mcap"));
   EXPECT_TRUE(BackendRegistry::is_registered("null"));
-  EXPECT_TRUE(BackendRegistry::is_registered("trossen"));
 }
 
 // Test that unknown backend types are not registered


### PR DESCRIPTION
### TL;DR

Remove stale "trossen" backend assertion from backend registry test

### What changed?

- Removed `EXPECT_TRUE(BackendRegistry::is_registered("trossen"))` from `test_backend_registry.cpp` since the "trossen" backend type is no longer registered.

### Why make this change?

The "trossen" backend was removed/renamed, so the test assertion was validating a non-existent registry entry.

### How to test?

```bash
ctest -R test_backend_registry
```