### PR TITLE
Add SessionManager unit tests for lifecycle, producers, and state management

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,10 @@ target_link_libraries(test_sink PRIVATE trossen_sdk GTest::gtest_main)
 add_executable(test_scheduler test_scheduler.cpp)
 target_link_libraries(test_scheduler PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_session_manager test_session_manager.cpp)
+target_link_libraries(test_session_manager PRIVATE trossen_sdk GTest::gtest_main)
+add_test(NAME test_session_manager COMMAND test_session_manager)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -79,3 +83,4 @@ gtest_discover_tests(test_queue_adapter)
 gtest_discover_tests(test_producer_registry)
 gtest_discover_tests(test_sink)
 gtest_discover_tests(test_scheduler)
+gtest_discover_tests(test_session_manager)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,7 +61,6 @@ target_link_libraries(test_scheduler PRIVATE trossen_sdk GTest::gtest_main)
 
 add_executable(test_session_manager test_session_manager.cpp)
 target_link_libraries(test_session_manager PRIVATE trossen_sdk GTest::gtest_main)
-add_test(NAME test_session_manager COMMAND test_session_manager)
 
 # Enable CTest integration
 include(GoogleTest)

--- a/tests/test_session_manager.cpp
+++ b/tests/test_session_manager.cpp
@@ -3,7 +3,7 @@
  * @brief Unit tests for SessionManager core lifecycle, polled producers, and state management
  *
  * Tests episode start/stop, producer registration guards, episode index tracking,
- * stats computation, max_episodes enforcement, and callback invocation.
+ * and stats computation.
  * Uses NullBackend via GlobalConfig to avoid real I/O.
  */
 
@@ -74,11 +74,7 @@ protected:
       }}
     };
 
-    try {
-      trossen::configuration::GlobalConfig::instance().load_from_json(config);
-    } catch (const std::exception&) {
-      // May already be loaded -- acceptable
-    }
+    trossen::configuration::GlobalConfig::instance().load_from_json(config);
   }
 };
 
@@ -209,14 +205,14 @@ TEST_F(SessionManagerTest, PolledProducer_RecordsReachBackend) {
 }
 
 // ============================================================================
-// SM-11: Episode complete callback
+// SM-10: Episode complete callback
 // ============================================================================
 
 // BUG: episode_complete_callback deadlocks in stop_episode().
 //
-// stop_episode() holds episode_mutex_ (line 253) and then calls stats() (line 319)
-// which also tries to lock episode_mutex_. Since std::mutex is not recursive, this
-// deadlocks on the same thread. This affects ANY use of set_episode_complete_callback().
+// stop_episode() holds episode_mutex_ and then calls stats(), which also tries to
+// lock episode_mutex_. Since std::mutex is not recursive, this deadlocks on the
+// same thread. This affects ANY use of set_episode_complete_callback().
 //
 // Recommended fix: either (a) release episode_mutex_ before calling the callback,
 // or (b) use a separate internal stats computation that does not acquire the lock,
@@ -227,22 +223,22 @@ TEST_F(SessionManagerTest, DISABLED_EpisodeCompleteCallback_Invoked) {
   SessionManager sm;
 
   std::atomic<bool> callback_fired{false};
-  uint64_t callback_episodes_completed = 0;
+  std::atomic<uint64_t> callback_episodes_completed{0};
   sm.set_episode_complete_callback(
     [&callback_fired, &callback_episodes_completed](const SessionManager::Stats& s) {
-      callback_fired = true;
-      callback_episodes_completed = s.total_episodes_completed;
+      callback_fired.store(true);
+      callback_episodes_completed.store(s.total_episodes_completed);
     });
 
   sm.start_episode();
   sm.stop_episode();
 
   EXPECT_TRUE(callback_fired.load());
-  EXPECT_EQ(callback_episodes_completed, 1);
+  EXPECT_EQ(callback_episodes_completed.load(), 1);
 }
 
 // ============================================================================
