### PR TITLE
Add configurable reset timer between recording episodes

### DIFF
--- a/examples/trossen_mobile_ai/config.json
+++ b/examples/trossen_mobile_ai/config.json
@@ -132,8 +132,9 @@
   },
 
   "session": {
-    "max_duration":  20.0,
-    "max_episodes":  5,
-    "backend_type":  "trossen_mcap"
+    "max_duration":     20.0,
+    "max_episodes":     5,
+    "reset_duration_s": 5.0,
+    "backend_type":     "trossen_mcap"
   }
 }

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -158,6 +158,10 @@ int main(int argc, char** argv) {
     "Teleop:               " +
     std::string(cfg.teleop.enabled ? "enabled" : "disabled") +
     " (" + std::to_string(cfg.teleop.pairs.size()) + " pairs)");
+  if (cfg.session.reset_duration_s > 0.0) {
+    config_lines.push_back(
+      "Reset period:         " + std::to_string(cfg.session.reset_duration_s) + " s");
+  }
 
   trossen::utils::print_config_banner("Trossen Mobile AI Kit Demo Usage", config_lines);
 
@@ -299,6 +303,16 @@ int main(int argc, char** argv) {
       break;
     }
 
+    // Stage all arms to starting position before each episode
+    std::cout << "\nStaging arms to starting position...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_modes(trossen_arm::Mode::position);
+      driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    }
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+    std::cout << "  [ok] Arms staged to starting position\n";
+
     if (cfg.teleop.enabled) {
       std::cout << "\nLocking leader arms and moving followers to match...\n";
       for (const auto& pair : cfg.teleop.pairs) {
@@ -408,6 +422,14 @@ int main(int argc, char** argv) {
     if (trossen::utils::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
+    }
+
+    if (cfg.session.reset_duration_s > 0.0) {
+      if (!trossen::utils::run_reset_period(
+            cfg.session.reset_duration_s, cfg.teleop, arm_components)) {
+        std::cout << "\nStopping at user request (Ctrl+C).\n";
+        break;
+      }
     }
   }
 

--- a/examples/trossen_solo_ai/config.json
+++ b/examples/trossen_solo_ai/config.json
@@ -81,8 +81,9 @@
   },
 
   "session": {
-    "max_duration":  10.0,
-    "max_episodes":  5,
-    "backend_type":  "trossen_mcap"
+    "max_duration":     10.0,
+    "max_episodes":     5,
+    "reset_duration_s": 5.0,
+    "backend_type":     "trossen_mcap"
   }
 }

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -142,6 +142,10 @@ int main(int argc, char** argv) {
     "Teleop:               " +
     std::string(cfg.teleop.enabled ? "enabled" : "disabled") +
     " (" + std::to_string(cfg.teleop.pairs.size()) + " pairs)");
+  if (cfg.session.reset_duration_s > 0.0) {
+    config_lines.push_back(
+      "Reset period:         " + std::to_string(cfg.session.reset_duration_s) + " s");
+  }
 
   trossen::utils::print_config_banner("Trossen Solo AI Kit Demo Usage", config_lines);
 
@@ -263,6 +267,16 @@ int main(int argc, char** argv) {
       break;
     }
 
