### PR TITLE
Add unit tests for configuration system and record types

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,14 @@ add_executable(test_lerobot_depth_utils test_lerobot_depth_utils.cpp)
 target_link_libraries(test_lerobot_depth_utils PRIVATE trossen_sdk GTest::gtest_main)
 add_test(NAME test_lerobot_depth_utils COMMAND test_lerobot_depth_utils)
 
+add_executable(test_record_types test_record_types.cpp)
+target_link_libraries(test_record_types PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_record_types COMMAND test_record_types)
+
+add_executable(test_config test_config.cpp)
+target_link_libraries(test_config PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_config COMMAND test_config)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -60,3 +68,5 @@ if(TROSSEN_ENABLE_REALSENSE)
   gtest_discover_tests(test_realsense_push_producer_metadata)
 endif()
 gtest_discover_tests(test_lerobot_depth_utils)
+gtest_discover_tests(test_record_types)
+gtest_discover_tests(test_config)

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -103,7 +103,8 @@ TEST(GlobalConfigTest, LoadAndRetrieve) {
   };
 
   // NOTE: This modifies the global singleton. Since other test suites
-  // also load configs, we accept that the last load wins.
+  // also load configs, subsequent loads merge into the existing config:
+  // keys in this JSON overwrite existing ones, but unspecified keys may persist.
   GlobalConfig::instance().load_from_json(config);
 
   auto sm_cfg = GlobalConfig::instance().get_as<SessionManagerConfig>("session_manager");

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,0 +1,181 @@
+/**
+ * @file test_config.cpp
+ * @brief Unit tests for configuration system: SessionManagerConfig, GlobalConfig, ConfigRegistry
+ *
+ * Tests JSON parsing, default values, partial configs, type safety of get_as,
+ * and nested namespace handling in GlobalConfig.
+ */
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/configuration/base_config.hpp"
+#include "trossen_sdk/configuration/config_registry.hpp"
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/types/runtime/session_manager_config.hpp"
+
+using trossen::configuration::BaseConfig;
+using trossen::configuration::ConfigRegistry;
+using trossen::configuration::GlobalConfig;
+using trossen::configuration::SessionManagerConfig;
+
+// ============================================================================
+// CFG-01: SessionManagerConfig defaults
+// ============================================================================
+
+TEST(SessionManagerConfigTest, Defaults) {
+  SessionManagerConfig cfg;
+
+  // Default max_duration is 20 seconds
+  ASSERT_TRUE(cfg.max_duration.has_value());
+  EXPECT_DOUBLE_EQ(cfg.max_duration->count(), 20.0);
+
+  // Default max_episodes is nullopt (unlimited)
+  EXPECT_FALSE(cfg.max_episodes.has_value());
+
+  // Default backend_type
+  EXPECT_EQ(cfg.backend_type, "trossen_mcap");
+
+  // Type string
+  EXPECT_EQ(cfg.type(), "session_manager");
+}
+
+// ============================================================================
+// CFG-02: SessionManagerConfig from_json overrides all fields
+// ============================================================================
+
+TEST(SessionManagerConfigTest, FromJson_Override) {
+  nlohmann::json j = {
+    {"type", "session_manager"},
+    {"max_duration", 30.0},
+    {"max_episodes", 50},
+    {"backend_type", "null"}
+  };
+
+  SessionManagerConfig cfg = SessionManagerConfig::from_json(j);
+
+  ASSERT_TRUE(cfg.max_duration.has_value());
+  EXPECT_DOUBLE_EQ(cfg.max_duration->count(), 30.0);
+
+  ASSERT_TRUE(cfg.max_episodes.has_value());
+  EXPECT_EQ(cfg.max_episodes.value(), 50);
+
+  EXPECT_EQ(cfg.backend_type, "null");
+}
+
+// ============================================================================
+// CFG-03: SessionManagerConfig from_json with partial JSON uses defaults
+// ============================================================================
+
+TEST(SessionManagerConfigTest, FromJson_Partial) {
+  // Only provide type, everything else defaults
+  nlohmann::json j = {
+    {"type", "session_manager"}
+  };
+
+  SessionManagerConfig cfg = SessionManagerConfig::from_json(j);
+
+  // max_duration should still be default 20s
+  ASSERT_TRUE(cfg.max_duration.has_value());
+  EXPECT_DOUBLE_EQ(cfg.max_duration->count(), 20.0);
+
+  // max_episodes should be nullopt
+  EXPECT_FALSE(cfg.max_episodes.has_value());
+
+  // backend_type should be default
+  EXPECT_EQ(cfg.backend_type, "trossen_mcap");
+}
+
+// ============================================================================
+// CFG-04: GlobalConfig load and retrieve
+// ============================================================================
+
+TEST(GlobalConfigTest, LoadAndRetrieve) {
+  nlohmann::json config = {
+    {"session_manager", {
+      {"type", "session_manager"},
+      {"max_duration", 15.0},
+      {"backend_type", "null"}
+    }}
+  };
+
+  // NOTE: This modifies the global singleton. Since other test suites
+  // also load configs, we accept that the last load wins.
+  GlobalConfig::instance().load_from_json(config);
+
+  auto sm_cfg = GlobalConfig::instance().get_as<SessionManagerConfig>("session_manager");
+  ASSERT_NE(sm_cfg, nullptr);
+  EXPECT_DOUBLE_EQ(sm_cfg->max_duration->count(), 15.0);
+  EXPECT_EQ(sm_cfg->backend_type, "null");
+}
+
+// ============================================================================
+// CFG-06: GlobalConfig get for missing key returns nullptr
+// ============================================================================
+
+TEST(GlobalConfigTest, Get_MissingKey_ReturnsNull) {
+  auto result = GlobalConfig::instance().get("nonexistent_key_xyz");
+  EXPECT_EQ(result, nullptr);
+}
+
+// ============================================================================
+// CFG-05: GlobalConfig get_as with wrong type throws
+// ============================================================================
+
+// A different config type for testing type mismatch.
+// Used to verify get_as<T> throws when T does not match the stored config type.
+struct DummyConfig : public BaseConfig {
+  std::string type() const override { return "dummy"; }
+};
+
+TEST(GlobalConfigTest, GetAs_WrongType_Throws) {
+  // Ensure session_manager is loaded (from previous test or fixture)
+  nlohmann::json config = {
+    {"session_manager", {
+      {"type", "session_manager"},
+      {"max_duration", 10.0},
+      {"backend_type", "null"}
+    }}
+  };
+  GlobalConfig::instance().load_from_json(config);
+
+  // Try to get session_manager as DummyConfig -- should throw
+  EXPECT_THROW(
+    GlobalConfig::instance().get_as<DummyConfig>("session_manager"),
+    std::runtime_error);
+}
+
+// ============================================================================
+// ConfigRegistry: unknown type throws
+// ============================================================================
+
+TEST(ConfigRegistryTest, UnknownType_Throws) {
+  nlohmann::json j = {{"type", "completely_unknown_type_xyz"}};
+  EXPECT_THROW(
+    ConfigRegistry::instance().create(j),
+    std::runtime_error);
+}
+
+// ============================================================================
+// ConfigRegistry: session_manager type is registered
+// ============================================================================
+
+TEST(ConfigRegistryTest, SessionManagerType_Registered) {
+  nlohmann::json j = {
+    {"type", "session_manager"},
+    {"max_duration", 5.0},
+    {"backend_type", "null"}
+  };
+
+  auto cfg = ConfigRegistry::instance().create(j);
+  ASSERT_NE(cfg, nullptr);
+  EXPECT_EQ(cfg->type(), "session_manager");
+
+  // Verify it can be downcast
+  auto sm_cfg = std::dynamic_pointer_cast<SessionManagerConfig>(cfg);
+  ASSERT_NE(sm_cfg, nullptr);
+  EXPECT_DOUBLE_EQ(sm_cfg->max_duration->count(), 5.0);
+}

