### PR TITLE
Add configurable reset wait to SessionManager

### DIFF
--- a/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
+++ b/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
@@ -38,13 +38,18 @@ struct SessionManagerConfig : public BaseConfig {
       j.at("backend_type").get_to(c.backend_type);
     }
     if (j.contains("reset_duration")) {
-      double val = j.at("reset_duration").get<double>();
-      if (val > 0.0) {
-        c.reset_duration = std::chrono::duration<double>{val};
+      const auto& rd = j.at("reset_duration");
+      if (rd.is_null()) {
+        // Explicit null = infinite wait (same as omitting the field)
+        c.reset_duration = std::nullopt;
       } else {
-        // Zero or negative = no wait (skip reset phase entirely).
-        // To get infinite wait, omit the field or set to null.
-        c.reset_duration = std::chrono::duration<double>{0.0};
+        double val = rd.get<double>();
+        if (val > 0.0) {
+          c.reset_duration = std::chrono::duration<double>{val};
+        } else {
+          // Zero or negative = no wait (skip reset phase entirely).
+          c.reset_duration = std::chrono::duration<double>{0.0};
+        }
       }
     }
 

--- a/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
+++ b/include/trossen_sdk/configuration/types/runtime/session_manager_config.hpp
@@ -18,6 +18,10 @@ struct SessionManagerConfig : public BaseConfig {
   std::optional<std::chrono::duration<double>> max_duration{std::chrono::seconds(20)};
   std::optional<uint32_t> max_episodes{std::nullopt};
   std::string backend_type{"trossen_mcap"};
+  /// Reset duration between episodes.
+  /// Positive = countdown timer (seconds). Zero = no wait (skip reset).
+  /// nullopt (field absent) = infinite wait for user input.
+  std::optional<std::chrono::duration<double>> reset_duration{std::nullopt};
 
   std::string type() const override { return "session_manager"; }
 
@@ -32,6 +36,16 @@ struct SessionManagerConfig : public BaseConfig {
     }
     if (j.contains("backend_type")) {
       j.at("backend_type").get_to(c.backend_type);
+    }
+    if (j.contains("reset_duration")) {
+      double val = j.at("reset_duration").get<double>();
+      if (val > 0.0) {
+        c.reset_duration = std::chrono::duration<double>{val};
+      } else {
+        // Zero or negative = no wait (skip reset phase entirely).
+        // To get infinite wait, omit the field or set to null.
+        c.reset_duration = std::chrono::duration<double>{0.0};
+      }
     }
 
     return c;

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -277,6 +277,28 @@ public:
   void print_stats_line(const Stats& stats);
 
   /**
+   * @brief Wait between episodes for the configured reset period
+   *
+   * If reset_duration is positive, prints a countdown for that many seconds.
+   * If reset_duration is zero, returns immediately (no reset phase).
+   * If reset_duration is unset (nullopt), blocks until signal_reset_complete()
+   * is called or right arrow is pressed.
+   * Both timed and infinite modes can be interrupted by Ctrl+C or skipped with
+   * right arrow key.
+   *
+   * @return true if reset completed normally, false if interrupted by stop request
+   */
+  bool wait_for_reset();
+
+  /**
+   * @brief Signal that the reset hold should end
+   *
+   * Thread-safe. Wakes wait_for_reset() from infinite hold or skips remaining
+   * countdown. Can be called from any thread (input thread, UI callback, etc.).
+   */
+  void signal_reset_complete();
+
+  /**
   * @brief Pausable sleep that respects stop requests
   *
   * Sleeps for the specified duration but checks g_stop_requested
@@ -376,6 +398,15 @@ private:
 
   /// @brief Flag indicating that auto-stop was triggered by monitor thread
   std::atomic<bool> auto_stop_triggered_{false};
+
+  /// @brief Condition variable for reset wait signaling
+  std::condition_variable reset_cv_;
+
+  /// @brief Mutex for reset condition variable
+  std::mutex reset_mutex_;
+
+  /// @brief Flag indicating that reset wait should end
+  std::atomic<bool> reset_signaled_{false};
 
   /// @brief Flag indicating that episode final statistics were emitted
   mutable std::atomic<bool> stats_emitted_{false};

--- a/src/configuration/sdk_config.cpp
+++ b/src/configuration/sdk_config.cpp
@@ -85,6 +85,9 @@ void SdkConfig::populate_global_config() const {
       sm["max_episodes"] = session.max_episodes.value();
     }
     sm["backend_type"] = session.backend_type;
+    if (session.reset_duration.has_value()) {
+      sm["reset_duration"] = session.reset_duration->count();
+    }
     gc_json["session_manager"] = sm;
   }
 

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -14,6 +14,8 @@
 
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
+#include "trossen_sdk/utils/app_utils.hpp"
+#include "trossen_sdk/utils/input_utils.hpp"
 
 namespace trossen::runtime {
 
@@ -274,6 +276,9 @@ bool SessionManager::start_episode() {
   preprocessing_duration_s_ =
     std::chrono::duration<double>(prep_end_time - prep_start_time).count();
   std::cout << "Episode " << next_episode_index_ << " started." << std::endl;
+
+  trossen::utils::announce(
+    "Episode " + std::to_string(next_episode_index_) + " started");
 
   // Invoke episode-started callbacks
   for (const auto& cb : episode_started_cbs_) {
@@ -570,6 +575,75 @@ void SessionManager::print_stats_line(const SessionManager::Stats& stats) {
   }
 
   std::cout << std::flush;
+}
+
+bool SessionManager::wait_for_reset() {
+  // Reset signal flag for this wait cycle
+  reset_signaled_.store(false);
+
+  trossen::utils::announce("Episode complete");
+
+  // Enable raw terminal input to detect keypresses without Enter
+  trossen::utils::RawModeGuard raw_mode;
+
+  // Helper: wait up to 100ms, waking early on signal_reset_complete()
+  auto wait_or_signal = [this]() {
+    std::unique_lock<std::mutex> lk(reset_mutex_);
+    reset_cv_.wait_for(lk, std::chrono::milliseconds(100), [this]() {
+      return reset_signaled_.load() || trossen::utils::g_stop_requested;
+    });
+  };
+
+  if (cfg_->reset_duration.has_value()) {
+    // Zero duration = skip reset phase entirely
+    if (cfg_->reset_duration->count() <= 0.0) {
+      return true;
+    }
+
+    // Countdown mode: wait for the configured duration
+    int total_seconds = static_cast<int>(cfg_->reset_duration->count());
+    if (total_seconds < 1) total_seconds = 1;
+
+    std::cout << "\nResetting environment — next episode in "
+              << total_seconds << " seconds...\n"
+              << "  (Press -> to skip)\n";
+    trossen::utils::announce("Reset time");
+
+    for (int i = total_seconds; i > 0; --i) {
+      if (trossen::utils::g_stop_requested || reset_signaled_.load()) break;
+      std::cout << "  " << i << "...\n";
+      // Poll for keypress during each second (10 x 100ms)
+      for (int ms = 0; ms < 10; ++ms) {
+        if (trossen::utils::g_stop_requested || reset_signaled_.load()) break;
+        auto key = trossen::utils::poll_keypress();
+        if (key == trossen::utils::KeyPress::kRightArrow) {
+          reset_signaled_.store(true);
+          break;
+        }
+        wait_or_signal();
+      }
+    }
+  } else {
+    // Infinite wait: block until right arrow, signal_reset_complete(), or Ctrl+C
+    std::cout << "\nWaiting for input — press -> to continue...\n";
+    trossen::utils::announce("Reset time. Waiting for input.");
+
+    while (!trossen::utils::g_stop_requested && !reset_signaled_.load()) {
+      auto key = trossen::utils::poll_keypress();
+      if (key == trossen::utils::KeyPress::kRightArrow) {
+        reset_signaled_.store(true);
+        break;
+      }
+      wait_or_signal();
+    }
+  }
+
+  return !trossen::utils::g_stop_requested;
+}
+
+void SessionManager::signal_reset_complete() {
+  reset_signaled_.store(true);
+  reset_cv_.notify_all();
 }
 
 SessionManager::Stats SessionManager::monitor_episode(

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -597,11 +598,11 @@ bool SessionManager::wait_for_reset() {
   if (cfg_->reset_duration.has_value()) {
     // Zero duration = skip reset phase entirely
     if (cfg_->reset_duration->count() <= 0.0) {
-      return true;
+      return !trossen::utils::g_stop_requested;
     }
 
     // Countdown mode: wait for the configured duration
-    int total_seconds = static_cast<int>(cfg_->reset_duration->count());
+    int total_seconds = static_cast<int>(std::ceil(cfg_->reset_duration->count()));
     if (total_seconds < 1) total_seconds = 1;
 
     std::cout << "\nResetting environment — next episode in "

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -16,7 +16,7 @@
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 #include "trossen_sdk/utils/app_utils.hpp"
-#include "trossen_sdk/utils/input_utils.hpp"
+#include "trossen_sdk/utils/keyboard_input_utils.hpp"
 
 namespace trossen::runtime {
 

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -279,7 +279,7 @@ bool SessionManager::start_episode() {
   std::cout << "Episode " << next_episode_index_ << " started." << std::endl;
 
   trossen::utils::announce(
-    "Episode " + std::to_string(next_episode_index_) + " started");
+    "Episode " + std::to_string(next_episode_index_) + " started", false);
 
   // Invoke episode-started callbacks
   for (const auto& cb : episode_started_cbs_) {


### PR DESCRIPTION
Between episodes the operator needs time to physically reset the robot environment. Right now there's no built-in pause, so every example has to roll its own sleep-and-wait logic.

This adds wait_for_reset() and signal_reset_complete() to SessionManager, plus a new reset_duration config field.

If reset_duration is a positive number, it runs a countdown timer with audio announcements. If it's zero, the reset phase is skipped entirely. If the field is omitted, it blocks indefinitely until the operator presses right arrow or signal_reset_complete() is called programmatically.

The wait uses the condition variable internally so signal_reset_complete() wakes it instantly rather than waiting for the next 100ms poll cycle. This keeps things responsive for future UI integration (buttons, touchscreen, foot pedal, etc.).

Also adds an announce("Episode N started") call at the start of each episode so the operator gets an audio cue that recording has begun.