### PR TITLE
Add unit tests for ProducerRegistry and QueueAdapter components

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,14 @@ add_executable(test_lerobot_utils test_lerobot_utils.cpp)
 target_link_libraries(test_lerobot_utils PRIVATE trossen_sdk GTest::gtest_main)
 add_test(NAME test_lerobot_utils COMMAND test_lerobot_utils)
 
+add_executable(test_queue_adapter test_queue_adapter.cpp)
+target_link_libraries(test_queue_adapter PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_queue_adapter COMMAND test_queue_adapter)
+
+add_executable(test_producer_registry test_producer_registry.cpp)
+target_link_libraries(test_producer_registry PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_producer_registry COMMAND test_producer_registry)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -75,3 +83,5 @@ gtest_discover_tests(test_lerobot_depth_utils)
 gtest_discover_tests(test_record_types)
 gtest_discover_tests(test_config)
 gtest_discover_tests(test_lerobot_utils)
+gtest_discover_tests(test_queue_adapter)
+gtest_discover_tests(test_producer_registry)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,62 +10,48 @@ FetchContent_MakeAvailable(googletest)
 # Unit test executables
 add_executable(test_timestamp test_timestamp.cpp)
 target_link_libraries(test_timestamp PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_timestamp COMMAND test_timestamp)
 
 add_executable(test_record test_record.cpp)
 target_link_libraries(test_record PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_record COMMAND test_record)
 
 add_executable(test_null_backend test_null_backend.cpp)
 target_link_libraries(test_null_backend PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_null_backend COMMAND test_null_backend)
 
 add_executable(test_backend_registry test_backend_registry.cpp)
 target_link_libraries(test_backend_registry PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_backend_registry COMMAND test_backend_registry)
 
 add_executable(test_push_producer_registry test_push_producer_registry.cpp)
 target_link_libraries(test_push_producer_registry PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_push_producer_registry COMMAND test_push_producer_registry)
 
 add_executable(test_push_producer_base test_push_producer_base.cpp)
 target_link_libraries(test_push_producer_base PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_push_producer_base COMMAND test_push_producer_base)
 
 add_executable(test_session_manager_push_producer test_session_manager_push_producer.cpp)
 target_link_libraries(test_session_manager_push_producer PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_session_manager_push_producer COMMAND test_session_manager_push_producer)
 
 if(TROSSEN_ENABLE_REALSENSE)
   add_executable(test_realsense_push_producer_metadata test_realsense_push_producer_metadata.cpp)
   target_link_libraries(test_realsense_push_producer_metadata PRIVATE trossen_sdk GTest::gtest_main)
   target_compile_definitions(test_realsense_push_producer_metadata PRIVATE TROSSEN_ENABLE_REALSENSE)
-  add_test(NAME test_realsense_push_producer_metadata COMMAND test_realsense_push_producer_metadata)
 endif()
 
 add_executable(test_lerobot_depth_utils test_lerobot_depth_utils.cpp)
 target_link_libraries(test_lerobot_depth_utils PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_lerobot_depth_utils COMMAND test_lerobot_depth_utils)
 
 add_executable(test_record_types test_record_types.cpp)
 target_link_libraries(test_record_types PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_record_types COMMAND test_record_types)
 
 add_executable(test_config test_config.cpp)
 target_link_libraries(test_config PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_config COMMAND test_config)
 
 add_executable(test_lerobot_utils test_lerobot_utils.cpp)
 target_link_libraries(test_lerobot_utils PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_lerobot_utils COMMAND test_lerobot_utils)
 
 add_executable(test_queue_adapter test_queue_adapter.cpp)
 target_link_libraries(test_queue_adapter PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_queue_adapter COMMAND test_queue_adapter)
 
 add_executable(test_producer_registry test_producer_registry.cpp)
 target_link_libraries(test_producer_registry PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_producer_registry COMMAND test_producer_registry)
 
 # Enable CTest integration
 include(GoogleTest)

