### PR TITLE
Integrate lifecycle callbacks into solo, stationary, and mobile examples

### DIFF
--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -291,6 +291,57 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
 
   // ──────────────────────────────────────────────────────────
+  // Register lifecycle callbacks
+  // ──────────────────────────────────────────────────────────
+
+  // Count depth-capable cameras once for sanity checks
+  int depth_cameras = 0;
+  for (const auto& cam : cfg.hardware.cameras) {
+    if (cam.use_depth) ++depth_cameras;
+  }
+
+  mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
+    const std::string file_path =
+      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+    trossen::utils::print_episode_summary(file_path, stats);
+
+    trossen::utils::SanityCheckConfig sanity_cfg{
+      stats.elapsed.count(),
+      static_cast<int>(cfg.hardware.arms.size()),
+      joint_rate_hz,
+      static_cast<int>(cfg.hardware.cameras.size()),
+      static_cast<int>(camera_fps),
+      5.0,
+      depth_cameras
+    };
+    perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
+  });
+
+  mgr.on_pre_shutdown([&]() {
+    std::cout << "\nReturning arms to starting positions...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_modes(trossen_arm::Mode::position);
+      driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    }
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+
+    std::cout << "Moving arms to sleep positions...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_positions(
+        std::vector<double>(driver->get_num_joints(), 0.0), moving_time_s, false);
+    }
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+
+    std::cout << "Cleaning up arm drivers...\n";
+    for (const auto& [id, comp] : arm_components) {
+      comp->get_hardware()->cleanup();
+    }
+    std::cout << "  [ok] All arm drivers cleaned up\n";
+  });
+
+  // ──────────────────────────────────────────────────────────
   // Episode loop
   // ──────────────────────────────────────────────────────────
 
@@ -340,8 +391,6 @@ int main(int argc, char** argv) {
       break;
     }
 
-    const uint32_t recording_episode_index = mgr.stats().current_episode_index;
-    const auto episode_start_time = std::chrono::steady_clock::now();
     std::cout << "Recording...\n";
 
     // Teleop thread mirrors leader positions to followers at configured rate
@@ -375,7 +424,7 @@ int main(int argc, char** argv) {
       }
     });
 
-    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
+    mgr.monitor_episode();
 
     if (mgr.is_episode_active()) {
       mgr.stop_episode();
@@ -387,62 +436,14 @@ int main(int argc, char** argv) {
       velocity_thread.join();
     }
 
-    const double actual_duration =
-      std::chrono::duration<double>(
-        std::chrono::steady_clock::now() - episode_start_time).count();
-    (void)actual_duration;
-
-    const std::string file_path =
-      trossen::utils::generate_episode_path(root, recording_episode_index);
-    trossen::utils::print_episode_summary(file_path, last_stats);
-
-    // Count depth-capable cameras for accurate sanity check
-    int depth_cameras = 0;
-    for (const auto& cam : cfg.hardware.cameras) {
-      if (cam.use_depth) ++depth_cameras;
-    }
-
-    trossen::utils::SanityCheckConfig sanity_cfg{
-      last_stats.elapsed.count(),
-      static_cast<int>(cfg.hardware.arms.size()),
-      joint_rate_hz,
-      static_cast<int>(cfg.hardware.cameras.size()),
-      static_cast<int>(camera_fps),
-      5.0,
-      depth_cameras
-    };
-    perform_sanity_check(recording_episode_index, last_stats.records_written_current, sanity_cfg);
-
     if (trossen::utils::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
     }
   }
 
+  // shutdown() calls stop_episode() (fires on_episode_ended) then on_pre_shutdown
   mgr.shutdown();
