### PR TITLE
Add depth camera awareness to sanity check

### DIFF
--- a/examples/so101/so101_lerobot_v2.cpp
+++ b/examples/so101/so101_lerobot_v2.cpp
@@ -402,7 +402,8 @@ int main(int argc, char** argv) {
       cfg.joint_rate_hz,
       1,  // 1 camera
       cfg.camera_fps,
-      5.0  // 5% tolerance
+      5.0,  // 5% tolerance
+      0     // no depth cameras
     };
     trossen::utils::perform_sanity_check(
       recording_episode_index,

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -122,7 +122,8 @@ int main(int argc, char** argv) {
     }
   }
   for (const auto& p : cfg.producers) {
-    if (p.type == "realsense_camera" || p.type == "opencv_camera") {
+    if (p.type == "realsense_camera" || p.type == "opencv_camera" ||
+        p.type == "zed_camera") {
       camera_fps = p.poll_rate_hz;
       break;
     }
@@ -395,13 +396,20 @@ int main(int argc, char** argv) {
       trossen::utils::generate_episode_path(root, recording_episode_index);
     trossen::utils::print_episode_summary(file_path, last_stats);
 
+    // Count depth-capable cameras for accurate sanity check
+    int depth_cameras = 0;
+    for (const auto& cam : cfg.hardware.cameras) {
+      if (cam.use_depth) ++depth_cameras;
+    }
+
     trossen::utils::SanityCheckConfig sanity_cfg{
       last_stats.elapsed.count(),
       static_cast<int>(cfg.hardware.arms.size()),
       joint_rate_hz,
       static_cast<int>(cfg.hardware.cameras.size()),
       static_cast<int>(camera_fps),
-      5.0
+      5.0,
+      depth_cameras
     };
     perform_sanity_check(recording_episode_index, last_stats.records_written_current, sanity_cfg);
 

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -1,8 +1,8 @@
 /**
  * @file trossen_solo_ai.cpp
- * @brief Single arm pair AI Kit demo - 1 leader + 1 follower + 2 RealSense cameras
+ * @brief Single arm pair AI Kit demo - 1 leader + 1 follower + 2 cameras
  *
- * Records one leader/follower arm pair along with 2 RealSense cameras.
+ * Records one leader/follower arm pair along with cameras (RealSense, OpenCV, or ZED).
  * All hardware parameters, session settings, and teleop setup are driven by a
  * single JSON config file with optional CLI overrides.
  *
@@ -115,7 +115,8 @@ int main(int argc, char** argv) {
     }
   }
   for (const auto& p : cfg.producers) {
-    if (p.type == "realsense_camera" || p.type == "opencv_camera") {
+    if (p.type == "realsense_camera" || p.type == "opencv_camera" ||
+        p.type == "zed_camera") {
       camera_fps = p.poll_rate_hz;
       break;
     }
@@ -345,13 +346,20 @@ int main(int argc, char** argv) {
       trossen::utils::generate_episode_path(root, recording_episode_index);
     trossen::utils::print_episode_summary(file_path, last_stats);
 
+    // Count depth-capable cameras for accurate sanity check
+    int depth_cameras = 0;
+    for (const auto& cam : cfg.hardware.cameras) {
+      if (cam.use_depth) ++depth_cameras;
+    }
+
     trossen::utils::SanityCheckConfig sanity_cfg{
       last_stats.elapsed.count(),
       static_cast<int>(cfg.hardware.arms.size()),
       joint_rate_hz,
       static_cast<int>(cfg.hardware.cameras.size()),
       static_cast<int>(camera_fps),
-      5.0
+      5.0,
+      depth_cameras
     };
     perform_sanity_check(recording_episode_index, last_stats.records_written_current, sanity_cfg);
 

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -117,7 +117,8 @@ int main(int argc, char** argv) {
     }
   }
   for (const auto& p : cfg.producers) {
-    if (p.type == "realsense_camera" || p.type == "opencv_camera") {
+    if (p.type == "realsense_camera" || p.type == "opencv_camera" ||
+        p.type == "zed_camera") {
       camera_fps = p.poll_rate_hz;
       break;
     }
@@ -347,13 +348,20 @@ int main(int argc, char** argv) {
       trossen::utils::generate_episode_path(root, recording_episode_index);
     trossen::utils::print_episode_summary(file_path, last_stats);
 
+    // Count depth-capable cameras for accurate sanity check
+    int depth_cameras = 0;
+    for (const auto& cam : cfg.hardware.cameras) {
+      if (cam.use_depth) ++depth_cameras;
+    }
+
     trossen::utils::SanityCheckConfig sanity_cfg{
       last_stats.elapsed.count(),
       static_cast<int>(cfg.hardware.arms.size()),
       joint_rate_hz,
       static_cast<int>(cfg.hardware.cameras.size()),
       static_cast<int>(camera_fps),
-      5.0
+      5.0,
+      depth_cameras
     };
     perform_sanity_check(recording_episode_index, last_stats.records_written_current, sanity_cfg);
 

--- a/include/trossen_sdk/utils/app_utils.hpp
+++ b/include/trossen_sdk/utils/app_utils.hpp
@@ -73,6 +73,7 @@ struct SanityCheckConfig {
   int camera_producers;         ///< Number of camera producers
   int camera_fps;               ///< Camera frame rate
   double tolerance_percent;     ///< Tolerance as percentage (default: 5.0%)
+  int depth_camera_producers;   ///< Number of depth-capable cameras (each emits 2x records)
 };
 
 /**

--- a/src/utils/app_utils.cpp
+++ b/src/utils/app_utils.cpp
@@ -191,11 +191,26 @@ bool perform_sanity_check(
   uint64_t actual_records,
   const SanityCheckConfig& config)
 {
-  // Calculate expected records based on actual duration
+  // Calculate expected records based on actual duration.
+  //
+  // Depth-capable cameras produce 2 records per frame (color + depth), so we
+  // count them separately:
+  //   color-only cameras = camera_producers - depth_camera_producers
+  //   depth cameras      = depth_camera_producers  (each emits 2 records/frame)
+  //
+  // Mathematically this simplifies to:
+  //   expected_image = fps * duration * (camera_producers + depth_camera_producers)
+  // because (N - D)*1 + D*2 = N + D.  We keep the explicit breakdown for
+  // clarity in the diagnostic output.
+  int color_only_cameras = config.camera_producers - config.depth_camera_producers;
+
   int expected_joint_records = static_cast<int>(
     config.joint_rate_hz * config.actual_duration_s * config.joint_producers);
-  int expected_image_records = static_cast<int>(
-    config.camera_fps * config.actual_duration_s * config.camera_producers);
+  int expected_color_records = static_cast<int>(
+    config.camera_fps * config.actual_duration_s * color_only_cameras);
+  int expected_depth_records = static_cast<int>(
+    config.camera_fps * config.actual_duration_s * config.depth_camera_producers * 2);
+  int expected_image_records = expected_color_records + expected_depth_records;
   int expected_total = expected_joint_records + expected_image_records;
 
   // Calculate tolerance range
@@ -210,7 +225,12 @@ bool perform_sanity_check(
             << config.actual_duration_s << "s\n";
   std::cout << "  Expected records:     ~" << expected_total
             << " (" << expected_joint_records << " joints + "
-            << expected_image_records << " images)\n";
+            << expected_image_records << " images";
+  if (config.depth_camera_producers > 0) {
+    std::cout << " [" << color_only_cameras << " color-only + "
+              << config.depth_camera_producers << " depth x2]";
+  }
+  std::cout << ")\n";
   std::cout << "  Actual records:       " << actual_records << "\n";
   std::cout << "  Tolerance range:      " << min_expected << " - " << max_expected << "\n";
 

--- a/src/utils/app_utils.cpp
+++ b/src/utils/app_utils.cpp
@@ -191,61 +191,58 @@ bool perform_sanity_check(
   uint64_t actual_records,
   const SanityCheckConfig& config)
 {
-  // Calculate expected records based on actual duration.
-  //
-  // Depth-capable cameras produce 2 records per frame (color + depth), so we
-  // count them separately:
-  //   color-only cameras = camera_producers - depth_camera_producers
-  //   depth cameras      = depth_camera_producers  (each emits 2 records/frame)
-  //
-  // Mathematically this simplifies to:
-  //   expected_image = fps * duration * (camera_producers + depth_camera_producers)
-  // because (N - D)*1 + D*2 = N + D.  We keep the explicit breakdown for
-  // clarity in the diagnostic output.
-  int color_only_cameras = config.camera_producers - config.depth_camera_producers;
-
-  int expected_joint_records = static_cast<int>(
+  // Expected sink records: each producer enqueues 1 record per poll/frame.
+  // Depth cameras embed color + depth in a single ImageRecord, so they count
+  // as 1 sink record per frame (same as color-only cameras). The backend then
+  // writes the depth as a separate channel in the output file.
+  int expected_joint = static_cast<int>(
     config.joint_rate_hz * config.actual_duration_s * config.joint_producers);
-  int expected_color_records = static_cast<int>(
-    config.camera_fps * config.actual_duration_s * color_only_cameras);
-  int expected_depth_records = static_cast<int>(
-    config.camera_fps * config.actual_duration_s * config.depth_camera_producers * 2);
-  int expected_image_records = expected_color_records + expected_depth_records;
-  int expected_total = expected_joint_records + expected_image_records;
+  int expected_camera = static_cast<int>(
+    config.camera_fps * config.actual_duration_s * config.camera_producers);
+  int expected_total = expected_joint + expected_camera;
 
-  // Calculate tolerance range
-  double tolerance_factor = 1.0 - (config.tolerance_percent / 100.0);
-  int min_expected = static_cast<int>(expected_total * tolerance_factor);
-  tolerance_factor = 1.0 + (config.tolerance_percent / 100.0);
-  int max_expected = static_cast<int>(expected_total * tolerance_factor);
+  // Backend output writes: depth cameras produce 2 channel writes per frame
+  int color_only = config.camera_producers - config.depth_camera_producers;
+  int expected_output_writes = expected_joint
+    + static_cast<int>(config.camera_fps * config.actual_duration_s * color_only)
+    + static_cast<int>(config.camera_fps * config.actual_duration_s *
+                       config.depth_camera_producers * 2);
 
-  // Print detailed check
-  std::cout << "\n[Sanity Check] Episode " << episode_index << ":\n";
-  std::cout << "  Actual duration:      " << std::fixed << std::setprecision(2)
-            << config.actual_duration_s << "s\n";
-  std::cout << "  Expected records:     ~" << expected_total
-            << " (" << expected_joint_records << " joints + "
-            << expected_image_records << " images";
-  if (config.depth_camera_producers > 0) {
-    std::cout << " [" << color_only_cameras << " color-only + "
-              << config.depth_camera_producers << " depth x2]";
-  }
-  std::cout << ")\n";
-  std::cout << "  Actual records:       " << actual_records << "\n";
-  std::cout << "  Tolerance range:      " << min_expected << " - " << max_expected << "\n";
+  // Tolerance range
+  double tol_lo = 1.0 - (config.tolerance_percent / 100.0);
+  double tol_hi = 1.0 + (config.tolerance_percent / 100.0);
+  int min_expected = static_cast<int>(expected_total * tol_lo);
+  int max_expected = static_cast<int>(expected_total * tol_hi);
 
   bool passed = (actual_records >= static_cast<uint64_t>(min_expected) &&
                  actual_records <= static_cast<uint64_t>(max_expected));
 
+  // Print report
+  std::cout << "\n[Sanity Check] Episode " << episode_index << ":\n";
+  std::cout << "  Duration:        " << std::fixed << std::setprecision(2)
+            << config.actual_duration_s << "s\n";
+  std::cout << "  Expected:        ~" << expected_total << " sink records ("
+            << expected_joint << " joints + "
+            << expected_camera << " camera frames)\n";
+  std::cout << "  Actual:          " << actual_records << " sink records\n";
+  std::cout << "  Tolerance:       " << min_expected << " - " << max_expected
+            << " (" << config.tolerance_percent << "%)\n";
+
   if (passed) {
-    std::cout << "  Status:               PASS (within "
-              << config.tolerance_percent << "% tolerance)\n";
+    std::cout << "  Status:          PASS\n";
   } else {
-    std::cout << "  Status:               WARNING (outside expected range)\n";
     double deviation =
       100.0 * (static_cast<double>(actual_records) - expected_total) / expected_total;
-    std::cout << "  Deviation:            " << std::fixed << std::setprecision(1)
-              << std::showpos << deviation << std::noshowpos << "%\n";
+    std::cout << "  Status:          WARNING (" << std::fixed << std::setprecision(1)
+              << std::showpos << deviation << std::noshowpos << "% deviation)\n";
+  }
+
+  // Depth info: show the distinction between sink records and output writes
+  if (config.depth_camera_producers > 0) {
+    std::cout << "\n  Depth cameras:   " << config.depth_camera_producers
+              << " of " << config.camera_producers << " cameras have depth enabled\n";
+    std::cout << "  Output writes:   ~" << expected_output_writes
+              << " (each depth frame writes color + depth as 2 channels)\n";
   }
 
   return passed;


### PR DESCRIPTION
SanityCheckConfig now includes depth_camera_producers to track cameras with
depth enabled. The sanity check reports a breakdown of color-only vs
color+depth records and expected MCAP backend writes (depth cameras produce
2 messages per record: 1 color + 1 depth).

The record count validation is unchanged since the sink counts each
ImageRecord as 1 regardless of embedded depth. The split exists for
diagnostic output to help debug depth frame loss.

Updated all example call sites (solo, stationary, mobile, so101) to compute
and pass the depth camera count. Also includes zed_camera in the camera FPS
detection loop.