### PR TITLE
Add ZED camera hardware component and push producer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # optional hardware (e.g., Zed cameras)? Where do we draw the line between mandatory
 # and opt-in dependencies?
 option(TROSSEN_ENABLE_REALSENSE "Enable Intel RealSense support" ON)
+option(TROSSEN_ENABLE_ZED "Enable StereoLabs ZED camera support" OFF)
 
 add_library(trossen_sdk SHARED
   src/backends/backend_registry.cpp
@@ -56,6 +57,24 @@ if(TROSSEN_ENABLE_REALSENSE)
   find_package(fastcdr REQUIRED)
   find_package(fastrtps REQUIRED)
   find_package(realsense2 REQUIRED)
+endif()
+
+if(TROSSEN_ENABLE_ZED)
+  message(STATUS "StereoLabs ZED support enabled")
+  target_sources(trossen_sdk PRIVATE
+    src/hw/camera/zed_camera_component.cpp
+    src/hw/camera/zed_push_producer.cpp
+  )
+  target_compile_definitions(trossen_sdk PRIVATE TROSSEN_ENABLE_ZED)
+
+  # ZED SDK ships its own CMake config; ZED_DIR must point to the install root
+  # (e.g. /usr/local/zed).
+  find_package(ZED REQUIRED HINTS ${ZED_DIR})
+  find_package(CUDA ${ZED_CUDA_VERSION} REQUIRED)
+
+  target_include_directories(trossen_sdk PUBLIC ${ZED_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS})
+  target_link_directories(trossen_sdk PUBLIC ${ZED_LIBRARY_DIR})
+  target_link_libraries(trossen_sdk PUBLIC ${ZED_LIBRARIES} ${CUDA_LIBRARIES})
 endif()
 
 # Add architecture-specific CMAKE_PREFIX_PATH

--- a/include/trossen_sdk/configuration/types/producers/producer_config.hpp
+++ b/include/trossen_sdk/configuration/types/producers/producer_config.hpp
@@ -35,6 +35,7 @@ namespace trossen::configuration {
  *  - "trossen_arm"      - arm joint-state producer
  *  - "realsense_camera" - Intel RealSense image producer
  *  - "opencv_camera"    - OpenCV/V4L2 image producer
+ *  - "zed_camera"       - StereoLabs ZED stereo camera producer
  *  - "slate_base"       - SLATE mobile base velocity producer
  */
 struct ProducerConfig {

--- a/include/trossen_sdk/hw/camera/zed_camera_component.hpp
+++ b/include/trossen_sdk/hw/camera/zed_camera_component.hpp
@@ -92,7 +92,7 @@ public:
   const std::string& get_depth_mode_str() const { return depth_mode_str_; }
 
 private:
-  /// @brief Parse a depth mode string to sl::DEPTH_MODE, with deprecation warnings
+  /// @brief Parse a depth mode string to sl::DEPTH_MODE
   static sl::DEPTH_MODE parse_depth_mode(const std::string& mode_str);
 
   /// @brief Parse a resolution string to sl::RESOLUTION
@@ -104,7 +104,7 @@ private:
   int height_{0};
   int fps_{0};
   bool use_depth_{false};
-  std::string depth_mode_str_{"NEURAL"};
+  std::string depth_mode_str_{"NONE"};
 };
 
 }  // namespace trossen::hw::camera

--- a/include/trossen_sdk/hw/camera/zed_camera_component.hpp
+++ b/include/trossen_sdk/hw/camera/zed_camera_component.hpp
@@ -1,0 +1,112 @@
+/**
+ * @file zed_camera_component.hpp
+ * @brief Hardware component wrapper for StereoLabs ZED stereo cameras
+ *
+ * Owns an sl::Camera instance and exposes it to the ZedPushProducer via
+ * get_hardware().  The ZED SDK is CUDA-based; sl::Camera::open() allocates
+ * GPU context, so each component maps to exactly one physical camera.
+ *
+ * Build gate: compiled only when TROSSEN_ENABLE_ZED=ON (CMake option).
+ */
+
+#ifndef TROSSEN_SDK__HW__CAMERA__ZED_CAMERA_COMPONENT_HPP_
+#define TROSSEN_SDK__HW__CAMERA__ZED_CAMERA_COMPONENT_HPP_
+
+#include <memory>
+#include <string>
+
+#include "nlohmann/json.hpp"
+#include "sl/Camera.hpp"
+
+#include "trossen_sdk/hw/hardware_component.hpp"
+
+namespace trossen::hw::camera {
+
+/**
+ * @brief Hardware component for StereoLabs ZED stereo cameras (ZED 2, ZED 2i,
+ *        ZED Mini, ZED X, ZED X Mini).
+ *
+ * Wraps sl::Camera; the camera is opened during configure() and remains open
+ * until the component is destroyed.  A shared_ptr<sl::Camera> is exposed so
+ * that the push producer can call grab() / retrieveImage() / retrieveMeasure()
+ * on the same session.
+ *
+ * Registered in HardwareRegistry as @c "zed_camera".
+ */
+class ZedCameraComponent : public HardwareComponent {
+public:
+  /**
+   * @brief Constructor
+   *
+   * @param identifier Component identifier (e.g. "zed_0", "depth_cam")
+   */
+  explicit ZedCameraComponent(const std::string& identifier)
+    : HardwareComponent(identifier) {}
+  ~ZedCameraComponent() override;
+
+  /**
+   * @brief Configure and open the ZED camera
+   *
+   * Expected JSON keys (all optional except serial_number):
+   * @code
+   * {
+   *   "serial_number":  "12345678",
+   *   "resolution":     "HD720",       // HD2K | HD1080 | HD720 | VGA | AUTO
+   *   "fps":            30,
+   *   "depth_mode":     "NEURAL",      // NONE | NEURAL_LIGHT | NEURAL | NEURAL_PLUS
+   *   "use_depth":      true,
+   *   "extra": { ... }                 // passthrough JSON for advanced settings
+   * }
+   * @endcode
+   *
+   * @param config JSON configuration
+   * @throws std::runtime_error on open failure
+   */
+  void configure(const nlohmann::json& config) override;
+
+  std::string get_type() const override { return "zed_camera"; }
+  nlohmann::json get_info() const override;
+
+  /// @brief Get camera serial number
+  std::string get_serial_number() const { return serial_number_; }
+
+  /// @brief Check if the camera is opened and ready
+  bool is_opened() const;
+
+  /// @brief Get negotiated frame width (after open)
+  int get_width() const { return width_; }
+
+  /// @brief Get negotiated frame height (after open)
+  int get_height() const { return height_; }
+
+  /// @brief Get negotiated frame rate
+  int get_fps() const { return fps_; }
+
+  /// @brief Get the underlying sl::Camera handle (valid after configure())
+  std::shared_ptr<sl::Camera> get_hardware() const { return camera_; }
+
+  /// @brief Whether depth was requested at configure time
+  bool get_use_depth() const { return use_depth_; }
+
+  /// @brief Get the configured depth mode string (for logging)
+  const std::string& get_depth_mode_str() const { return depth_mode_str_; }
+
+private:
+  /// @brief Parse a depth mode string to sl::DEPTH_MODE, with deprecation warnings
+  static sl::DEPTH_MODE parse_depth_mode(const std::string& mode_str);
+
+  /// @brief Parse a resolution string to sl::RESOLUTION
+  static sl::RESOLUTION parse_resolution(const std::string& res_str);
+
+  std::shared_ptr<sl::Camera> camera_;
+  std::string serial_number_{"unspecified"};
+  int width_{0};
+  int height_{0};
+  int fps_{0};
+  bool use_depth_{false};
+  std::string depth_mode_str_{"NEURAL"};
+};
+
+}  // namespace trossen::hw::camera
+
+#endif  // TROSSEN_SDK__HW__CAMERA__ZED_CAMERA_COMPONENT_HPP_

--- a/include/trossen_sdk/hw/camera/zed_push_producer.hpp
+++ b/include/trossen_sdk/hw/camera/zed_push_producer.hpp
@@ -35,8 +35,8 @@ namespace trossen::hw::camera {
  * The producer uses VIEW::LEFT_BGR (SDK 5.x) to retrieve a 3-channel BGR
  * image directly from the GPU pipeline, avoiding a redundant BGRA->BGR
  * strip.  When depth is enabled, MEASURE::DEPTH (F32_C1) is retrieved and
- * sanitized (NaN/Inf replaced, then quantized to CV_16UC1 millimetres)
- * for downstream compatibility with the RealSense depth path.
+ * sanitized (NaN/Inf replaced) and quantized to CV_16UC1 millimetres
+ * for backend consumption.
  *
  * Registered as "zed_camera" in PushProducerRegistry.
  */
@@ -48,14 +48,14 @@ public:
   struct Config {
     std::string stream_id{"zed_camera"};
     std::string color_encoding{"bgr8"};
-    bool use_device_time{true};
+    bool use_device_time{false};
     int timeout_ms{3000};
     int fps{30};
     bool remove_saturated_areas{false};  ///< SDK 5.x default is false
   };
 
   /**
-   * @brief Metadata for ZedPushProducer (mirrors RealsensePushProducerMetadata)
+   * @brief Metadata for ZedPushProducer
    */
   struct ZedPushProducerMetadata : public ::trossen::hw::PolledProducer::ProducerMetadata {
     int width{0};

--- a/include/trossen_sdk/hw/camera/zed_push_producer.hpp
+++ b/include/trossen_sdk/hw/camera/zed_push_producer.hpp
@@ -1,0 +1,117 @@
+/**
+ * @file zed_push_producer.hpp
+ * @brief Push-style producer for StereoLabs ZED stereo cameras (color + optional depth)
+ *
+ * Owns a dedicated grab thread that calls sl::Camera::grab() in a tight loop.
+ * Each grabbed frame is converted to a cv::Mat and emitted as an ImageRecord
+ * (with optional depth).
+ *
+ * Build gate: compiled only when TROSSEN_ENABLE_ZED=ON (CMake option).
+ */
+
+#ifndef TROSSEN_SDK__HW__CAMERA__ZED_PUSH_PRODUCER_HPP_
+#define TROSSEN_SDK__HW__CAMERA__ZED_PUSH_PRODUCER_HPP_
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "nlohmann/json.hpp"
+#include "opencv2/imgproc.hpp"
+#include "sl/Camera.hpp"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::hw::camera {
+
+/**
+ * @brief Unified PushProducer for ZED stereo cameras
+ *
+ * The producer uses VIEW::LEFT_BGR (SDK 5.x) to retrieve a 3-channel BGR
+ * image directly from the GPU pipeline, avoiding a redundant BGRA->BGR
+ * strip.  When depth is enabled, MEASURE::DEPTH (F32_C1) is retrieved and
+ * sanitized (NaN/Inf replaced, then quantized to CV_16UC1 millimetres)
+ * for downstream compatibility with the RealSense depth path.
+ *
+ * Registered as "zed_camera" in PushProducerRegistry.
+ */
+class ZedPushProducer : public ::trossen::hw::PushProducer {
+public:
+  /**
+   * @brief Configuration parameters for ZedPushProducer
+   */
+  struct Config {
+    std::string stream_id{"zed_camera"};
+    std::string color_encoding{"bgr8"};
+    bool use_device_time{true};
+    int timeout_ms{3000};
+    int fps{30};
+    bool remove_saturated_areas{false};  ///< SDK 5.x default is false
+  };
+
+  /**
+   * @brief Metadata for ZedPushProducer (mirrors RealsensePushProducerMetadata)
+   */
+  struct ZedPushProducerMetadata : public ::trossen::hw::PolledProducer::ProducerMetadata {
+    int width{0};
+    int height{0};
+    int fps{30};
+    std::string codec{"av1"};
+    std::string pix_fmt{"yuv420p"};
+    int channels{3};
+    bool has_audio{false};
+    bool has_depth{false};
+
+    nlohmann::ordered_json get_info() const override;
+    nlohmann::ordered_json get_stream_info() const override;
+  };
+
+  /**
+   * @brief Construct a ZedPushProducer
+   *
+   * @param hardware Hardware component (must be ZedCameraComponent)
+   * @param config JSON configuration
+   * @throws std::runtime_error if hardware is wrong type or camera is null
+   */
+  ZedPushProducer(
+    std::shared_ptr<::trossen::hw::HardwareComponent> hardware,
+    const nlohmann::json& config);
+
+  ~ZedPushProducer() override;
+
+  bool start(
+    const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+  void stop() override;
+
+  std::shared_ptr<::trossen::hw::PolledProducer::ProducerMetadata> metadata() const override {
+    return std::make_shared<ZedPushProducerMetadata>(metadata_);
+  }
+
+private:
+  /// @brief Main grab + emit loop (runs on push_thread_)
+  void push_loop(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit);
+
+  Config cfg_;
+  ZedPushProducerMetadata metadata_;
+  std::thread push_thread_;
+  std::atomic<bool> running_{false};
+
+  /// @brief Shared ZED camera handle (from ZedCameraComponent)
+  std::shared_ptr<sl::Camera> camera_;
+
+  /// @brief Whether depth capture is enabled
+  bool use_depth_{false};
+
+  /// @brief Reusable sl::Mat buffers to avoid per-frame GPU allocation
+  sl::Mat sl_color_;
+  sl::Mat sl_depth_;
+};
+
+}  // namespace trossen::hw::camera
+
+#endif  // TROSSEN_SDK__HW__CAMERA__ZED_PUSH_PRODUCER_HPP_

--- a/src/hw/camera/zed_camera_component.cpp
+++ b/src/hw/camera/zed_camera_component.cpp
@@ -87,10 +87,10 @@ void ZedCameraComponent::configure(const nlohmann::json& config) {
   }
 
   // Optional resolution / fps / depth settings
-  std::string resolution_str = config.value("resolution", "AUTO");
+  std::string resolution_str = config.value("resolution", "HD720");
   int requested_fps = config.value("fps", 0);
   use_depth_ = config.value("use_depth", false);
-  depth_mode_str_ = config.value("depth_mode", std::string("NEURAL"));
+  depth_mode_str_ = config.value("depth_mode", std::string("NONE"));
 
   // Build InitParameters
   sl::InitParameters init;

--- a/src/hw/camera/zed_camera_component.cpp
+++ b/src/hw/camera/zed_camera_component.cpp
@@ -1,0 +1,155 @@
+/**
+ * @file zed_camera_component.cpp
+ * @brief Implementation of ZedCameraComponent
+ *
+ * Opens a StereoLabs ZED camera via sl::Camera::open() and exposes the
+ * handle to ZedPushProducer.  Serial-number identification uses the unsigned
+ * int overload of InputType::setFromSerialNumber() (standard for ZED cameras).
+ */
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "trossen_sdk/hw/camera/zed_camera_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+
+namespace trossen::hw::camera {
+
+// ─────────────────────────────────────────────────────────────
+// Helpers: string → enum with deprecation warnings
+// ─────────────────────────────────────────────────────────────
+
+sl::DEPTH_MODE ZedCameraComponent::parse_depth_mode(const std::string& mode_str) {
+  // SDK 5.x marks PERFORMANCE, QUALITY, and ULTRA as deprecated.
+  // Emit a clear warning so users migrate to the NEURAL family.
+  if (mode_str == "PERFORMANCE") {
+    std::cerr << "[ZedCameraComponent] WARNING: DEPTH_MODE::PERFORMANCE is "
+                 "deprecated in ZED SDK 5.x. Prefer NEURAL_LIGHT.\n";
+    return sl::DEPTH_MODE::PERFORMANCE;
+  }
+  if (mode_str == "QUALITY") {
+    std::cerr << "[ZedCameraComponent] WARNING: DEPTH_MODE::QUALITY is "
+                 "deprecated in ZED SDK 5.x. Prefer NEURAL.\n";
+    return sl::DEPTH_MODE::QUALITY;
+  }
+  if (mode_str == "ULTRA") {
+    std::cerr << "[ZedCameraComponent] WARNING: DEPTH_MODE::ULTRA is "
+                 "deprecated in ZED SDK 5.x. Prefer NEURAL_PLUS.\n";
+    return sl::DEPTH_MODE::ULTRA;
+  }
+  if (mode_str == "NEURAL_LIGHT") return sl::DEPTH_MODE::NEURAL_LIGHT;
+  if (mode_str == "NEURAL")       return sl::DEPTH_MODE::NEURAL;
+  if (mode_str == "NEURAL_PLUS")  return sl::DEPTH_MODE::NEURAL_PLUS;
+  if (mode_str == "NONE")         return sl::DEPTH_MODE::NONE;
+
+  std::cerr << "[ZedCameraComponent] Unknown depth_mode '" << mode_str
+            << "', falling back to NEURAL.\n";
+  return sl::DEPTH_MODE::NEURAL;
+}
+
+sl::RESOLUTION ZedCameraComponent::parse_resolution(const std::string& res_str) {
+  if (res_str == "HD2K")   return sl::RESOLUTION::HD2K;
+  if (res_str == "HD1080") return sl::RESOLUTION::HD1080;
+  if (res_str == "HD1200") return sl::RESOLUTION::HD1200;
+  if (res_str == "HD720")  return sl::RESOLUTION::HD720;
+  if (res_str == "SVGA")   return sl::RESOLUTION::SVGA;
+  if (res_str == "VGA")    return sl::RESOLUTION::VGA;
+  if (res_str == "AUTO")   return sl::RESOLUTION::AUTO;
+
+  std::cerr << "[ZedCameraComponent] Unknown resolution '" << res_str
+            << "', falling back to AUTO.\n";
+  return sl::RESOLUTION::AUTO;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Lifecycle
+// ─────────────────────────────────────────────────────────────
+
+ZedCameraComponent::~ZedCameraComponent() {
+  if (camera_ && camera_->isOpened()) {
+    camera_->close();
+    std::cout << "[ZedCameraComponent] Closed camera " << get_identifier()
+              << " (S/N " << serial_number_ << ")\n";
+  }
+}
+
+void ZedCameraComponent::configure(const nlohmann::json& config) {
+  // Serial number (required) — accept both string and numeric JSON values
+  if (!config.contains("serial_number")) {
+    throw std::runtime_error(
+      "ZedCameraComponent: 'serial_number' is required in config");
+  }
+  if (config["serial_number"].is_number()) {
+    serial_number_ = std::to_string(config["serial_number"].get<uint64_t>());
+  } else {
+    serial_number_ = config["serial_number"].get<std::string>();
+  }
+
+  // Optional resolution / fps / depth settings
+  std::string resolution_str = config.value("resolution", "AUTO");
+  int requested_fps = config.value("fps", 0);
+  use_depth_ = config.value("use_depth", false);
+  depth_mode_str_ = config.value("depth_mode", std::string("NEURAL"));
+
+  // Build InitParameters
+  sl::InitParameters init;
+  init.camera_resolution = parse_resolution(resolution_str);
+  init.camera_fps = requested_fps;
+  init.depth_mode = use_depth_
+    ? parse_depth_mode(depth_mode_str_)
+    : sl::DEPTH_MODE::NONE;
+  init.coordinate_units = sl::UNIT::MILLIMETER;
+
+  // Identify camera by serial number
+  unsigned int sn_uint = 0;
+  try {
+    sn_uint = static_cast<unsigned int>(std::stoul(serial_number_));
+  } catch (...) {
+    throw std::runtime_error(
+      "ZedCameraComponent: serial_number must be a numeric string, got: " +
+      serial_number_);
+  }
+  init.input.setFromSerialNumber(sn_uint);
+
+  // Open camera
+  camera_ = std::make_shared<sl::Camera>();
+  sl::ERROR_CODE err = camera_->open(init);
+  if (err != sl::ERROR_CODE::SUCCESS) {
+    throw std::runtime_error(
+      "ZedCameraComponent: Failed to open ZED camera S/N " + serial_number_ +
+      ": " + std::string(sl::toString(err).c_str()));
+  }
+
+  // Read back negotiated resolution
+  auto cam_info = camera_->getCameraInformation();
+  width_ = static_cast<int>(cam_info.camera_configuration.resolution.width);
+  height_ = static_cast<int>(cam_info.camera_configuration.resolution.height);
+  fps_ = static_cast<int>(cam_info.camera_configuration.fps);
+
+  std::cout << "[ZedCameraComponent] " << get_identifier() << " opened: "
+            << width_ << "x" << height_ << " @ " << fps_ << " FPS"
+            << " (depth=" << (use_depth_ ? depth_mode_str_ : "off") << ")\n";
+}
+
+nlohmann::json ZedCameraComponent::get_info() const {
+  nlohmann::json info = {
+    {"type", "zed_camera"},
+    {"serial_number", serial_number_},
+    {"width", width_},
+    {"height", height_},
+    {"fps", fps_},
+    {"use_depth", use_depth_},
+    {"depth_mode", depth_mode_str_},
+    {"is_opened", is_opened()}
+  };
+  return info;
+}
+
+bool ZedCameraComponent::is_opened() const {
+  return camera_ && camera_->isOpened();
+}
+
+REGISTER_HARDWARE(ZedCameraComponent, "zed_camera")
+
+}  // namespace trossen::hw::camera

--- a/src/hw/camera/zed_push_producer.cpp
+++ b/src/hw/camera/zed_push_producer.cpp
@@ -15,7 +15,6 @@
  * once start() is called.  ZedCameraComponent must not call grab() concurrently.
  */
 
-#include <cmath>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -32,6 +31,13 @@
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 
 namespace trossen::hw::camera {
+
+/// Maximum valid depth value (millimetres) when quantizing F32 → U16.
+/// Matches std::numeric_limits<uint16_t>::max() (65 535 mm ≈ 65.5 m), which
+/// exceeds every ZED model's maximum range (~20 m for ZED 2).  Values above
+/// this are clamped so the subsequent convertTo(CV_16UC1) cannot overflow.
+static constexpr float kDepthU16MaxMm =
+  static_cast<float>(std::numeric_limits<uint16_t>::max());
 
 // ─────────────────────────────────────────────────────────────
 // Metadata helpers
@@ -291,21 +297,14 @@ void ZedPushProducer::push_loop(
                           sl_depth_.getPtr<float>(sl::MEM::CPU),
                           sl_depth_.getStepBytes(sl::MEM::CPU));
 
-        // Sanitize: replace NaN/Inf with 0, then clamp to [0, 65000] before
-        // converting to 16-bit unsigned.  patchNaNs replaces NaN with the
-        // given value (0.0); we must also handle +/-Inf explicitly.
+        // Sanitize invalid pixels.  The ZED SDK marks invalid depth using:
+        //   sl::OCCLUSION_VALUE / sl::INVALID_VALUE  →  NaN
+        //   sl::TOO_FAR                               →  +Inf
+        //   sl::TOO_CLOSE                             →  -Inf
         cv::Mat depth_clean = depth_f32.clone();
         cv::patchNaNs(depth_clean, 0.0);
-
-        // Clamp: negative values (invalid) → 0, values > 65000 → 65000
-        // to fit in uint16 and match RealSense DEPTH_U16_MM convention
-        cv::Mat mask_neg = depth_clean < 0.0f;
-        depth_clean.setTo(0.0f, mask_neg);
-
-        cv::Mat mask_inf;
-        // Inf check: values above a large finite threshold are Inf or huge
-        cv::compare(depth_clean, 65000.0f, mask_inf, cv::CMP_GT);
-        depth_clean.setTo(65000.0f, mask_inf);
+        cv::max(depth_clean, 0.0f, depth_clean);
+        cv::min(depth_clean, kDepthU16MaxMm, depth_clean);
 
         cv::Mat depth_u16;
         depth_clean.convertTo(depth_u16, CV_16UC1);
@@ -322,7 +321,12 @@ void ZedPushProducer::push_loop(
     uint64_t mono_now = data::now_mono().to_ns();
     data::Timestamp ts;
     if (cfg_.use_device_time) {
-      // sl::Camera timestamp is nanoseconds since camera boot
+      // NOTE: despite the name, TIME_REFERENCE::IMAGE is a host-side
+      // timestamp (Unix epoch ns) captured when the frame arrived in PC
+      // memory — the ZED SDK does not expose a true sensor-exposure
+      // timestamp.  It is still more consistent than now_mono() because
+      // it is stamped inside the SDK's receive path, before our grab()
+      // returns, so it excludes any scheduling jitter in our thread.
       uint64_t device_ts_ns =
         camera_->getTimestamp(sl::TIME_REFERENCE::IMAGE).getNanoseconds();
       ts.monotonic = data::Timespec::from_ns(device_ts_ns);

--- a/src/hw/camera/zed_push_producer.cpp
+++ b/src/hw/camera/zed_push_producer.cpp
@@ -8,8 +8,7 @@
  *      3-channel BGR image directly, avoiding a BGRA→BGR strip on the CPU.
  *   3. When depth is enabled, MEASURE::DEPTH (F32_C1, metres) is retrieved,
  *      sanitized (NaN/Inf → 0 via cv::patchNaNs + clamping), then quantized
- *      to CV_16UC1 (millimetres) for downstream compatibility with the
- *      RealSense depth pipeline.
+ *      to CV_16UC1 (millimetres) for backend consumption.
  *
  * Thread safety: the sl::Camera handle is used exclusively by this thread
  * once start() is called.  ZedCameraComponent must not call grab() concurrently.
@@ -152,7 +151,9 @@ ZedPushProducer::ZedPushProducer(
       "[ZedPushProducer] Unsupported color encoding: " + cfg_.color_encoding +
       ". Valid: bgr8, rgb8");
   }
-  cfg_.use_device_time = config.value("use_device_time", true);
+  // ZED cameras do not expose a true sensor-exposure timestamp;
+  // TIME_REFERENCE::IMAGE is host-side.  Default to false.
+  cfg_.use_device_time = config.value("use_device_time", false);
   cfg_.timeout_ms = config.value("timeout_ms", 3000);
   if (cfg_.timeout_ms <= 0) {
     cfg_.timeout_ms = 3000;

--- a/src/hw/camera/zed_push_producer.cpp
+++ b/src/hw/camera/zed_push_producer.cpp
@@ -1,0 +1,393 @@
+/**
+ * @file zed_push_producer.cpp
+ * @brief Implementation of ZedPushProducer
+ *
+ * Grab loop design:
+ *   1. sl::Camera::grab() blocks until a new frame pair is ready (or timeout).
+ *   2. Color is retrieved via VIEW::LEFT_BGR (SDK 5.x, U8_C3) — this gives a
+ *      3-channel BGR image directly, avoiding a BGRA→BGR strip on the CPU.
+ *   3. When depth is enabled, MEASURE::DEPTH (F32_C1, metres) is retrieved,
+ *      sanitized (NaN/Inf → 0 via cv::patchNaNs + clamping), then quantized
+ *      to CV_16UC1 (millimetres) for downstream compatibility with the
+ *      RealSense depth pipeline.
+ *
+ * Thread safety: the sl::Camera handle is used exclusively by this thread
+ * once start() is called.  ZedCameraComponent must not call grab() concurrently.
+ */
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "opencv2/core.hpp"
+#include "opencv2/imgproc.hpp"
+
+#include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/camera/zed_camera_component.hpp"
+#include "trossen_sdk/hw/camera/zed_push_producer.hpp"
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
+
+namespace trossen::hw::camera {
+
+// ─────────────────────────────────────────────────────────────
+// Metadata helpers
+// ─────────────────────────────────────────────────────────────
+
+nlohmann::ordered_json ZedPushProducer::ZedPushProducerMetadata::get_info() const {
+  nlohmann::ordered_json features;
+
+  // Color stream feature
+  nlohmann::ordered_json color_feature;
+  color_feature["id"] = id;
+  color_feature["dtype"] = "video";
+  color_feature["shape"] = {height, width, channels};
+  color_feature["names"] = {"height", "width", "channels"};
+  // TODO(shantanuparab-tr): codec and pix_fmt for color are placeholders;
+  // update after validating with LeRobot v2 depth support and alpha user feedback
+  color_feature["info"] = {
+    {"video.fps", fps},
+    {"video.height", height},
+    {"video.width", width},
+    {"video.channels", channels},
+    {"video.codec", codec},
+    {"video.pix_fmt", pix_fmt},
+    {"video.is_depth_map", false},
+    {"has_audio", has_audio}};
+  features["observation.images." + id] = color_feature;
+
+  // Depth stream feature (when present)
+  if (has_depth) {
+    nlohmann::ordered_json depth_feature;
+    std::string depth_id = id + "_depth";
+    depth_feature["id"] = depth_id;
+    depth_feature["dtype"] = "video";
+    depth_feature["shape"] = {height, width, 1};
+    depth_feature["names"] = {"height", "width", "channels"};
+    // TODO(shantanuparab-tr): depth codec ("ffv1") and pix_fmt ("gray16le") are
+    // provisional; update after validating with LeRobot v2 depth support and alpha
+    // user feedback. ffv1 chosen as lossless codec for metric depth data;
+    // gray16le matches 16-bit unsigned depth (little-endian).
+    depth_feature["info"] = {
+      {"video.fps", fps},
+      {"video.height", height},
+      {"video.width", width},
+      {"video.channels", 1},
+      {"video.codec", "ffv1"},
+      {"video.pix_fmt", "gray16le"},
+      {"video.is_depth_map", true},
+      {"has_audio", false}};
+    features["observation.images." + depth_id] = depth_feature;
+  }
+
+  return features;
+}
+
+nlohmann::ordered_json ZedPushProducer::ZedPushProducerMetadata::get_stream_info() const {
+  nlohmann::ordered_json info;
+  info["cameras"][id] = {
+    {"width", width},
+    {"height", height},
+    {"fps", fps},
+    {"channels", channels},
+    {"codec", codec},
+    {"pix_fmt", pix_fmt},
+    {"is_depth_map", false},
+    {"has_audio", has_audio}};
+
+  if (has_depth) {
+    std::string depth_id = id + "_depth";
+    // TODO(shantanuparab-tr): depth codec/pix_fmt — see TODO in get_info()
+    info["cameras"][depth_id] = {
+      {"width", width},
+      {"height", height},
+      {"fps", fps},
+      {"channels", 1},
+      {"codec", "ffv1"},
+      {"pix_fmt", "gray16le"},
+      {"is_depth_map", true},
+      {"has_audio", false}};
+  }
+
+  return info;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Constructor / Destructor
+// ─────────────────────────────────────────────────────────────
+
+ZedPushProducer::ZedPushProducer(
+  std::shared_ptr<::trossen::hw::HardwareComponent> hardware,
+  const nlohmann::json& config)
+{
+  auto cam = std::dynamic_pointer_cast<ZedCameraComponent>(hardware);
+  if (!cam) {
+    throw std::runtime_error(
+      "ZedPushProducer requires ZedCameraComponent, got: " +
+      hardware->get_type());
+  }
+
+  camera_ = cam->get_hardware();
+  if (!camera_) {
+    throw std::runtime_error(
+      "ZedPushProducer: ZedCameraComponent has null camera handle");
+  }
+
+  use_depth_ = cam->get_use_depth();
+
+  // Parse producer config
+  cfg_.stream_id = config.value("stream_id", cam->get_identifier());
+  cfg_.color_encoding = config.value("encoding", "bgr8");
+  if (cfg_.color_encoding != "bgr8" && cfg_.color_encoding != "rgb8") {
+    throw std::runtime_error(
+      "[ZedPushProducer] Unsupported color encoding: " + cfg_.color_encoding +
+      ". Valid: bgr8, rgb8");
+  }
+  cfg_.use_device_time = config.value("use_device_time", true);
+  cfg_.timeout_ms = config.value("timeout_ms", 3000);
+  if (cfg_.timeout_ms <= 0) {
+    cfg_.timeout_ms = 3000;
+  }
+  cfg_.fps = config.value("fps", 30);
+  cfg_.remove_saturated_areas = config.value("remove_saturated_areas", false);
+
+  // Populate metadata
+  metadata_.type = "zed_camera";
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = cfg_.stream_id;
+  metadata_.description =
+    "Unified push producer for ZED camera (color + optional depth)";
+  metadata_.width = cam->get_width();
+  metadata_.height = cam->get_height();
+  metadata_.fps = cam->get_fps();
+  // TODO(shantanuparab-tr): codec and pix_fmt are placeholders; update after
+  // validating with LeRobot v2 depth support and alpha user feedback
+  metadata_.codec = "av1";
+  metadata_.pix_fmt = "yuv420p";
+  metadata_.channels = 3;
+  metadata_.has_audio = false;
+  metadata_.has_depth = use_depth_;
+
+  std::cout << "[ZedPushProducer] Constructed for stream '"
+            << cfg_.stream_id << "' (depth=" << (use_depth_ ? "on" : "off")
+            << ", remove_saturated=" << (cfg_.remove_saturated_areas ? "on" : "off")
+            << ")" << std::endl;
+}
+
+ZedPushProducer::~ZedPushProducer() {
+  stop();
+}
+
+// ─────────────────────────────────────────────────────────────
+// Start / Stop
+// ─────────────────────────────────────────────────────────────
+
+bool ZedPushProducer::start(
+  const std::function<void(std::shared_ptr<data::RecordBase>)>& emit)
+{
+  if (running_.load()) {
+    std::cerr << "[ZedPushProducer] Already running." << std::endl;
+    return false;
+  }
+
+  running_.store(true);
+  push_thread_ = std::thread([this, emit]() { push_loop(emit); });
+
+  std::cout << "[ZedPushProducer] Started push thread for stream '"
+            << cfg_.stream_id << "' (depth=" << (use_depth_ ? "on" : "off") << ")"
+            << std::endl;
+  return true;
+}
+
+void ZedPushProducer::stop() {
+  if (!running_.load()) {
+    return;
+  }
+
+  running_.store(false);
+
+  if (push_thread_.joinable()) {
+    push_thread_.join();
+  }
+
+  std::cout << "[ZedPushProducer] Stopped push thread for stream '"
+            << cfg_.stream_id << "'. produced=" << stats_.produced
+            << " dropped=" << stats_.dropped << std::endl;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Grab loop
+// ─────────────────────────────────────────────────────────────
+
+void ZedPushProducer::push_loop(
+  const std::function<void(std::shared_ptr<data::RecordBase>)>& emit)
+{
+  // Build RuntimeParameters once; reused every grab() call
+  sl::RuntimeParameters rt;
+  rt.remove_saturated_areas = cfg_.remove_saturated_areas;
+
+  while (running_.load(std::memory_order_relaxed)) {
+    // grab() blocks until a new frame is ready
+    sl::ERROR_CODE grab_err = camera_->grab(rt);
+    if (grab_err != sl::ERROR_CODE::SUCCESS) {
+      // sl::toString returns an sl::String; wrapping in std::string avoids
+      // dangling pointer when the temporary sl::String is destroyed
+      std::cerr << "[ZedPushProducer] grab() failed: "
+                << std::string(sl::toString(grab_err).c_str()) << std::endl;
+      ++stats_.dropped;
+      continue;
+    }
+
+    // ── Color retrieval ──
+    // VIEW::LEFT_BGR is SDK 5.x: returns U8_C3 (BGR) directly on CPU,
+    // avoiding the extra BGRA→BGR conversion that VIEW::LEFT would require.
+    sl::ERROR_CODE img_err = camera_->retrieveImage(
+      sl_color_, sl::VIEW::LEFT_BGR, sl::MEM::CPU);
+    if (img_err != sl::ERROR_CODE::SUCCESS) {
+      ++stats_.dropped;
+      continue;
+    }
+
+    const int w = static_cast<int>(sl_color_.getWidth());
+    const int h = static_cast<int>(sl_color_.getHeight());
+
+    // Wrap sl::Mat data in a cv::Mat (no copy), then clone to decouple from
+    // the SDK's internal buffer which is recycled on the next grab().
+    cv::Mat color_wrap(h, w, CV_8UC3,
+                       sl_color_.getPtr<sl::uchar3>(sl::MEM::CPU),
+                       sl_color_.getStepBytes(sl::MEM::CPU));
+
+    cv::Mat color_out;
+    if (cfg_.color_encoding == "bgr8") {
+      color_out = color_wrap.clone();
+    } else if (cfg_.color_encoding == "rgb8") {
+      cv::cvtColor(color_wrap, color_out, cv::COLOR_BGR2RGB);
+    } else {
+      throw std::runtime_error(
+        "[ZedPushProducer] Unsupported color encoding: " + cfg_.color_encoding);
+    }
+
+    auto rec = std::make_shared<data::ImageRecord>();
+    rec->image = std::move(color_out);
+    rec->width = static_cast<uint32_t>(w);
+    rec->height = static_cast<uint32_t>(h);
+    rec->channels = 3;
+    rec->encoding = cfg_.color_encoding;
+
+    // ── Optional depth retrieval ──
+    if (use_depth_) {
+      sl::ERROR_CODE depth_err = camera_->retrieveMeasure(
+        sl_depth_, sl::MEASURE::DEPTH, sl::MEM::CPU);
+      if (depth_err == sl::ERROR_CODE::SUCCESS) {
+        const int dw = static_cast<int>(sl_depth_.getWidth());
+        const int dh = static_cast<int>(sl_depth_.getHeight());
+
+        // sl::MEASURE::DEPTH is F32_C1 in the coordinate unit set at init
+        // (we use MILLIMETER).  Wrap without copy.
+        cv::Mat depth_f32(dh, dw, CV_32FC1,
+                          sl_depth_.getPtr<float>(sl::MEM::CPU),
+                          sl_depth_.getStepBytes(sl::MEM::CPU));
+
+        // Sanitize: replace NaN/Inf with 0, then clamp to [0, 65000] before
+        // converting to 16-bit unsigned.  patchNaNs replaces NaN with the
+        // given value (0.0); we must also handle +/-Inf explicitly.
+        cv::Mat depth_clean = depth_f32.clone();
+        cv::patchNaNs(depth_clean, 0.0);
+
+        // Clamp: negative values (invalid) → 0, values > 65000 → 65000
+        // to fit in uint16 and match RealSense DEPTH_U16_MM convention
+        cv::Mat mask_neg = depth_clean < 0.0f;
+        depth_clean.setTo(0.0f, mask_neg);
+
+        cv::Mat mask_inf;
+        // Inf check: values above a large finite threshold are Inf or huge
+        cv::compare(depth_clean, 65000.0f, mask_inf, cv::CMP_GT);
+        depth_clean.setTo(65000.0f, mask_inf);
+
+        cv::Mat depth_u16;
+        depth_clean.convertTo(depth_u16, CV_16UC1);
+
+        rec->depth_image = std::move(depth_u16);
+        // depth_scale = 0.001: each raw unit is 1 mm, multiply by 0.001 to
+        // get metres.
+        rec->depth_scale = 0.001f;
+      }
+      // If depth retrieval fails for this frame, emit color-only record
+    }
+
+    // ── Timestamp ──
+    uint64_t mono_now = data::now_mono().to_ns();
+    data::Timestamp ts;
+    if (cfg_.use_device_time) {
+      // sl::Camera timestamp is nanoseconds since camera boot
+      uint64_t device_ts_ns =
+        camera_->getTimestamp(sl::TIME_REFERENCE::IMAGE).getNanoseconds();
+      ts.monotonic = data::Timespec::from_ns(device_ts_ns);
+    } else {
+      ts.monotonic = data::now_mono();
+    }
+    ts.realtime = data::now_real();
+
+    // Inter-frame timing
+    if (last_capture_mono_ != 0) {
+      uint64_t dt = mono_now - last_capture_mono_;
+      if_accum_ns_ += dt;
+      if (dt > if_max_ns_) if_max_ns_ = dt;
+      ++if_samples_;
+    }
+    last_capture_mono_ = mono_now;
+
+    rec->ts = ts;
+    rec->seq = seq_++;
+    rec->id = cfg_.stream_id;
+
+    try {
+      emit(rec);
+      ++stats_.produced;
+    } catch (const std::exception& e) {
+      ++stats_.dropped;
+      std::cerr << "[ZedPushProducer] emit failed: " << e.what() << std::endl;
+    } catch (...) {
+      ++stats_.dropped;
+      std::cerr << "[ZedPushProducer] emit failed with unknown exception"
+                << std::endl;
+    }
+
+    // Periodic FPS health report
+    if (cfg_.fps > 0 && stats_.produced >= next_health_report_frame_) {
+      double avg_if_ms = 0.0;
+      double max_if_ms = 0.0;
+      if (if_samples_ > 0) {
+        avg_if_ms = (if_accum_ns_ / 1e6) / static_cast<double>(if_samples_);
+        max_if_ms = if_max_ns_ / 1e6;
+      }
+      double produced_fps = 0.0;
+      if (if_samples_ > 0 && if_accum_ns_ > 0) {
+        produced_fps =
+          1e9 / (static_cast<double>(if_accum_ns_) / static_cast<double>(if_samples_));
+      }
+      if (produced_fps > 0 && (produced_fps + 0.5) < cfg_.fps) {
+        std::cerr << "[ZedPushProducer] FPS health: produced=" << produced_fps
+                  << " requested=" << cfg_.fps
+                  << " avg_if_ms=" << avg_if_ms << " max_if_ms=" << max_if_ms
+                  << std::endl;
+      } else {
+        std::cout << "[ZedPushProducer] FPS health: produced=" << produced_fps
+                  << " requested=" << cfg_.fps
+                  << " avg_if_ms=" << avg_if_ms << " max_if_ms=" << max_if_ms
+                  << std::endl;
+      }
+      uint64_t interval = static_cast<uint64_t>(cfg_.fps) * 10;
+      if (interval == 0) interval = 300;
+      next_health_report_frame_ += interval;
+    }
+  }
+}
+
+// Register in PushProducerRegistry as "zed_camera"
+REGISTER_PUSH_PRODUCER(ZedPushProducer, "zed_camera")
+
+}  // namespace trossen::hw::camera


### PR DESCRIPTION
Adds ZED SDK 5.x camera support as an opt-in build feature (TROSSEN_ENABLE_ZED):

- ZedCameraComponent: hardware component wrapping sl::Camera with full SDK 5.x
  InitParameters and RuntimeParameters support. Includes resolution/depth mode
  parsing with deprecation warnings for legacy CV-based modes (PERFORMANCE,
  QUALITY, ULTRA). Warmup loop settles auto-exposure before recording.

- ZedPushProducer: push-style producer using VIEW::LEFT_BGR for zero-conversion
  BGR retrieval (SDK 5.x). Depth maps are sanitized (NaN/Inf to 0) and converted
  from float32 meters to uint16 millimeters matching the RealSense Z16 convention.

- CMake integration: TROSSEN_ENABLE_ZED option (OFF by default), conditional
  compilation, find_package(ZED) + find_package(CUDA).