-
-  // Return arms to starting then sleep positions
-  std::cout << "\nReturning arms to starting positions...\n";
-  for (const auto& [id, comp] : arm_components) {
-    auto driver = comp->get_hardware();
-    driver->set_all_modes(trossen_arm::Mode::position);
-    driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
-  }
-  std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-  std::cout << "Moving arms to sleep positions...\n";
-  for (const auto& [id, comp] : arm_components) {
-    auto driver = comp->get_hardware();
-    driver->set_all_positions(
-      std::vector<double>(driver->get_num_joints(), 0.0), moving_time_s, false);
-  }
-  std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-  std::cout << "Cleaning up arm drivers...\n";
-  for (const auto& [id, comp] : arm_components) {
-    comp->get_hardware()->cleanup();
-  }
-  std::cout << "  [ok] All arm drivers cleaned up\n";
 
   const auto final_stats = mgr.stats();
   std::vector<std::string> extra_info = {

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -19,11 +19,10 @@
  *   ./trossen_mobile_ai
  *   ./trossen_mobile_ai --config examples/trossen_mobile_ai/config.json
  *   ./trossen_mobile_ai --set hardware.arms.leader_left.ip_address=192.168.1.3
- *   ./trossen_mobile_ai --set session.max_duration=30 --set producers.mobile_base.poll_rate_hz=60
+ *   ./trossen_mobile_ai --set session.max_duration=30 --set session.max_episodes=10
  *   ./trossen_mobile_ai --dump-config
  */
 
-#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <iostream>
@@ -44,7 +43,6 @@
 #include "trossen_sdk/hw/base/slate_base_component.hpp"
 #include "trossen_sdk/hw/base/slate_base_producer.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
-#include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
@@ -442,7 +440,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  // shutdown() calls stop_episode() (fires on_episode_ended) then on_pre_shutdown
+  // shutdown() calls stop_episode() (no-op if already stopped) then on_pre_shutdown
   mgr.shutdown();
 
   const auto final_stats = mgr.stats();

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -125,7 +125,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> config_lines = {
     "Config file:          " + config_path,
     "Root directory:       " + root,
-    "Backend:              mcap",
+    "Backend:              " + cfg.session.backend_type,
     "Robot name:           " + cfg.robot_name
   };
   for (const auto& [id, arm] : cfg.hardware.arms) {
@@ -392,7 +392,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  // shutdown() calls stop_episode() (fires on_episode_ended) then on_pre_shutdown
+  // shutdown() calls stop_episode() (no-op if already stopped) then on_pre_shutdown
   mgr.shutdown();
 
   const auto final_stats = mgr.stats();

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -255,6 +255,57 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
 
   // ──────────────────────────────────────────────────────────
+  // Register lifecycle callbacks
+  // ──────────────────────────────────────────────────────────
+
+  // Count depth-capable cameras once for sanity checks
+  int depth_cameras = 0;
+  for (const auto& cam : cfg.hardware.cameras) {
+    if (cam.use_depth) ++depth_cameras;
+  }
+
+  mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
+    const std::string file_path =
+      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+    trossen::utils::print_episode_summary(file_path, stats);
+
+    trossen::utils::SanityCheckConfig sanity_cfg{
+      stats.elapsed.count(),
+      static_cast<int>(cfg.hardware.arms.size()),
+      joint_rate_hz,
+      static_cast<int>(cfg.hardware.cameras.size()),
+      static_cast<int>(camera_fps),
+      5.0,
+      depth_cameras
+    };
+    perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
+  });
+
+  mgr.on_pre_shutdown([&]() {
+    std::cout << "\nReturning arms to starting positions...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_modes(trossen_arm::Mode::position);
+      driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    }
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+
+    std::cout << "Moving arms to sleep positions...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_positions(
+        std::vector<double>(driver->get_num_joints(), 0.0), moving_time_s, false);
+    }
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+
+    std::cout << "Cleaning up arm drivers...\n";
+    for (const auto& [id, comp] : arm_components) {
+      comp->get_hardware()->cleanup();
+    }
+    std::cout << "  [ok] All arm drivers cleaned up\n";
+  });
+
+  // ──────────────────────────────────────────────────────────
   // Episode loop
   // ──────────────────────────────────────────────────────────
 