--- a/tests/test_record_types.cpp
+++ b/tests/test_record_types.cpp
@@ -155,7 +155,8 @@ TEST(Odometry2DRecordTest, InheritedFields) {
   rec.seq = 77;
   rec.id = "test_odom";
 
-  EXPECT_GT(rec.ts.monotonic.sec, 0);
+  EXPECT_TRUE(rec.ts.monotonic.sec > 0 ||
+              (rec.ts.monotonic.sec == 0 && rec.ts.monotonic.nsec > 0));
   EXPECT_EQ(rec.seq, 77);
   EXPECT_EQ(rec.id, "test_odom");
 }

--- a/tests/test_record_types.cpp
+++ b/tests/test_record_types.cpp
@@ -1,0 +1,161 @@
+/**
+ * @file test_record_types.cpp
+ * @brief Unit tests for TeleopJointStateRecord and Odometry2DRecord
+ *
+ * Covers construction, type conversion, default values, and polymorphic
+ * behavior for record types not covered by the existing test_record.cpp.
+ */
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/data/record.hpp"
+
+using trossen::data::Odometry2DRecord;
+using trossen::data::RecordBase;
+using trossen::data::TeleopJointStateRecord;
+using trossen::data::Timestamp;
+
+// ============================================================================
+// TeleopJointStateRecord tests
+// ============================================================================
+
+// REC-01: Double vector constructor converts correctly
+TEST(TeleopJointStateRecordTest, DoubleConstructor) {
+  Timestamp ts;
+  ts.monotonic.sec = 10;
+  ts.realtime.sec = 1'730'000'000;
+
+  std::vector<double> actions_d = {1.0, 2.0, 3.0, 4.0};
+  std::vector<double> observations_d = {0.5, 1.5, 2.5, 3.5};
+
+  TeleopJointStateRecord rec(ts, 42, "teleop/joints", actions_d, observations_d);
+
+  EXPECT_EQ(rec.seq, 42);
+  EXPECT_EQ(rec.id, "teleop/joints");
+
+  ASSERT_EQ(rec.actions.size(), 4);
+  ASSERT_EQ(rec.observations.size(), 4);
+
+  // Verify double-to-float conversion
+  EXPECT_FLOAT_EQ(rec.actions[0], 1.0f);
+  EXPECT_FLOAT_EQ(rec.actions[3], 4.0f);
+  EXPECT_FLOAT_EQ(rec.observations[0], 0.5f);
+  EXPECT_FLOAT_EQ(rec.observations[3], 3.5f);
+}
+
+// REC-02: Float vector constructor preserves values
+TEST(TeleopJointStateRecordTest, FloatConstructor) {
+  Timestamp ts;
+  std::vector<float> actions_f = {1.5f, 2.5f};
+  std::vector<float> observations_f = {3.5f, 4.5f};
+
+  TeleopJointStateRecord rec(ts, 10, "teleop/arm", actions_f, observations_f);
+
+  ASSERT_EQ(rec.actions.size(), 2);
+  ASSERT_EQ(rec.observations.size(), 2);
+
+  EXPECT_FLOAT_EQ(rec.actions[0], 1.5f);
+  EXPECT_FLOAT_EQ(rec.actions[1], 2.5f);
+  EXPECT_FLOAT_EQ(rec.observations[0], 3.5f);
+  EXPECT_FLOAT_EQ(rec.observations[1], 4.5f);
+}
+
+// Default construction
+TEST(TeleopJointStateRecordTest, DefaultConstruction) {
+  TeleopJointStateRecord rec;
+
+  EXPECT_EQ(rec.seq, 0);
+  EXPECT_TRUE(rec.id.empty());
+  EXPECT_TRUE(rec.actions.empty());
+  EXPECT_TRUE(rec.observations.empty());
+}
+
+// Empty vectors
+TEST(TeleopJointStateRecordTest, EmptyVectors) {
+  Timestamp ts;
+  std::vector<float> empty;
+
+  TeleopJointStateRecord rec(ts, 1, "empty", empty, empty);
+
+  EXPECT_TRUE(rec.actions.empty());
+  EXPECT_TRUE(rec.observations.empty());
+}
+
+// Polymorphic downcast
+TEST(TeleopJointStateRecordTest, PolymorphicDowncast) {
+  auto rec = std::make_unique<TeleopJointStateRecord>();
+  rec->seq = 99;
+  rec->id = "teleop";
+  rec->actions = {1.0f, 2.0f};
+  rec->observations = {3.0f, 4.0f};
+
+  RecordBase* base = rec.get();
+  EXPECT_EQ(base->seq, 99);
+
+  auto* derived = dynamic_cast<TeleopJointStateRecord*>(base);
+  ASSERT_NE(derived, nullptr);
+  EXPECT_EQ(derived->actions.size(), 2);
+}
+
+// ============================================================================
+// Odometry2DRecord tests
+// ============================================================================
+
+// REC-03: Default values are zero
+TEST(Odometry2DRecordTest, DefaultValues) {
+  Odometry2DRecord rec;
+
+  EXPECT_FLOAT_EQ(rec.pose.x, 0.0f);
+  EXPECT_FLOAT_EQ(rec.pose.y, 0.0f);
+  EXPECT_FLOAT_EQ(rec.pose.theta, 0.0f);
+  EXPECT_FLOAT_EQ(rec.twist.linear_x, 0.0f);
+  EXPECT_FLOAT_EQ(rec.twist.linear_y, 0.0f);
+  EXPECT_FLOAT_EQ(rec.twist.angular_z, 0.0f);
+}
+
+// Custom values
+TEST(Odometry2DRecordTest, CustomValues) {
+  Odometry2DRecord rec;
+  rec.pose.x = 1.5f;
+  rec.pose.y = 2.5f;
+  rec.pose.theta = 0.785f;  // ~45 degrees
+  rec.twist.linear_x = 0.5f;
+  rec.twist.angular_z = 0.1f;
+  rec.id = "base/odom";
+  rec.seq = 100;
+
+  EXPECT_FLOAT_EQ(rec.pose.x, 1.5f);
+  EXPECT_FLOAT_EQ(rec.twist.linear_x, 0.5f);
+  EXPECT_EQ(rec.id, "base/odom");
+}
+
+// REC-04: Polymorphic downcast
+TEST(Odometry2DRecordTest, PolymorphicDowncast) {
+  auto rec = std::make_shared<Odometry2DRecord>();
+  rec->seq = 50;
+  rec->id = "odom";
+  rec->pose.x = 1.0f;
+
+  std::shared_ptr<RecordBase> base = rec;
+
+  auto* derived = dynamic_cast<Odometry2DRecord*>(base.get());
+  ASSERT_NE(derived, nullptr);
+  EXPECT_FLOAT_EQ(derived->pose.x, 1.0f);
+  EXPECT_EQ(derived->id, "odom");
+}
+
+// Ensure RecordBase fields inherited correctly
+TEST(Odometry2DRecordTest, InheritedFields) {
+  Odometry2DRecord rec;
+  rec.ts = trossen::data::make_timestamp_now();
+  rec.seq = 77;
+  rec.id = "test_odom";
+
+  EXPECT_GT(rec.ts.monotonic.sec, 0);
+  EXPECT_EQ(rec.seq, 77);
+  EXPECT_EQ(rec.id, "test_odom");
+}


### PR DESCRIPTION
### TL;DR

Added comprehensive unit tests for configuration system and record types to improve test coverage.

### What changed?

Added two new test executables:
- `test_config.cpp` - Tests for `SessionManagerConfig`, `GlobalConfig`, and `ConfigRegistry` including JSON parsing, default values, partial configurations, type safety, and error handling
- `test_record_types.cpp` - Tests for `TeleopJointStateRecord` and `Odometry2DRecord` covering construction, type conversion, default values, and polymorphic behavior

Both test executables are integrated with GoogleTest and CTest for automated test discovery.

### How to test?

Run the new tests using:
```bash
ctest -R "test_config|test_record_types"
```

Or run the executables directly:
```bash
./test_config
./test_record_types
```

### Why make this change?

These tests provide essential coverage for configuration management and data record functionality that wasn't previously tested, ensuring reliability of JSON configuration parsing, type safety in the configuration system, and correct behavior of record types used throughout the SDK.