--- a/tests/test_producer_registry.cpp
+++ b/tests/test_producer_registry.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file test_producer_registry.cpp
+ * @brief Unit tests for ProducerRegistry (polled producers)
+ *
+ * Tests registration, creation, duplicate detection, error paths,
+ * and enumeration of registered producer types.
+ */
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/hw/producer_base.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+
+using trossen::runtime::ProducerRegistry;
+
+// Minimal concrete PolledProducer for testing
+class MockPolledProducerForRegistry : public trossen::hw::PolledProducer {
+public:
+  MockPolledProducerForRegistry() = default;
+  ~MockPolledProducerForRegistry() override = default;
+
+  void poll(
+    const std::function<void(std::shared_ptr<trossen::data::RecordBase>)>&) override {}
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<ProducerMetadata>();
+  }
+};
+
+// ============================================================================
+// PR-01: Unknown type is not registered
+// ============================================================================
+
+TEST(ProducerRegistryTest, IsNotRegistered_UnknownType) {
+  EXPECT_FALSE(ProducerRegistry::is_registered("nonexistent_polled_type_xyz"));
+}
+
+// ============================================================================
+// PR-02: Create throws for unknown type
+// ============================================================================
+
+TEST(ProducerRegistryTest, Create_ThrowsForUnknownType) {
+  EXPECT_THROW(
+    ProducerRegistry::create("nonexistent_polled_type_xyz", nullptr, {}),
+    std::runtime_error);
+}
+
+// ============================================================================
+// PR-03: Register and create mock producer
+// ============================================================================
+
+// Fixture that registers a mock factory once. The try/catch guards against
+// duplicate registration when GTest re-runs the suite (static registry persists).
+class ProducerRegistryRegistrationTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    try {
+      ProducerRegistry::register_producer(
+        "mock_polled_for_test",
+        [](std::shared_ptr<trossen::hw::HardwareComponent>,
+           const nlohmann::json&)
+          -> std::shared_ptr<trossen::hw::PolledProducer>
+        {
+          return std::make_shared<MockPolledProducerForRegistry>();
+        });
+    } catch (const std::runtime_error&) {
+      // Already registered from previous test run
+    }
+  }
+};
+
+TEST_F(ProducerRegistryRegistrationTest, IsRegisteredAfterRegister) {
+  EXPECT_TRUE(ProducerRegistry::is_registered("mock_polled_for_test"));
+}
+
+TEST_F(ProducerRegistryRegistrationTest, CreateReturnsNonNull) {
+  auto producer = ProducerRegistry::create("mock_polled_for_test", nullptr, {});
+  ASSERT_NE(producer, nullptr);
+}
+
+// ============================================================================
+// PR-04: Duplicate registration throws
+// ============================================================================
+
+TEST_F(ProducerRegistryRegistrationTest, DuplicateRegistration_Throws) {
+  EXPECT_THROW(
+    ProducerRegistry::register_producer(
+      "mock_polled_for_test",
+      [](std::shared_ptr<trossen::hw::HardwareComponent>,
+         const nlohmann::json&)
+        -> std::shared_ptr<trossen::hw::PolledProducer>
+      {
+        return std::make_shared<MockPolledProducerForRegistry>();
+      }),
+    std::runtime_error);
+}
+
+// ============================================================================
+// PR-05: Registered type appears in list
+// ============================================================================
+
+TEST_F(ProducerRegistryRegistrationTest, GetRegisteredTypes_ContainsMock) {
+  auto types = ProducerRegistry::get_registered_types();
+  bool found = false;
+  for (const auto& t : types) {
+    if (t == "mock_polled_for_test") {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+// ============================================================================
+// Edge cases
+// ============================================================================
+
+TEST(ProducerRegistryTest, CreateWithEmptyType_Throws) {
+  EXPECT_THROW(
+    ProducerRegistry::create("", nullptr, {}),
+    std::runtime_error);
+}
+
+TEST(ProducerRegistryTest, IsNotRegistered_EmptyString) {
+  EXPECT_FALSE(ProducerRegistry::is_registered(""));
+}
+
+// Test that GetRegisteredTypes is callable without error
+TEST(ProducerRegistryTest, GetRegisteredTypes_Callable) {
+  std::vector<std::string> types;
+  EXPECT_NO_THROW(types = ProducerRegistry::get_registered_types());
+}
+
+// Test with null factory return
+class ProducerRegistryNullFactoryTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    try {
+      ProducerRegistry::register_producer(
+        "null_factory_polled_for_test",
+        [](std::shared_ptr<trossen::hw::HardwareComponent>,
+           const nlohmann::json&)
+          -> std::shared_ptr<trossen::hw::PolledProducer>
+        {
+          return nullptr;
+        });
+    } catch (const std::runtime_error&) {
+      // Already registered
+    }
+  }
+};
+
+TEST_F(ProducerRegistryNullFactoryTest, CreateThrowsWhenFactoryReturnsNull) {
+  EXPECT_THROW(
+    ProducerRegistry::create("null_factory_polled_for_test", nullptr, {}),
+    std::runtime_error);
+}

--- a/tests/test_producer_registry.cpp
+++ b/tests/test_producer_registry.cpp
@@ -55,12 +55,11 @@ TEST(ProducerRegistryTest, Create_ThrowsForUnknownType) {
 // PR-03: Register and create mock producer
 // ============================================================================
 
-// Fixture that registers a mock factory once. The try/catch guards against
-// duplicate registration when GTest re-runs the suite (static registry persists).
+// Fixture that registers a mock factory once per process.
 class ProducerRegistryRegistrationTest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
-    try {
+    if (!ProducerRegistry::is_registered("mock_polled_for_test")) {
       ProducerRegistry::register_producer(
         "mock_polled_for_test",
         [](std::shared_ptr<trossen::hw::HardwareComponent>,
@@ -69,8 +68,6 @@ protected:
         {
           return std::make_shared<MockPolledProducerForRegistry>();
         });
-    } catch (const std::runtime_error&) {
-      // Already registered from previous test run
     }
   }
 };
@@ -141,7 +138,7 @@ TEST(ProducerRegistryTest, GetRegisteredTypes_Callable) {
 class ProducerRegistryNullFactoryTest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
-    try {
+    if (!ProducerRegistry::is_registered("null_factory_polled_for_test")) {
       ProducerRegistry::register_producer(
         "null_factory_polled_for_test",
         [](std::shared_ptr<trossen::hw::HardwareComponent>,
@@ -150,8 +147,6 @@ protected:
         {
           return nullptr;
         });
-    } catch (const std::runtime_error&) {
-      // Already registered
     }
   }
 };

--- a/tests/test_queue_adapter.cpp
+++ b/tests/test_queue_adapter.cpp
@@ -1,0 +1,144 @@
+/**
+ * @file test_queue_adapter.cpp
+ * @brief Unit tests for QueueAdapter (MoodyCamelQueueAdapter)
+ *
+ * Tests basic FIFO behavior, empty queue safety, and multi-producer
+ * single-consumer (MPSC) correctness.
+ */
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/io/queue_adapter.hpp"
+
+using trossen::data::JointStateRecord;
+using trossen::data::RecordBase;
+using trossen::io::MoodyCamelQueueAdapter;
+
+// ============================================================================
+// QA-01: Enqueue then dequeue returns same record
+// ============================================================================
+
+TEST(QueueAdapterTest, EnqueueDequeue_SingleRecord) {
+  MoodyCamelQueueAdapter queue;
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->seq = 42;
+  rec->id = "test_stream";
+
+  queue.enqueue(rec);
+
+  std::shared_ptr<RecordBase> out;
+  ASSERT_TRUE(queue.try_dequeue(out));
+  ASSERT_NE(out, nullptr);
+  EXPECT_EQ(out->seq, 42);
+  EXPECT_EQ(out->id, "test_stream");
+}
+
+// ============================================================================
+// QA-02: try_dequeue on empty queue returns false
+// ============================================================================
+
+TEST(QueueAdapterTest, TryDequeue_EmptyReturnsFalse) {
+  MoodyCamelQueueAdapter queue;
+  std::shared_ptr<RecordBase> out;
+  EXPECT_FALSE(queue.try_dequeue(out));
+}
+
+// ============================================================================
+// QA-03: Multiple enqueue/dequeue preserves all records
+// ============================================================================
+
+TEST(QueueAdapterTest, MultipleEnqueueDequeue_AllRecovered) {
+  MoodyCamelQueueAdapter queue;
+
+  constexpr int N = 100;
+  for (int i = 0; i < N; ++i) {
+    auto rec = std::make_shared<JointStateRecord>();
+    rec->seq = i;
+    queue.enqueue(rec);
+  }
+
+  int count = 0;
+  std::shared_ptr<RecordBase> out;
+  while (queue.try_dequeue(out)) {
+    ASSERT_NE(out, nullptr);
+    ++count;
+    out.reset();
+  }
+  EXPECT_EQ(count, N);
+}
+
+// ============================================================================
+// QA-04: Concurrent enqueue from multiple threads, all dequeued
+// ============================================================================
+
+TEST(QueueAdapterTest, ConcurrentEnqueue_AllDequeued) {
+  MoodyCamelQueueAdapter queue;
+
+  constexpr int NUM_THREADS = 4;
+  constexpr int RECORDS_PER_THREAD = 200;
+
+  std::vector<std::thread> producers;
+  for (int t = 0; t < NUM_THREADS; ++t) {
+    producers.emplace_back([&queue, t]() {
+      for (int i = 0; i < RECORDS_PER_THREAD; ++i) {
+        auto rec = std::make_shared<JointStateRecord>();
+        rec->seq = t * RECORDS_PER_THREAD + i;
+        queue.enqueue(rec);
+      }
+    });
+  }
+
+  for (auto& th : producers) {
+    th.join();
+  }
+
+  // Single consumer dequeues all
+  int count = 0;
+  std::shared_ptr<RecordBase> out;
+  while (queue.try_dequeue(out)) {
+    ASSERT_NE(out, nullptr);
+    ++count;
+    out.reset();
+  }
+
+  EXPECT_EQ(count, NUM_THREADS * RECORDS_PER_THREAD);
+}
+
+// ============================================================================
+// Edge: Dequeue after all consumed returns false
+// ============================================================================
+
+TEST(QueueAdapterTest, DequeueAfterConsumed_ReturnsFalse) {
+  MoodyCamelQueueAdapter queue;
+
+  auto rec = std::make_shared<JointStateRecord>();
+  queue.enqueue(rec);
+
+  std::shared_ptr<RecordBase> out;
+  ASSERT_TRUE(queue.try_dequeue(out));
+  EXPECT_FALSE(queue.try_dequeue(out));
+}
+
+// ============================================================================
+// QueueAdapter interface: polymorphic use through base pointer
+// ============================================================================
+
+TEST(QueueAdapterTest, PolymorphicUse) {
+  std::unique_ptr<trossen::io::QueueAdapter> queue =
+    std::make_unique<MoodyCamelQueueAdapter>();
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->seq = 99;
+  queue->enqueue(rec);
+
+  std::shared_ptr<RecordBase> out;
+  ASSERT_TRUE(queue->try_dequeue(out));
+  EXPECT_EQ(out->seq, 99);
+}


### PR DESCRIPTION
### TL;DR

Added unit tests for `ProducerRegistry` and `QueueAdapter` components to improve test coverage.

### What changed?

Added two new test files:
- `test_producer_registry.cpp` - Tests producer registration, creation, duplicate detection, error handling, and enumeration of registered producer types
- `test_queue_adapter.cpp` - Tests FIFO behavior, empty queue safety, and multi-producer single-consumer (MPSC) correctness for the MoodyCamelQueueAdapter

Both test executables are now built and integrated with CTest for automated test discovery.

### How to test?

Run the new tests using:
```bash
ctest -R "test_producer_registry|test_queue_adapter"
```

Or run all tests:
```bash
ctest
```

### Why make this change?

These tests validate critical functionality of the producer registry system and queue adapter, ensuring proper registration mechanisms, thread-safe queue operations, and error handling paths work as expected.