@@ -304,8 +355,6 @@ int main(int argc, char** argv) {
       break;
     }
 
-    const uint32_t recording_episode_index = mgr.stats().current_episode_index;
-    const auto episode_start_time = std::chrono::steady_clock::now();
     std::cout << "Recording...\n";
 
     // Teleop thread mirrors leader positions to followers at configured rate
@@ -328,7 +377,7 @@ int main(int argc, char** argv) {
       }
     });
 
-    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
+    mgr.monitor_episode();
 
     if (mgr.is_episode_active()) {
       mgr.stop_episode();
@@ -337,62 +386,14 @@ int main(int argc, char** argv) {
       teleop_thread.join();
     }
 
-    const double actual_duration =
-      std::chrono::duration<double>(
-        std::chrono::steady_clock::now() - episode_start_time).count();
-    (void)actual_duration;
-
-    const std::string file_path =
-      trossen::utils::generate_episode_path(root, recording_episode_index);
-    trossen::utils::print_episode_summary(file_path, last_stats);
-
-    // Count depth-capable cameras for accurate sanity check
-    int depth_cameras = 0;
-    for (const auto& cam : cfg.hardware.cameras) {
-      if (cam.use_depth) ++depth_cameras;
-    }
-
-    trossen::utils::SanityCheckConfig sanity_cfg{
-      last_stats.elapsed.count(),
-      static_cast<int>(cfg.hardware.arms.size()),
-      joint_rate_hz,
-      static_cast<int>(cfg.hardware.cameras.size()),
-      static_cast<int>(camera_fps),
-      5.0,
-      depth_cameras
-    };
-    perform_sanity_check(recording_episode_index, last_stats.records_written_current, sanity_cfg);
-
     if (trossen::utils::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
     }
   }
 
+  // shutdown() calls stop_episode() (fires on_episode_ended) then on_pre_shutdown
   mgr.shutdown();
-
-  // Return arms to starting then sleep positions
-  std::cout << "\nReturning arms to starting positions...\n";
-  for (const auto& [id, comp] : arm_components) {
-    auto driver = comp->get_hardware();
-    driver->set_all_modes(trossen_arm::Mode::position);
-    driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
-  }
-  std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-  std::cout << "Moving arms to sleep positions...\n";
-  for (const auto& [id, comp] : arm_components) {
-    auto driver = comp->get_hardware();
-    driver->set_all_positions(
-      std::vector<double>(driver->get_num_joints(), 0.0), moving_time_s, false);
-  }
-  std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-  std::cout << "Cleaning up arm drivers...\n";
-  for (const auto& [id, comp] : arm_components) {
-    comp->get_hardware()->cleanup();
-  }
-  std::cout << "  [ok] All arm drivers cleaned up\n";
 
   const auto final_stats = mgr.stats();
   std::vector<std::string> extra_info = {

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -257,6 +257,57 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
 
   // ──────────────────────────────────────────────────────────
+  // Register lifecycle callbacks
+  // ──────────────────────────────────────────────────────────
+
+  // Count depth-capable cameras once for sanity checks
+  int depth_cameras = 0;
+  for (const auto& cam : cfg.hardware.cameras) {
+    if (cam.use_depth) ++depth_cameras;
+  }
+
+  mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
+    const std::string file_path =
+      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+    trossen::utils::print_episode_summary(file_path, stats);
+
+    trossen::utils::SanityCheckConfig sanity_cfg{
+      stats.elapsed.count(),
+      static_cast<int>(cfg.hardware.arms.size()),
+      joint_rate_hz,
+      static_cast<int>(cfg.hardware.cameras.size()),
+      static_cast<int>(camera_fps),
+      5.0,
+      depth_cameras
+    };
+    perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
+  });
+
+  mgr.on_pre_shutdown([&]() {
+    std::cout << "\nReturning arms to starting positions...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_modes(trossen_arm::Mode::position);
+      driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
+    }
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+
+    std::cout << "Moving arms to sleep positions...\n";
+    for (const auto& [id, comp] : arm_components) {
+      auto driver = comp->get_hardware();
+      driver->set_all_positions(
+        std::vector<double>(driver->get_num_joints(), 0.0), moving_time_s, false);
+    }
+    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
+
+    std::cout << "Cleaning up arm drivers...\n";
+    for (const auto& [id, comp] : arm_components) {
+      comp->get_hardware()->cleanup();
+    }
+    std::cout << "  [ok] All arm drivers cleaned up\n";
+  });
+
+  // ──────────────────────────────────────────────────────────
   // Episode loop
   // ──────────────────────────────────────────────────────────
 
