### PR TITLE
Add unit tests for Sink and Scheduler components

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,11 +55,9 @@ target_link_libraries(test_producer_registry PRIVATE trossen_sdk GTest::gtest_ma
 
 add_executable(test_sink test_sink.cpp)
 target_link_libraries(test_sink PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_sink COMMAND test_sink)
 
 add_executable(test_scheduler test_scheduler.cpp)
 target_link_libraries(test_scheduler PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_scheduler COMMAND test_scheduler)
 
 # Enable CTest integration
 include(GoogleTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,14 @@ target_link_libraries(test_queue_adapter PRIVATE trossen_sdk GTest::gtest_main)
 add_executable(test_producer_registry test_producer_registry.cpp)
 target_link_libraries(test_producer_registry PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_sink test_sink.cpp)
+target_link_libraries(test_sink PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_sink COMMAND test_sink)
+
+add_executable(test_scheduler test_scheduler.cpp)
+target_link_libraries(test_scheduler PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_scheduler COMMAND test_scheduler)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -71,3 +79,5 @@ gtest_discover_tests(test_config)
 gtest_discover_tests(test_lerobot_utils)
 gtest_discover_tests(test_queue_adapter)
 gtest_discover_tests(test_producer_registry)
+gtest_discover_tests(test_sink)
+gtest_discover_tests(test_scheduler)

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -1,0 +1,260 @@
+/**
+ * @file test_scheduler.cpp
+ * @brief Unit tests for the Scheduler dual-lane periodic task scheduler
+ *
+ * Tests task registration, lane classification (high-res vs normal),
+ * task execution, and statistics tracking.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/runtime/scheduler.hpp"
+
+using trossen::runtime::Scheduler;
+
+// ============================================================================
+// Task registration and lane classification
+// ============================================================================
+
+// SCHED-01: Task with period > high_res_cutover goes to normal lane
+// NOTE: These lane-classification tests access tasks_high_ and tasks_normal_ directly.
+// These are public members of Scheduler (header-level visibility).
+TEST(SchedulerTest, AddTask_NormalLane) {
+  Scheduler sched;
+  // Default cutover is 5ms; period of 100ms should go to normal
+  sched.add_task(
+    std::chrono::milliseconds(100),
+    []() {},
+    Scheduler::TaskOptions{.name = "normal_task"});
+
+  EXPECT_EQ(sched.tasks_normal_.size(), 1);
+  EXPECT_EQ(sched.tasks_high_.size(), 0);
+  EXPECT_EQ(sched.tasks_normal_[0].stats.name, "normal_task");
+  EXPECT_FALSE(sched.tasks_normal_[0].high_res);
+}
+
+// SCHED-02: Task with period <= high_res_cutover goes to high-res lane
+TEST(SchedulerTest, AddTask_HighResLane) {
+  Scheduler sched;
+  // Default cutover is 5ms; period of 5ms should go to high-res
+  sched.add_task(
+    std::chrono::milliseconds(5),
+    []() {},
+    Scheduler::TaskOptions{.name = "high_res_task"});
+
+  EXPECT_EQ(sched.tasks_high_.size(), 1);
+  EXPECT_EQ(sched.tasks_normal_.size(), 0);
+  EXPECT_TRUE(sched.tasks_high_[0].high_res);
+}
+
+// SCHED-03: Zero period is silently ignored
+TEST(SchedulerTest, AddTask_ZeroPeriod_Ignored) {
+  Scheduler sched;
+  sched.add_task(
+    std::chrono::milliseconds(0),
+    []() {},
+    Scheduler::TaskOptions{});
+
+  EXPECT_EQ(sched.tasks_high_.size(), 0);
+  EXPECT_EQ(sched.tasks_normal_.size(), 0);
+}
+
+// Negative period is also ignored
+TEST(SchedulerTest, AddTask_NegativePeriod_Ignored) {
+  Scheduler sched;
+  sched.add_task(
+    std::chrono::milliseconds(-10),
+    []() {},
+    Scheduler::TaskOptions{});
+
+  EXPECT_EQ(sched.tasks_high_.size(), 0);
+  EXPECT_EQ(sched.tasks_normal_.size(), 0);
+}
+
+// SCHED-07: force_high_res in TaskOptions elevates task regardless of period
+TEST(SchedulerTest, ForceHighRes_MovesToHighLane) {
+  Scheduler sched;
+  sched.add_task(
+    std::chrono::milliseconds(100),  // normally goes to normal lane
+    []() {},
+    Scheduler::TaskOptions{.force_high_res = true, .name = "forced_high"});
+
+  EXPECT_EQ(sched.tasks_high_.size(), 1);
+  EXPECT_EQ(sched.tasks_normal_.size(), 0);
+  EXPECT_TRUE(sched.tasks_high_[0].high_res);
+}
+
+// SCHED-10: Config force_high_res elevates all tasks
+TEST(SchedulerTest, ConfigForceHighRes_AllTasksElevated) {
+  Scheduler sched;
+  Scheduler::Config cfg;
+  cfg.force_high_res = true;
+  sched.configure(cfg);
+
+  sched.add_task(
+    std::chrono::milliseconds(100),
+    []() {},
+    Scheduler::TaskOptions{.name = "should_be_high"});
+
+  sched.add_task(
+    std::chrono::milliseconds(200),
+    []() {},
+    Scheduler::TaskOptions{.name = "also_high"});
+
+  EXPECT_EQ(sched.tasks_high_.size(), 2);
+  EXPECT_EQ(sched.tasks_normal_.size(), 0);
+}
+
+// ============================================================================
+// Start/Stop lifecycle
+// ============================================================================
+
+// SCHED-04: Start and stop with no tasks does not hang
+TEST(SchedulerTest, StartStop_NoTasks) {
+  Scheduler sched;
+  sched.start();
+  // Give threads a moment to start
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  sched.stop();
+  // If we reach here, no deadlock occurred
+  SUCCEED();
+}
+
+// ============================================================================
+// Task execution
+// ============================================================================
+
+// SCHED-05: A registered task runs at least once within reasonable time
+TEST(SchedulerTest, TaskExecutes_AtLeastOnce) {
+  Scheduler sched;
+  std::atomic<int> counter{0};
+
+  sched.add_task(
+    std::chrono::milliseconds(10),
+    [&counter]() { counter++; },
+    Scheduler::TaskOptions{.name = "counter_task"});
+
+  sched.start();
+  // Wait up to 200ms for at least one execution
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  sched.stop();
+
+  EXPECT_GT(counter.load(), 0);
+}
+
+// SCHED-06: After running, task stats show ticks > 0
+TEST(SchedulerTest, TaskStats_TickCountIncreases) {
+  Scheduler sched;
+
+  sched.add_task(
+    std::chrono::milliseconds(10),
+    []() {},
+    Scheduler::TaskOptions{.name = "tick_task"});
+
+  sched.start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  sched.stop();
+
+  auto stats = sched.task_stats();
+  ASSERT_EQ(stats.size(), 1);
+  EXPECT_GT(stats[0].ticks, 0);
+  EXPECT_EQ(stats[0].name, "tick_task");
+}
+
+// SCHED-08: Multiple tasks with different periods both execute
+TEST(SchedulerTest, MultipleTasksExecute) {
+  Scheduler sched;
+  std::atomic<int> fast_counter{0};
+  std::atomic<int> slow_counter{0};
+
+  sched.add_task(
+    std::chrono::milliseconds(10),
+    [&fast_counter]() { fast_counter++; },
+    Scheduler::TaskOptions{.name = "fast"});
+
+  sched.add_task(
+    std::chrono::milliseconds(50),
+    [&slow_counter]() { slow_counter++; },
+    Scheduler::TaskOptions{.name = "slow"});
+
+  sched.start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  sched.stop();
+
+  EXPECT_GT(fast_counter.load(), 0);
+  EXPECT_GT(slow_counter.load(), 0);
+  // Fast task should have run more times than slow task
+  EXPECT_GT(fast_counter.load(), slow_counter.load());
+}
+
+// SCHED-09: Task name is preserved in stats
+TEST(SchedulerTest, TaskName_PreservedInStats) {
+  Scheduler sched;
+
+  sched.add_task(
+    std::chrono::milliseconds(50),
+    []() {},
+    Scheduler::TaskOptions{.name = "my_named_task"});
+
+  auto stats = sched.task_stats();
+  ASSERT_EQ(stats.size(), 1);
+  EXPECT_EQ(stats[0].name, "my_named_task");
+}
+
+// Test period_ns is correctly stored in stats
+TEST(SchedulerTest, TaskStats_PeriodStored) {
+  Scheduler sched;
+
+  sched.add_task(
+    std::chrono::milliseconds(33),
+    []() {},
+    Scheduler::TaskOptions{.name = "period_check"});
+
+  auto stats = sched.task_stats();
+  ASSERT_EQ(stats.size(), 1);
+  EXPECT_EQ(stats[0].period_ns, 33'000'000ULL);
+}
+
+// Test that add_task with uint32_t overload works
+TEST(SchedulerTest, AddTask_Uint32Overload) {
+  Scheduler sched;
+  std::atomic<int> counter{0};
+
+  sched.add_task(
+    [&counter]() { counter++; },
+    50,  // period_ms as uint32_t
+    Scheduler::TaskOptions{.name = "uint32_task"});
+
+  sched.start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  sched.stop();
+
+  EXPECT_GT(counter.load(), 0);
+}
+
+// Test overall scheduler stats track wake cycles.
+// NOTE: Known issue -- Scheduler::running_ is a plain bool read from two threads
+// (main thread and lane threads). This is a data race and should be std::atomic<bool>.
+// These timing-based tests may be flaky under ThreadSanitizer until that is fixed.
+TEST(SchedulerTest, SchedulerStats_WakeCycles) {
+  Scheduler sched;
+
+  sched.add_task(
+    std::chrono::milliseconds(50),
+    []() {},
+    Scheduler::TaskOptions{.name = "wake_test"});
+
+  sched.start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  sched.stop();
+
+  auto stats = sched.stats();
+  // Both lanes have threads; normal lane has the task
+  EXPECT_GT(stats.wake_cycles_normal, 0);
+  EXPECT_GT(stats.normal_ticks, 0);
+}

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -26,7 +26,10 @@ using trossen::runtime::Scheduler;
 // These are public members of Scheduler (header-level visibility).
 TEST(SchedulerTest, AddTask_NormalLane) {
   Scheduler sched;
-  // Default cutover is 5ms; period of 100ms should go to normal
+  Scheduler::Config cfg;
+  cfg.high_res_cutover_ms = 5;
+  sched.configure(cfg);
+  // Period of 100ms exceeds cutover, should go to normal lane
   sched.add_task(
     std::chrono::milliseconds(100),
     []() {},
@@ -41,7 +44,10 @@ TEST(SchedulerTest, AddTask_NormalLane) {
 // SCHED-02: Task with period <= high_res_cutover goes to high-res lane
 TEST(SchedulerTest, AddTask_HighResLane) {
   Scheduler sched;
-  // Default cutover is 5ms; period of 5ms should go to high-res
+  Scheduler::Config cfg;
+  cfg.high_res_cutover_ms = 5;
+  sched.configure(cfg);
+  // Period of 5ms <= cutover, should go to high-res lane
   sched.add_task(
     std::chrono::milliseconds(5),
     []() {},
@@ -140,8 +146,13 @@ TEST(SchedulerTest, TaskExecutes_AtLeastOnce) {
     Scheduler::TaskOptions{.name = "counter_task"});
 
   sched.start();
-  // Wait up to 200ms for at least one execution
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  // Poll up to 200ms for at least one execution
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+  while (counter.load() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
   sched.stop();
 
   EXPECT_GT(counter.load(), 0);

--- a/tests/test_sink.cpp
+++ b/tests/test_sink.cpp
@@ -1,0 +1,304 @@
+/**
+ * @file test_sink.cpp
+ * @brief Unit tests for Sink drain loop, lifecycle, and record delivery
+ *
+ * Tests the Sink component which owns a queue and a drain thread that forwards
+ * records to a backend. Uses NullBackend as a concrete backend to verify record
+ * delivery without I/O side effects.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/io/backends/null/null_backend.hpp"
+#include "trossen_sdk/io/sink.hpp"
+
+using trossen::data::ImageRecord;
+using trossen::data::JointStateRecord;
+using trossen::data::RecordBase;
+using trossen::data::Timestamp;
+using trossen::io::Sink;
+using trossen::io::backends::NullBackend;
+
+// ============================================================================
+// Helper: create a NullBackend wrapped in shared_ptr
+// ============================================================================
+
+static std::shared_ptr<NullBackend> make_null_backend() {
+  return std::make_shared<NullBackend>();
+}
+
+// ============================================================================
+// Start/Stop lifecycle tests
+// ============================================================================
+
+// SINK-01: Sink starts and stops cleanly with no records enqueued
+TEST(SinkTest, StartStop_EmptyQueue) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+
+  sink.start();
+  // Give drain loop a chance to spin
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  sink.stop();
+
+  EXPECT_EQ(sink.processed_count(), 0);
+  EXPECT_EQ(backend->count(), 0);
+}
+
+// SINK-06: Double start is idempotent (no second thread spawned)
+TEST(SinkTest, DoubleStart_IsIdempotent) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+
+  sink.start();
+  sink.start();  // second start should be no-op
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->seq = 1;
+  rec->id = "test";
+  sink.enqueue(rec);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  sink.stop();
+
+  // Should still have processed exactly 1 record (not 2 from double drain)
+  EXPECT_EQ(backend->count(), 1);
+}
+
+// SINK-07: Double stop does not crash
+TEST(SinkTest, DoubleStop_IsIdempotent) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+
+  sink.start();
+  sink.stop();
+  EXPECT_NO_THROW(sink.stop());
+}
+
+// SINK-11: Start without backend throws
+TEST(SinkTest, Start_ThrowsWithoutBackend) {
+  Sink sink(nullptr);
+  EXPECT_THROW(sink.start(), std::runtime_error);
+}
+
+// ============================================================================
+// Record delivery tests
+// ============================================================================
+
+// SINK-02: Single record enqueued reaches backend
+TEST(SinkTest, EnqueueAndDrain_SingleRecord) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+  sink.start();
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->seq = 42;
+  rec->id = "arm/joints";
+  sink.enqueue(rec);
+
+  // Wait for drain
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  sink.stop();
+
+  EXPECT_EQ(backend->count(), 1);
+  EXPECT_EQ(sink.processed_count(), 1);
+}
+
+// SINK-03: Multiple records all reach backend with correct count
+TEST(SinkTest, EnqueueAndDrain_MultipleRecords) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+  sink.start();
+
+  constexpr int N = 100;
+  for (int i = 0; i < N; ++i) {
+    auto rec = std::make_shared<JointStateRecord>();
+    rec->seq = i;
+    rec->id = "arm/joints";
+    sink.enqueue(rec);
+  }
+
+  // Wait for drain
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  sink.stop();
+
+  EXPECT_EQ(backend->count(), N);
+  EXPECT_EQ(sink.processed_count(), static_cast<size_t>(N));
+}
+
+// SINK-04: emplace<> constructs record in-place and drains it
+TEST(SinkTest, Emplace_ConstructsAndDrains) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+  sink.start();
+
+  sink.emplace<JointStateRecord>();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  sink.stop();
+
+  EXPECT_EQ(backend->count(), 1);
+  EXPECT_EQ(sink.processed_count(), 1);
+}
+
+// SINK-05: Records enqueued before stop() are flushed during final drain
+TEST(SinkTest, Stop_DrainsRemainingRecords) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+  sink.start();
+
+  // Enqueue a batch, then immediately stop
+  constexpr int N = 50;
+  for (int i = 0; i < N; ++i) {
+    auto rec = std::make_shared<JointStateRecord>();
+    rec->seq = i;
+    rec->id = "arm/joints";
+    sink.enqueue(rec);
+  }
+
+  sink.stop();
+
+  // All records should have been flushed during the final drain in stop()
+  EXPECT_EQ(backend->count(), N);
+  EXPECT_EQ(sink.processed_count(), static_cast<size_t>(N));
+}
+
+// SINK-08: processed_count is accurate after drain
+TEST(SinkTest, ProcessedCount_AccurateAfterDrain) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+  sink.start();
+
+  for (int i = 0; i < 10; ++i) {
+    sink.emplace<JointStateRecord>();
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  sink.stop();
+
+  EXPECT_EQ(sink.processed_count(), 10);
+  EXPECT_EQ(backend->count(), 10);
+}
+
+// SINK-09: Enqueue nullptr is safely ignored
+TEST(SinkTest, EnqueueNull_IsIgnored) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+  sink.start();
+
+  sink.enqueue(nullptr);
+  sink.enqueue(nullptr);
+
+  // Enqueue a real record to verify pipeline still works
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->seq = 1;
+  rec->id = "test";
+  sink.enqueue(rec);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  sink.stop();
+
+  // Only the real record should have been processed
+  EXPECT_EQ(backend->count(), 1);
+}
+
+// SINK-10: Multiple producer threads all deliver records
+TEST(SinkTest, MultiProducerDrain) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+  sink.start();
+
+  constexpr int NUM_THREADS = 4;
+  constexpr int RECORDS_PER_THREAD = 50;
+
+  std::vector<std::thread> producers;
+  for (int t = 0; t < NUM_THREADS; ++t) {
+    producers.emplace_back([&sink, t]() {
+      for (int i = 0; i < RECORDS_PER_THREAD; ++i) {
+        auto rec = std::make_shared<JointStateRecord>();
+        rec->seq = t * RECORDS_PER_THREAD + i;
+        rec->id = "thread_" + std::to_string(t);
+        sink.enqueue(rec);
+      }
+    });
+  }
+
+  for (auto& th : producers) {
+    th.join();
+  }
+
+  // Wait for drain to complete
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  sink.stop();
+
+  EXPECT_EQ(backend->count(), NUM_THREADS * RECORDS_PER_THREAD);
+  EXPECT_EQ(sink.processed_count(),
+            static_cast<size_t>(NUM_THREADS * RECORDS_PER_THREAD));
+}
+
+// SINK-12: Large batch drains completely
+TEST(SinkTest, LargeBatch_DrainedCompletely) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+  sink.start();
+
+  constexpr int N = 2000;
+  for (int i = 0; i < N; ++i) {
+    auto rec = std::make_shared<JointStateRecord>();
+    rec->seq = i;
+    rec->id = "large_batch";
+    sink.enqueue(rec);
+  }
+
+  // Allow time for drain, then stop to flush remainder
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  sink.stop();
+
+  EXPECT_EQ(backend->count(), N);
+}
+
+// Test that sink destructor stops cleanly (RAII)
+TEST(SinkTest, Destructor_StopsCleanly) {
+  auto backend = make_null_backend();
+  {
+    Sink sink(backend);
+    sink.start();
+
+    for (int i = 0; i < 10; ++i) {
+      sink.emplace<JointStateRecord>();
+    }
+    // Sink goes out of scope here -- destructor should call stop()
+  }
+
+  // Backend should have received all records
+  EXPECT_EQ(backend->count(), 10);
+}
+
+// Test mixed record types through sink
+TEST(SinkTest, MixedRecordTypes) {
+  auto backend = make_null_backend();
+  Sink sink(backend);
+  sink.start();
+
+  auto joint = std::make_shared<JointStateRecord>();
+  joint->id = "arm/joints";
+  sink.enqueue(joint);
+
+  auto img = std::make_shared<ImageRecord>();
+  img->id = "cam/color";
+  img->width = 640;
+  img->height = 480;
+  sink.enqueue(img);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  sink.stop();
+
+  EXPECT_EQ(backend->count(), 2);
+}

--- a/tests/test_sink.cpp
+++ b/tests/test_sink.cpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -52,8 +53,8 @@ TEST(SinkTest, StartStop_EmptyQueue) {
   EXPECT_EQ(backend->count(), 0);
 }
 
-// SINK-06: Double start is idempotent (no second thread spawned)
-TEST(SinkTest, DoubleStart_IsIdempotent) {
+// SINK-06: Double start does not crash and records are still processed
+TEST(SinkTest, DoubleStart_DoesNotCrash) {
   auto backend = make_null_backend();
   Sink sink(backend);
 
@@ -68,7 +69,7 @@ TEST(SinkTest, DoubleStart_IsIdempotent) {
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   sink.stop();
 
-  // Should still have processed exactly 1 record (not 2 from double drain)
+  // Record should still be processed normally after double start
   EXPECT_EQ(backend->count(), 1);
 }
 
@@ -125,8 +126,6 @@ TEST(SinkTest, EnqueueAndDrain_MultipleRecords) {
     sink.enqueue(rec);
   }
 
-  // Wait for drain
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
   sink.stop();
 
   EXPECT_EQ(backend->count(), N);
@@ -257,8 +256,6 @@ TEST(SinkTest, LargeBatch_DrainedCompletely) {
     sink.enqueue(rec);
   }
 
-  // Allow time for drain, then stop to flush remainder
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
   sink.stop();
 
   EXPECT_EQ(backend->count(), N);


### PR DESCRIPTION
### TL;DR

Added comprehensive unit tests for the Scheduler and Sink components to verify task scheduling, lifecycle management, and record processing functionality.

### What changed?

Added two new test files:

- `test_scheduler.cpp` - Tests for the dual-lane periodic task scheduler including:
  - Task registration and lane classification (high-res vs normal)
  - Start/stop lifecycle operations
  - Task execution verification and statistics tracking
  - Multiple task coordination and timing validation

- `test_sink.cpp` - Tests for the Sink drain loop and record delivery including:
  - Start/stop lifecycle with proper cleanup
  - Single and multiple record processing through NullBackend
  - Multi-threaded producer scenarios
  - Error handling for null records and missing backends
  - RAII destructor behavior

Both test suites are integrated into the CMake build system with proper linking to `trossen_sdk` and `GTest::gtest_main`.

### How to test?

Run the new test suites:
```bash
# Build and run scheduler tests
make test_scheduler && ./test_scheduler

# Build and run sink tests  
make test_sink && ./test_sink

# Or run all tests
ctest
```

### Why make this change?

These tests provide essential coverage for core runtime components that handle task scheduling and data processing. The Scheduler tests verify correct lane assignment, timing behavior, and statistics collection. The Sink tests ensure reliable record delivery and proper thread lifecycle management, which are critical for data pipeline integrity.