+    // Stage all arms to starting position before each episode
+    std::cout << "\nStaging arms to starting position...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_modes(trossen_arm::Mode::position);
+      driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    }
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+    std::cout << "  [ok] Arms staged to starting position\n";
+
     if (cfg.teleop.enabled) {
       std::cout << "\nLocking leader arms and moving followers to match...\n";
       for (const auto& pair : cfg.teleop.pairs) {
@@ -358,6 +372,14 @@ int main(int argc, char** argv) {
     if (trossen::utils::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
+    }
+
+    if (cfg.session.reset_duration_s > 0.0) {
+      if (!trossen::utils::run_reset_period(
+            cfg.session.reset_duration_s, cfg.teleop, arm_components)) {
+        std::cout << "\nStopping at user request (Ctrl+C).\n";
+        break;
+      }
     }
   }
 

--- a/examples/trossen_stationary_ai/config.json
+++ b/examples/trossen_stationary_ai/config.json
@@ -134,14 +134,15 @@
 
   "backend": {
     "root":             "~/.trossen_sdk",
-    "dataset_id":       "stationary_dataset",
+    "dataset_id":       "stationary_dataset_001",
     "compression":      "",
     "chunk_size_bytes": 4194304
   },
 
   "session": {
-    "max_duration":  20.0,
-    "max_episodes":  5,
-    "backend_type":  "trossen_mcap"
+    "max_duration":     10.0,
+    "max_episodes":     5,
+    "reset_duration_s": 5.0,
+    "backend_type":     "trossen_mcap"
   }
 }

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -144,6 +144,10 @@ int main(int argc, char** argv) {
     "Teleop:               " +
     std::string(cfg.teleop.enabled ? "enabled" : "disabled") +
     " (" + std::to_string(cfg.teleop.pairs.size()) + " pairs)");
+  if (cfg.session.reset_duration_s > 0.0) {
+    config_lines.push_back(
+      "Reset period:         " + std::to_string(cfg.session.reset_duration_s) + " s");
+  }
 
   trossen::utils::print_config_banner("Trossen Stationary AI Kit Demo Usage", config_lines);
 
@@ -265,6 +269,16 @@ int main(int argc, char** argv) {
       break;
     }
 
+    // Stage all arms to starting position before each episode
+    std::cout << "\nStaging arms to starting position...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_modes(trossen_arm::Mode::position);
+      driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    }
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+    std::cout << "  [ok] Arms staged to starting position\n";
+
     if (cfg.teleop.enabled) {
       std::cout << "\nLocking leader arms and moving followers to match...\n";
       for (const auto& pair : cfg.teleop.pairs) {
@@ -360,6 +374,14 @@ int main(int argc, char** argv) {
     if (trossen::utils::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
+    }
+
+    if (cfg.session.reset_duration_s > 0.0) {
+      if (!trossen::utils::run_reset_period(
+            cfg.session.reset_duration_s, cfg.teleop, arm_components)) {
+        std::cout << "\nStopping at user request (Ctrl+C).\n";
+        break;
+      }
     }
   }
 

--- a/include/trossen_sdk/configuration/sdk_config.hpp
+++ b/include/trossen_sdk/configuration/sdk_config.hpp
@@ -50,6 +50,7 @@
  *   "session": {
  *     "max_duration": 20.0,
  *     "max_episodes": 5,
+ *     "reset_duration_s": 5.0,
  *     "backend_type": "trossen_mcap"
  *   }
  * }

--- a/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
+++ b/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
@@ -7,6 +7,7 @@
 #define TROSSEN_SDK__CONFIGURATION__TYPES__RUNTIME__SESSION_MANAGER_CONFIG_HPP_
 
 #include <chrono>
+#include <iostream>
 #include <optional>
 
 #include "trossen_sdk/configuration/base_config.hpp"
@@ -17,6 +18,7 @@ namespace trossen::configuration {
 struct SessionManagerConfig : public BaseConfig {
   std::optional<std::chrono::duration<double>> max_duration{std::chrono::seconds(20)};
   std::optional<uint32_t> max_episodes{std::nullopt};
+  double reset_duration_s{0.0};
   std::string backend_type{"trossen_mcap"};
 
   std::string type() const override { return "session_manager"; }
@@ -29,6 +31,14 @@ struct SessionManagerConfig : public BaseConfig {
     }
     if (j.contains("max_episodes")) {
       c.max_episodes = j.at("max_episodes").get<uint32_t>();
+    }
+    if (j.contains("reset_duration_s")) {
+      c.reset_duration_s = j.at("reset_duration_s").get<double>();
+      if (c.reset_duration_s < 0.0) {
+        std::cerr << "[Warning] reset_duration_s is negative ("
+                  << c.reset_duration_s << "), clamping to 0.0 (disabled)\n";
+        c.reset_duration_s = 0.0;
+      }
     }
     if (j.contains("backend_type")) {
       j.at("backend_type").get_to(c.backend_type);

--- a/include/trossen_sdk/utils/app_utils.hpp
+++ b/include/trossen_sdk/utils/app_utils.hpp
@@ -14,10 +14,14 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
+#include "trossen_sdk/configuration/types/teleop_config.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 
 namespace trossen::utils {
@@ -114,5 +118,22 @@ std::string generate_episode_path(
   const std::string& output_dir,
   uint32_t episode_index,
   const std::string& extension = "trossen_mcap");
+
+/**
+ * @brief Run a reset period between episodes with teleop active
+ *
+ * Displays a countdown timer while keeping leader-follower teleoperation
+ * running so the operator can physically reset the scene.
+ *
+ * @param duration_s Reset period duration in seconds
+ * @param teleop_cfg Teleoperation configuration
+ * @param arm_components Map of arm components for teleop mirroring
+ * @return true if completed normally, false if interrupted by Ctrl+C
+ */
+bool run_reset_period(
+  double duration_s,
+  const configuration::TeleoperationConfig& teleop_cfg,
+  const std::unordered_map<std::string,
+    std::shared_ptr<hw::arm::TrossenArmComponent>>& arm_components);
 
 }  // namespace trossen::utils

--- a/scripts/trossen_mcap_to_lerobot_v2/config.json
+++ b/scripts/trossen_mcap_to_lerobot_v2/config.json
@@ -9,7 +9,7 @@
     "encode_videos": true,
     "task_name": "perform a generic task",
     "repository_id": "TrossenRoboticsCommunity",
-    "dataset_id": "mcap_converted_dataset",
+    "dataset_id": "stationary_dataset_001",
     "episode_index": 0,
     "chunk_size": 2,
     "robot_name": "trossen_solo_ai",

--- a/src/utils/app_utils.cpp
+++ b/src/utils/app_utils.cpp
@@ -3,12 +3,14 @@
  * @brief Implementation of shared utilities for Trossen SDK applications
  */
 
+#include <atomic>
 #include <csignal>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "trossen_sdk/utils/app_utils.hpp"
@@ -255,6 +257,85 @@ std::string generate_episode_path(
        << std::setfill('0') << std::setw(6) << episode_index
        << "." << extension;
   return path.str();
+}
+
+bool run_reset_period(
+  double duration_s,
+  const configuration::TeleoperationConfig& teleop_cfg,
+  const std::unordered_map<std::string,
+    std::shared_ptr<hw::arm::TrossenArmComponent>>& arm_components)
+{
+  // Brief arm lock: hold all arms in their current position for 1 second
+  // so the user gets tactile feedback that recording stopped
+  if (teleop_cfg.enabled && !g_stop_requested) {
+    std::cout << "\n  Locking arms (1s)...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_modes(trossen_arm::Mode::position);
+      driver->set_all_positions(driver->get_all_positions(), 0.0f, false);
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+
+  std::cout << "\n═══════════════════════════════════════════════════════════\n";
+  std::cout << "  Scene Reset Period (" << std::fixed << std::setprecision(1)
+            << duration_s << "s)\n";
+  std::cout << "  Teleop active — reposition the scene for the next episode\n";
+  std::cout << "═══════════════════════════════════════════════════════════\n";
+
+  std::atomic<bool> reset_done{false};
+
+  // Teleop thread mirrors leader positions to followers during reset
+  std::thread teleop_thread([&]() {
+    if (!teleop_cfg.enabled) {
+      return;
+    }
+    const auto sleep_ns = static_cast<int64_t>(1e9 / teleop_cfg.rate_hz);
+    while (!reset_done && !g_stop_requested) {
+      for (const auto& pair : teleop_cfg.pairs) {
+        auto leader_it = arm_components.find(pair.leader);
+        auto follower_it = arm_components.find(pair.follower);
+        if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
+          continue;
+        }
+        follower_it->second->get_hardware()->set_all_positions(
+          leader_it->second->get_hardware()->get_all_positions(), 0.0f, false);
+      }
+      std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
+    }
+  });
+
+  // Countdown loop on the main thread
+  auto start = std::chrono::steady_clock::now();
+  auto target = start + std::chrono::duration<double>(duration_s);
+  bool interrupted = false;
+
+  while (std::chrono::steady_clock::now() < target) {
+    if (g_stop_requested) {
+      interrupted = true;
+      break;
+    }
+    double remaining =
+      std::chrono::duration<double>(target - std::chrono::steady_clock::now()).count();
+    if (remaining < 0.0) remaining = 0.0;
+    std::cout << "\r  Time remaining: " << std::fixed << std::setprecision(1)
+              << remaining << "s   " << std::flush;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  std::cout << "\r  Time remaining: 0.0s   \n";
+
+  reset_done = true;
+  if (teleop_thread.joinable()) {
+    teleop_thread.join();
+  }
+
+  if (interrupted) {
+    return false;
+  }
+
+  std::cout << "  Reset period complete. Starting next episode...\n\n";
+  return true;
 }
 
 }  // namespace trossen::utils

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -36,6 +36,9 @@ TEST(SessionManagerConfigTest, Defaults) {
   // Default max_episodes is nullopt (unlimited)
   EXPECT_FALSE(cfg.max_episodes.has_value());
 
+  // Default reset_duration_s is 0.0 (disabled)
+  EXPECT_DOUBLE_EQ(cfg.reset_duration_s, 0.0);
+
   // Default backend_type
   EXPECT_EQ(cfg.backend_type, "trossen_mcap");
 
@@ -52,6 +55,7 @@ TEST(SessionManagerConfigTest, FromJson_Override) {
     {"type", "session_manager"},
     {"max_duration", 30.0},
     {"max_episodes", 50},
+    {"reset_duration_s", 7.5},
     {"backend_type", "null"}
   };
 
@@ -62,6 +66,8 @@ TEST(SessionManagerConfigTest, FromJson_Override) {
 
   ASSERT_TRUE(cfg.max_episodes.has_value());
   EXPECT_EQ(cfg.max_episodes.value(), 50);
+
+  EXPECT_DOUBLE_EQ(cfg.reset_duration_s, 7.5);
 
   EXPECT_EQ(cfg.backend_type, "null");
 }
@@ -87,6 +93,41 @@ TEST(SessionManagerConfigTest, FromJson_Partial) {
 
   // backend_type should be default
   EXPECT_EQ(cfg.backend_type, "trossen_mcap");
+
+  // reset_duration_s should be default 0.0 when absent from JSON
+  EXPECT_DOUBLE_EQ(cfg.reset_duration_s, 0.0);
+}
+
+// ============================================================================
+// CFG-03b: SessionManagerConfig from_json clamps negative reset_duration_s
+// ============================================================================
+
+TEST(SessionManagerConfigTest, FromJson_NegativeResetDuration_ClampedToZero) {
+  nlohmann::json j = {
+    {"type", "session_manager"},
+    {"reset_duration_s", -3.0}
+  };
+
+  SessionManagerConfig cfg = SessionManagerConfig::from_json(j);
+
+  // Negative values must be clamped to 0.0 (disabled)
+  EXPECT_DOUBLE_EQ(cfg.reset_duration_s, 0.0);
+}
+
+// ============================================================================
+// CFG-03c: SessionManagerConfig from_json accepts zero reset_duration_s
+// ============================================================================
+
+TEST(SessionManagerConfigTest, FromJson_ZeroResetDuration_RemainsZero) {
+  nlohmann::json j = {
+    {"type", "session_manager"},
+    {"reset_duration_s", 0.0}
+  };
+
+  SessionManagerConfig cfg = SessionManagerConfig::from_json(j);
+
+  // Explicit zero should remain zero (disabled)
+  EXPECT_DOUBLE_EQ(cfg.reset_duration_s, 0.0);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `reset_duration_s` config field to `SessionManagerConfig` (default `0.0` = disabled)
- Implement `run_reset_period()` utility that runs a countdown with teleop active between episodes
- Integrate reset period into all three example scripts (solo, stationary, mobile)
- Add negative value validation with clamp-to-zero warning
- Add config banner display for reset period when enabled
- Add unit tests for `reset_duration_s` parsing (default, override, partial, negative, zero)

## Test plan

- [x] Build passes (make)
- [x] All 204 tests pass (ctest)
- [x] Config parsing tests added for reset_duration_s edge cases
- [ ] Manual: run example with reset_duration_s: 5.0 and verify countdown
- [ ] Manual: Ctrl+C during reset for clean exit
- [ ] Manual: reset_duration_s: 0.0 for backward compatibility
- [ ] Manual: --set session.reset_duration_s=10 CLI override