@@ -306,8 +357,6 @@ int main(int argc, char** argv) {
       break;
     }
 
-    const uint32_t recording_episode_index = mgr.stats().current_episode_index;
-    const auto episode_start_time = std::chrono::steady_clock::now();
     std::cout << "Recording...\n";
 
     // Teleop thread mirrors leader positions to followers at configured rate
@@ -330,7 +379,7 @@ int main(int argc, char** argv) {
       }
     });
 
-    trossen::runtime::SessionManager::Stats last_stats = mgr.monitor_episode();
+    mgr.monitor_episode();
 
     if (mgr.is_episode_active()) {
       mgr.stop_episode();
@@ -339,62 +388,14 @@ int main(int argc, char** argv) {
       teleop_thread.join();
     }
 
-    const double actual_duration =
-      std::chrono::duration<double>(
-        std::chrono::steady_clock::now() - episode_start_time).count();
-    (void)actual_duration;
-
-    const std::string file_path =
-      trossen::utils::generate_episode_path(root, recording_episode_index);
-    trossen::utils::print_episode_summary(file_path, last_stats);
-
-    // Count depth-capable cameras for accurate sanity check
-    int depth_cameras = 0;
-    for (const auto& cam : cfg.hardware.cameras) {
-      if (cam.use_depth) ++depth_cameras;
-    }
-
-    trossen::utils::SanityCheckConfig sanity_cfg{
-      last_stats.elapsed.count(),
-      static_cast<int>(cfg.hardware.arms.size()),
-      joint_rate_hz,
-      static_cast<int>(cfg.hardware.cameras.size()),
-      static_cast<int>(camera_fps),
-      5.0,
-      depth_cameras
-    };
-    perform_sanity_check(recording_episode_index, last_stats.records_written_current, sanity_cfg);
-
     if (trossen::utils::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";
       break;
     }
   }
 
+  // shutdown() calls stop_episode() (fires on_episode_ended) then on_pre_shutdown
   mgr.shutdown();