-// SM-10: Stats records_written_current tracks produced count
+// SM-11: Stats records_written_current tracks produced count
 // ============================================================================
 
 TEST_F(SessionManagerTest, Stats_RecordsWrittenTracked) {

--- a/tests/test_session_manager.cpp
+++ b/tests/test_session_manager.cpp
@@ -1,0 +1,297 @@
+/**
+ * @file test_session_manager.cpp
+ * @brief Unit tests for SessionManager core lifecycle, polled producers, and state management
+ *
+ * Tests episode start/stop, producer registration guards, episode index tracking,
+ * stats computation, max_episodes enforcement, and callback invocation.
+ * Uses NullBackend via GlobalConfig to avoid real I/O.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
+
+using trossen::data::JointStateRecord;
+using trossen::data::RecordBase;
+using trossen::data::Timestamp;
+using trossen::hw::PolledProducer;
+using trossen::runtime::SessionManager;
+
+// ============================================================================
+// Mock polled producer
+// ============================================================================
+
+// Concrete PolledProducer that emits a JointStateRecord per poll() call.
+// Increments stats_.produced so tests can verify the scheduler polled it.
+class MockPolledProducer : public PolledProducer {
+public:
+  MockPolledProducer() = default;
+  ~MockPolledProducer() override = default;
+
+  void poll(const std::function<void(std::shared_ptr<RecordBase>)>& emit) override {
+    auto rec = std::make_shared<JointStateRecord>();
+    rec->seq = seq_++;
+    rec->id = "mock/joints";
+    rec->positions = {1.0f, 2.0f, 3.0f};
+    emit(rec);
+    ++stats_.produced;
+  }
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    auto meta = std::make_shared<ProducerMetadata>();
+    meta->type = "mock";
+    meta->id = "mock_producer";
+    meta->name = "Mock Producer";
+    return meta;
+  }
+};
+
+// ============================================================================
+// Test fixture: loads minimal GlobalConfig with null backend
+// ============================================================================
+
+class SessionManagerTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    nlohmann::json config = {
+      {"session_manager", {
+        {"type", "session_manager"},
+        {"max_duration", 10.0},
+        {"max_episodes", 100},
+        {"backend_type", "null"}
+      }}
+    };
+
+    try {
+      trossen::configuration::GlobalConfig::instance().load_from_json(config);
+    } catch (const std::exception&) {
+      // May already be loaded -- acceptable
+    }
+  }
+};
+
+// ============================================================================
+// SM-01: Basic start/stop lifecycle
+// ============================================================================
+
+TEST_F(SessionManagerTest, StartStop_MinimalEpisode) {
+  SessionManager sm;
+  ASSERT_TRUE(sm.start_episode());
+  EXPECT_TRUE(sm.is_episode_active());
+
+  sm.stop_episode();
+  EXPECT_FALSE(sm.is_episode_active());
+}
+
+// ============================================================================
+// SM-02: stop_episode is no-op when not active
+// ============================================================================
+
+TEST_F(SessionManagerTest, StopEpisode_NoOp_WhenNotActive) {
+  SessionManager sm;
+  EXPECT_FALSE(sm.is_episode_active());
+  EXPECT_NO_THROW(sm.stop_episode());
+  EXPECT_FALSE(sm.is_episode_active());
+}
+
+// ============================================================================
+// SM-03: add_producer with null throws
+// ============================================================================
+
+TEST_F(SessionManagerTest, AddProducer_NullThrows) {
+  SessionManager sm;
+  EXPECT_THROW(
+    sm.add_producer(nullptr, std::chrono::milliseconds(100)),
+    std::invalid_argument);
+}
+
+// ============================================================================
+// SM-04: add_producer during active episode throws
+// ============================================================================
+
+TEST_F(SessionManagerTest, AddProducer_DuringEpisode_Throws) {
+  SessionManager sm;
+  sm.start_episode();
+
+  auto producer = std::make_shared<MockPolledProducer>();
+  EXPECT_THROW(
+    sm.add_producer(producer, std::chrono::milliseconds(100)),
+    std::runtime_error);
+
+  sm.stop_episode();
+}
+
+// ============================================================================
+// SM-05: Double start returns false
+// ============================================================================
+
+TEST_F(SessionManagerTest, DoubleStart_ReturnsFalse) {
+  SessionManager sm;
+  ASSERT_TRUE(sm.start_episode());
+  EXPECT_FALSE(sm.start_episode());
+  sm.stop_episode();
+}
+
+// ============================================================================
+// SM-06: Episode index increments per episode
+// ============================================================================
+
+TEST_F(SessionManagerTest, EpisodeIndex_IncrementsPerEpisode) {
+  SessionManager sm;
+
+  // Episode 0
+  ASSERT_TRUE(sm.start_episode());
+  sm.stop_episode();
+
+  // Episode 1
+  ASSERT_TRUE(sm.start_episode());
+  sm.stop_episode();
+
+  auto s = sm.stats();
+  EXPECT_EQ(s.total_episodes_completed, 2);
+}
+
+// ============================================================================
+// SM-07: is_episode_active reflects state
+// ============================================================================
+
+TEST_F(SessionManagerTest, IsEpisodeActive_ReflectsState) {
+  SessionManager sm;
+
+  EXPECT_FALSE(sm.is_episode_active());
+  sm.start_episode();
+  EXPECT_TRUE(sm.is_episode_active());
+  sm.stop_episode();
+  EXPECT_FALSE(sm.is_episode_active());
+}
+
+// ============================================================================
+// SM-08: shutdown stops active episode
+// ============================================================================
+
+TEST_F(SessionManagerTest, Shutdown_StopsActiveEpisode) {
+  SessionManager sm;
+  sm.start_episode();
+  EXPECT_TRUE(sm.is_episode_active());
+
+  sm.shutdown();
+  EXPECT_FALSE(sm.is_episode_active());
+}
+
+// ============================================================================
+// SM-09: Polled producer records reach backend
+// ============================================================================
+
+TEST_F(SessionManagerTest, PolledProducer_RecordsReachBackend) {
+  SessionManager sm;
+  auto producer = std::make_shared<MockPolledProducer>();
+  sm.add_producer(producer, std::chrono::milliseconds(10));
+
+  sm.start_episode();
+  // Let the scheduler poll the producer several times
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  sm.stop_episode();
+
+  // Producer should have been polled at least once
+  EXPECT_GT(producer->stats().produced, 0);
+}
+
+// ============================================================================
+// SM-11: Episode complete callback
+// ============================================================================
+
+// BUG: episode_complete_callback deadlocks in stop_episode().
+//
+// stop_episode() holds episode_mutex_ (line 253) and then calls stats() (line 319)
+// which also tries to lock episode_mutex_. Since std::mutex is not recursive, this
+// deadlocks on the same thread. This affects ANY use of set_episode_complete_callback().
+//
+// Recommended fix: either (a) release episode_mutex_ before calling the callback,
+// or (b) use a separate internal stats computation that does not acquire the lock,
+// or (c) switch episode_mutex_ to std::recursive_mutex.
+//
+// This test is DISABLED until the deadlock is fixed.
+TEST_F(SessionManagerTest, DISABLED_EpisodeCompleteCallback_Invoked) {
+  SessionManager sm;
+
+  std::atomic<bool> callback_fired{false};
+  uint64_t callback_episodes_completed = 0;
+  sm.set_episode_complete_callback(
+    [&callback_fired, &callback_episodes_completed](const SessionManager::Stats& s) {
+      callback_fired = true;
+      callback_episodes_completed = s.total_episodes_completed;
+    });
+
+  sm.start_episode();
+  sm.stop_episode();
+
+  EXPECT_TRUE(callback_fired.load());
+  EXPECT_EQ(callback_episodes_completed, 1);
+}
+
+// ============================================================================
+// SM-10: Stats records_written_current tracks produced count
+// ============================================================================
+
+TEST_F(SessionManagerTest, Stats_RecordsWrittenTracked) {
+  SessionManager sm;
+  auto producer = std::make_shared<MockPolledProducer>();
+  sm.add_producer(producer, std::chrono::milliseconds(10));
+
+  sm.start_episode();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  // Check stats while episode is active
+  auto s = sm.stats();
+  // Records should be non-zero (scheduler has been polling)
+  EXPECT_GT(s.records_written_current, 0);
+
+  sm.stop_episode();
+}
+
+// ============================================================================
+// Shutdown idempotency: multiple shutdown calls are safe
+// ============================================================================
+
+TEST_F(SessionManagerTest, Shutdown_IsIdempotent) {
+  SessionManager sm;
+  sm.start_episode();
+  sm.shutdown();
+  EXPECT_NO_THROW(sm.shutdown());
+  EXPECT_NO_THROW(sm.shutdown());
+}
+
+// ============================================================================
+// add_push_producer during active episode throws
+// ============================================================================
+
+TEST_F(SessionManagerTest, AddPushProducer_DuringEpisode_Throws) {
+  SessionManager sm;
+  sm.start_episode();
+
+  // Create a minimal push producer
+  class MinimalPushProducer : public trossen::hw::PushProducer {
+  public:
+    bool start(const std::function<void(std::shared_ptr<RecordBase>)>&) override {
+      return true;
+    }
+    void stop() override {}
+  };
+
+  auto pp = std::make_shared<MinimalPushProducer>();
+  EXPECT_THROW(sm.add_push_producer(pp), std::runtime_error);
+
+  sm.stop_episode();
+}


### PR DESCRIPTION
### TL;DR

Added comprehensive unit tests for the SessionManager component to verify core lifecycle operations, producer management, and state tracking functionality.

### What changed?

Added a new test file `test_session_manager.cpp` with 11 test cases covering:
- Episode start/stop lifecycle and state management
- Producer registration validation and timing restrictions
- Episode index tracking and statistics computation
- Callback invocation and shutdown behavior
- Error handling for invalid operations

The tests use a mock polled producer and null backend configuration to avoid real I/O operations during testing.

### How to test?

Run the new test suite:
```bash
ctest -R test_session_manager
```

Or run all tests to ensure no regressions:
```bash
ctest
```

### Why make this change?

The SessionManager is a critical component that manages data collection episodes and producer scheduling. These tests ensure proper behavior of core functionality including lifecycle management, thread safety guards, and statistics tracking. One test is disabled due to an identified deadlock bug in the episode complete callback mechanism, which is documented for future resolution.