### PR TITLE
Add announce() text-to-speech utility for audio indicators

### DIFF
--- a/include/trossen_sdk/utils/app_utils.hpp
+++ b/include/trossen_sdk/utils/app_utils.hpp
@@ -121,8 +121,8 @@ std::string generate_episode_path(
  *
  * Blocks until speech finishes (-w flag). Safe to call even if spd-say
  * is not installed — fails silently (stderr suppressed).
- * Only alphanumeric characters and basic punctuation are passed through;
- * all other characters are stripped for shell safety.
+ * Message is passed directly to spd-say via posix_spawn (no shell involved),
+ * so all characters are safe and no sanitization is needed.
  *
  * @param message Text to speak; empty messages are ignored
  */

--- a/include/trossen_sdk/utils/app_utils.hpp
+++ b/include/trossen_sdk/utils/app_utils.hpp
@@ -116,4 +116,16 @@ std::string generate_episode_path(
   uint32_t episode_index,
   const std::string& extension = "trossen_mcap");
 
+/**
+ * @brief Announce a message via text-to-speech (spd-say)
+ *
+ * Blocks until speech finishes (-w flag). Safe to call even if spd-say
+ * is not installed — fails silently (stderr suppressed).
+ * Only alphanumeric characters and basic punctuation are passed through;
+ * all other characters are stripped for shell safety.
+ *
+ * @param message Text to speak; empty messages are ignored
+ */
+void announce(const std::string& message);
+
 }  // namespace trossen::utils

--- a/include/trossen_sdk/utils/app_utils.hpp
+++ b/include/trossen_sdk/utils/app_utils.hpp
@@ -119,13 +119,14 @@ std::string generate_episode_path(
 /**
  * @brief Announce a message via text-to-speech (spd-say)
  *
- * Blocks until speech finishes (-w flag). Safe to call even if spd-say
- * is not installed — fails silently (stderr suppressed).
+ * Safe to call even if spd-say is not installed -- fails silently.
  * Message is passed directly to spd-say via posix_spawn (no shell involved),
  * so all characters are safe and no sanitization is needed.
  *
  * @param message Text to speak; empty messages are ignored
+ * @param block If true (default), blocks until speech finishes.
+ *              If false, returns immediately while speech plays in background.
  */
-void announce(const std::string& message);
+void announce(const std::string& message, bool block = true);
 
 }  // namespace trossen::utils

--- a/src/utils/app_utils.cpp
+++ b/src/utils/app_utils.cpp
@@ -279,11 +279,14 @@ std::string generate_episode_path(
   return path.str();
 }
 
-void announce(const std::string& message) {
+void announce(const std::string& message, bool block) {
   if (message.empty()) return;
 
   // Spawn spd-say directly via posix_spawnp (no shell involved).
-  const char* argv[] = {"spd-say", "-w", message.c_str(), nullptr};
+  // When blocking, pass -w so spd-say itself waits for speech to finish.
+  const char* argv_block[] = {"spd-say", "-w", message.c_str(), nullptr};
+  const char* argv_async[] = {"spd-say", message.c_str(), nullptr};
+  const char** argv = block ? argv_block : argv_async;
 
   // Suppress stderr so missing spd-say doesn't print errors
   posix_spawn_file_actions_t actions;
@@ -299,8 +302,8 @@ void announce(const std::string& message) {
     const_cast<char**>(argv), environ);
   if (have_actions) posix_spawn_file_actions_destroy(&actions);
 
-  if (err == 0) {
-    waitpid(pid, nullptr, 0);  // block until speech finishes
+  if (err == 0 && block) {
+    waitpid(pid, nullptr, 0);
   }
 }
 

--- a/src/utils/app_utils.cpp
+++ b/src/utils/app_utils.cpp
@@ -3,15 +3,18 @@
  * @brief Implementation of shared utilities for Trossen SDK applications
  */
 
-#include <cctype>
 #include <csignal>
-#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
+
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "trossen_sdk/utils/app_utils.hpp"
 
@@ -278,19 +281,27 @@ std::string generate_episode_path(
 
 void announce(const std::string& message) {
   if (message.empty()) return;
-  // Allowlist: keep only characters safe for shell single-quote context.
-  // SECURITY: single-quote (') MUST NOT be added — it terminates the shell
-  // string in the spd-say command below and would enable command injection.
-  std::string safe_msg;
-  safe_msg.reserve(message.size());
-  for (char c : message) {
-    if (std::isalnum(static_cast<unsigned char>(c)) || c == ' ' ||
-        c == '.' || c == ',' || c == '!' || c == '?' || c == '-') {
-      safe_msg += c;
-    }
+
+  // Spawn spd-say directly via posix_spawnp (no shell involved).
+  const char* argv[] = {"spd-say", "-w", message.c_str(), nullptr};
+
+  // Suppress stderr so missing spd-say doesn't print errors
+  posix_spawn_file_actions_t actions;
+  bool have_actions = (posix_spawn_file_actions_init(&actions) == 0);
+  if (have_actions) {
+    posix_spawn_file_actions_addopen(
+      &actions, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
   }
-  if (safe_msg.empty()) return;
-  (void)std::system(("spd-say -w '" + safe_msg + "' 2>/dev/null").c_str());
+
+  pid_t pid;
+  int err = posix_spawnp(
+    &pid, "spd-say", have_actions ? &actions : nullptr, nullptr,
+    const_cast<char**>(argv), environ);
+  if (have_actions) posix_spawn_file_actions_destroy(&actions);
+
+  if (err == 0) {
+    waitpid(pid, nullptr, 0);  // block until speech finishes
+  }
 }
 
 }  // namespace trossen::utils

--- a/src/utils/app_utils.cpp
+++ b/src/utils/app_utils.cpp
@@ -3,7 +3,9 @@
  * @brief Implementation of shared utilities for Trossen SDK applications
  */
 
+#include <cctype>
 #include <csignal>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -272,6 +274,23 @@ std::string generate_episode_path(
        << std::setfill('0') << std::setw(6) << episode_index
        << "." << extension;
   return path.str();
+}
+
+void announce(const std::string& message) {
+  if (message.empty()) return;
+  // Allowlist: keep only characters safe for shell single-quote context.
+  // SECURITY: single-quote (') MUST NOT be added — it terminates the shell
+  // string in the spd-say command below and would enable command injection.
+  std::string safe_msg;
+  safe_msg.reserve(message.size());
+  for (char c : message) {
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == ' ' ||
+        c == '.' || c == ',' || c == '!' || c == '?' || c == '-') {
+      safe_msg += c;
+    }
+  }
+  if (safe_msg.empty()) return;
+  (void)std::system(("spd-say -w '" + safe_msg + "' 2>/dev/null").c_str());
 }
 
 }  // namespace trossen::utils


### PR DESCRIPTION
During data collection, the operator is physically focused on resetting the robot environment and not always watching the screen. We need audio cues so they know when episodes start, end, and when to reset.

This adds a small announce() utility that speaks a short message using spd-say (pre-installed on Ubuntu Desktop). It blocks until speech finishes so announcements don't overlap each other.

Input is sanitized with a character allowlist before being passed to the shell. The critical invariant, that single-quote must never be in the allowlist, is documented with a SECURITY comment so future contributors don't accidentally introduce a shell injection vector.

Fails silently when spd-say isn't installed, so headless and non-Ubuntu systems just skip the audio with no errors.