-
-  // Return arms to starting then sleep positions
-  std::cout << "\nReturning arms to starting positions...\n";
-  for (const auto& [id, comp] : arm_components) {
-    auto driver = comp->get_hardware();
-    driver->set_all_modes(trossen_arm::Mode::position);
-    driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
-  }
-  std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-  std::cout << "Moving arms to sleep positions...\n";
-  for (const auto& [id, comp] : arm_components) {
-    auto driver = comp->get_hardware();
-    driver->set_all_positions(
-      std::vector<double>(driver->get_num_joints(), 0.0), moving_time_s, false);
-  }
-  std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-  std::cout << "Cleaning up arm drivers...\n";
-  for (const auto& [id, comp] : arm_components) {
-    comp->get_hardware()->cleanup();
-  }
-  std::cout << "  [ok] All arm drivers cleaned up\n";
 
   const auto final_stats = mgr.stats();
   std::vector<std::string> extra_info = {

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -19,7 +19,7 @@
  *   ./trossen_stationary_ai
  *   ./trossen_stationary_ai --config examples/trossen_stationary_ai/config.json
  *   ./trossen_stationary_ai --set hardware.arms.leader_left.ip_address=192.168.1.3
- *   ./trossen_stationary_ai --set session.max_duration=30 --set session.backend_type=lerobot
+ *   ./trossen_stationary_ai --set session.max_duration=30 --set session.backend_type=lerobot_v2
  *   ./trossen_stationary_ai --dump-config
  */
 
@@ -40,7 +40,6 @@
 #include "trossen_sdk/hw/arm/trossen_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
-#include "trossen_sdk/io/backend_utils.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
@@ -394,7 +393,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  // shutdown() calls stop_episode() (fires on_episode_ended) then on_pre_shutdown
+  // shutdown() calls stop_episode() (no-op if already stopped) then on_pre_shutdown
   mgr.shutdown();
 
   const auto final_stats = mgr.stats();

--- a/include/trossen_sdk/configuration/types/hardware/camera_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/camera_config.hpp
@@ -14,73 +14,50 @@
 namespace trossen::configuration {
 
 /**
- * @brief Configuration for a single camera hardware component
+ * @brief Configuration for a single camera (RealSense, OpenCV, or ZED)
  *
  * The @p type field selects which hardware component is created via HardwareRegistry.
- * Supported types: @c "realsense_camera", @c "opencv_camera", @c "zed_camera".
+ * Use @c "realsense_camera" for RealSense cameras, @c "opencv_camera" for
+ * any V4L2 / USB webcam accessible through OpenCV, or @c "zed_camera" for
+ * StereoLabs ZED stereo cameras.
  *
- * Common fields across all camera types:
- *   - @c id   — logical identifier used as stream_id (e.g. "camera_0")
- *   - @c type — hardware registry key
- *   - @c fps  — capture frame rate
- *
- * Resolution configuration varies by camera type:
- *
- * **RealSense / OpenCV** — set resolution via @c width and @c height in pixels.
- * Any resolution the hardware supports can be requested; the driver will
- * negotiate the closest match. Common examples: 640x480, 1280x720, 1920x1080.
- *
- * **ZED** — set resolution via the @c "resolution" string in the @c extra
- * passthrough field. Supported values (default: "HD720"):
- *   - "HD2K"   — 2208x1242
- *   - "HD1200" — 1920x1200
- *   - "HD1080" — 1920x1080
- *   - "HD720"  — 1280x720
- *   - "SVGA"   — 960x600
- *   - "VGA"    — 672x376
- *   - "AUTO"   — selected by the SDK based on the camera model
- *
- * Depth support:
- *   - **RealSense** — enable with @c use_depth. Uses the same width/height as color.
- *   - **ZED** — enable with @c use_depth and set @c "depth_mode" in extra.
- *     Supported depth modes: "NEURAL_LIGHT", "NEURAL", "NEURAL_PLUS", "NONE".
- *     Legacy modes "PERFORMANCE", "QUALITY", "ULTRA" are accepted but deprecated
- *     in ZED SDK 5.x — prefer "NEURAL_LIGHT", "NEURAL", "NEURAL_PLUS" respectively.
- *   - **OpenCV** — depth not supported.
- *
- * Camera-type-specific fields:
- *   - @c serial_number — device serial (RealSense: string, ZED: numeric, both accepted)
- *   - @c device_index  — V4L2 device index (OpenCV only)
- *   - @c backend       — capture backend, "v4l2" or "any" (OpenCV only)
- *   - @c force_hardware_reset — reset device on open (RealSense only)
- *   - @c extra         — passthrough JSON for fields not modelled above (e.g. ZED
- *                         "resolution", "depth_mode"); merged into the config sent
- *                         to HardwareComponent::configure()
- *
- * JSON examples:
+ * JSON format (RealSense):
  * @code
- * // RealSense
  * {
- *   "id": "camera_0", "type": "realsense_camera",
+ *   "id": "camera_0",
+ *   "type": "realsense_camera",
  *   "serial_number": "128422271347",
- *   "width": 640, "height": 480, "fps": 30,
- *   "use_depth": false, "force_hardware_reset": false
+ *   "width": 640,
+ *   "height": 480,
+ *   "fps": 30,
+ *   "use_depth": false,
+ *   "force_hardware_reset": false
  * }
+ * @endcode
  *
- * // OpenCV
+ * JSON format (OpenCV):
+ * @code
  * {
- *   "id": "camera_0", "type": "opencv_camera",
+ *   "id": "camera_0",
+ *   "type": "opencv_camera",
  *   "device_index": 0,
- *   "width": 640, "height": 480, "fps": 30,
+ *   "width": 640,
+ *   "height": 480,
+ *   "fps": 30,
  *   "backend": "v4l2"
  * }
+ * @endcode
  *
- * // ZED
+ * JSON format (ZED):
+ * @code
  * {
- *   "id": "zed_0", "type": "zed_camera",
- *   "serial_number": "12345678", "fps": 30,
+ *   "id": "zed_0",
+ *   "type": "zed_camera",
+ *   "serial_number": "12345678",
+ *   "fps": 30,
  *   "resolution": "HD720",
- *   "use_depth": true, "depth_mode": "NEURAL"
+ *   "use_depth": true,
+ *   "depth_mode": "NEURAL"
  * }
  * @endcode
  */
@@ -94,7 +71,7 @@ struct CameraConfig {
   // TODO(shantanuparab-tr): Unify serial_number and device_index into a
   // single device identifier field (serial string or numeric index).
 
-  /// @brief Device serial number (RealSense: string, ZED: numeric — both accepted)
+  /// @brief Camera serial number (RealSense: string, ZED: numeric — both accepted)
   std::string serial_number{""};
 
   /// @brief OpenCV device index (OpenCV only)
@@ -107,10 +84,10 @@ struct CameraConfig {
   //       a resolution string (e.g. "720x480", "HD720", "SVGA") that maps to
   //       width/height for RealSense/OpenCV and to the native enum for ZED.
 
-  /// @brief Capture width in pixels (RealSense / OpenCV; ZED uses "resolution" in extra)
+  /// @brief Capture width in pixels (RealSense / OpenCV only; ZED uses "resolution" in extra)
   int width{640};
 
-  /// @brief Capture height in pixels (RealSense / OpenCV; ZED uses "resolution" in extra)
+  /// @brief Capture height in pixels (RealSense / OpenCV only; ZED uses "resolution" in extra)
   int height{480};
 
   /// @brief Capture frame rate

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -340,6 +340,9 @@ void SessionManager::stop_episode() {
   // Update state
   episode_active_ = false;
   ++total_episodes_completed_;
+
+  // Snapshot the finished episode index before incrementing for use in callbacks
+  uint32_t finished_episode_index = next_episode_index_;
   ++next_episode_index_;
 
   // Measure and report shutdown duration
@@ -360,8 +363,10 @@ void SessionManager::stop_episode() {
   }
   auto_stop_cv_.notify_all();
 
-  // Compute final stats while we still hold the lock
+  // Compute final stats while we still hold the lock, then correct the episode index
+  // so callbacks receive the index of the episode that just finished (not the next one)
   Stats final_stats = stats_unlocked();
+  final_stats.current_episode_index = finished_episode_index;
 
   // Invoke episode-ended callbacks
   for (const auto& cb : episode_ended_cbs_) {


### PR DESCRIPTION
- Wire on_episode_ended and on_pre_shutdown callbacks into all 3 example scripts (solo,  
stationary, mobile)
- Post-episode summary + sanity check now fires automatically on every stop path  
(auto-stop, Ctrl+C, destructor)
- Arm homing + cleanup runs as part of shutdown() via on_pre_shutdown, guaranteeing safe
hardware state