### PR TITLE
Add discard_episode() to backend interface for re-record support

### DIFF
--- a/include/trossen_sdk/io/backend.hpp
+++ b/include/trossen_sdk/io/backend.hpp
@@ -105,6 +105,15 @@ public:
   virtual void close() = 0;
 
   /**
+   * @brief Discard all data for the current episode
+   *
+   * Closes the backend without finalizing, then deletes all files/directories
+   * associated with the current episode_index_. Used for re-recording.
+   * Safe to call even if the backend was already closed (e.g., by Sink::stop()).
+   */
+  virtual void discard_episode() = 0;
+
+  /**
    * @brief Scan directory for existing episode files and return next index
    * @return Next episode index to use
    */

--- a/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
@@ -418,6 +418,92 @@ inline bool write_task_entry(
 }
 
 /**
+ * @brief Remove the last non-empty line from a JSONL file
+ *
+ * Used during episode discard to undo appended entries.
+ *
+ * @param file_path Path to the JSONL file
+ * @return true on success, false on failure
+ */
+inline bool remove_last_jsonl_line(const std::filesystem::path& file_path) {
+  namespace fs = std::filesystem;
+  if (!fs::exists(file_path)) return true;
+
+  std::ifstream in(file_path);
+  if (!in.is_open()) return false;
+
+  std::vector<std::string> lines;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty()) lines.push_back(line);
+  }
+  in.close();
+
+  if (lines.empty()) return true;
+  lines.pop_back();
+
+  std::ofstream out(file_path, std::ios::trunc);
+  if (!out.is_open()) return false;
+  for (const auto& l : lines) {
+    out << l << "\n";
+  }
+  out.close();
+  return true;
+}
+
+/**
+ * @brief Revert info.json counters after discarding an episode
+ *
+ * Decrements total_episodes, total_frames, total_videos, and adjusts
+ * the train split range. Requires the frame count that was recorded for
+ * the discarded episode.
+ *
+ * @param meta_dir Path to the meta directory
+ * @param episode_frame_count Number of frames in the discarded episode
+ * @param num_videos Number of video streams in the discarded episode
+ * @return true on success, false on failure
+ */
+inline bool revert_info_json(
+    const std::filesystem::path& meta_dir,
+    int episode_frame_count,
+    int num_videos) {
+  namespace fs = std::filesystem;
+
+  fs::path info_path = meta_dir / JSON_INFO;
+  if (!fs::exists(info_path)) return true;
+
+  nlohmann::ordered_json info_json;
+  {
+    std::ifstream info_file(info_path);
+    if (!info_file.is_open()) return false;
+    info_file >> info_json;
+  }
+
+  int total_episodes = std::max(0, info_json.value("total_episodes", 0) - 1);
+  info_json["total_episodes"] = total_episodes;
+  info_json["total_videos"] = std::max(0, info_json.value("total_videos", 0) - num_videos);
+  info_json["total_frames"] = std::max(0, info_json.value("total_frames", 0) - episode_frame_count);
+
+  int chunks_size = info_json.value("chunks_size", 1000);
+  info_json["total_chunks"] = std::max(1, (total_episodes + chunks_size - 1) / chunks_size);
+
+  // Adjust train split end
+  std::string train_split = info_json["splits"].value("train", "0:0");
+  size_t colon_pos = train_split.find(':');
+  if (colon_pos != std::string::npos) {
+    int train_start = std::stoi(train_split.substr(0, colon_pos));
+    int train_end = std::max(train_start, std::stoi(train_split.substr(colon_pos + 1)) - 1);
+    info_json["splits"]["train"] = std::to_string(train_start) + ":" + std::to_string(train_end);
+  }
+
+  std::ofstream out(info_path);
+  if (!out.is_open()) return false;
+  out << info_json.dump(4);
+  out.close();
+  return true;
+}
+
+/**
  * @brief Append episode statistics to episodes_stats.jsonl
  *
  * @param meta_dir Path to the meta directory
@@ -625,6 +711,11 @@ public:
   void close() override;
 
   /**
+   * @brief Discard episode data and delete parquet file + image directories
+   */
+  void discard_episode() override;
+
+  /**
    * @brief Add metadata to be written to info.json
    *
    * @param md Metadata to add
@@ -761,6 +852,14 @@ public:
   }
 
 private:
+  /**
+   * @brief Close writer, output stream, and image workers without finalization.
+   *
+   * Shared teardown used by both close() and discard_episode(). Does NOT call
+   * convert_to_videos() or compute_statistics(). Caller must hold open_mutex_.
+   */
+  void close_resources();
+
   /**
    * @brief Write a joint state record to disk
    *

--- a/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
@@ -418,14 +418,19 @@ inline bool write_task_entry(
 }
 
 /**
- * @brief Remove the last non-empty line from a JSONL file
+ * @brief Remove the last JSONL entry matching a given episode_index
  *
- * Used during episode discard to undo appended entries.
+ * Only removes the last line if its "episode_index" field matches the
+ * expected index. Returns true (no-op) if the last entry doesn't match,
+ * preventing accidental deletion of a previous episode's metadata.
  *
  * @param file_path Path to the JSONL file
- * @return true on success, false on failure
+ * @param expected_episode_index Episode index that must match for removal
+ * @return true on success or no-op, false on I/O failure
  */
-inline bool remove_last_jsonl_line(const std::filesystem::path& file_path) {
+inline bool remove_last_jsonl_line(
+    const std::filesystem::path& file_path,
+    int expected_episode_index) {
   namespace fs = std::filesystem;
   if (!fs::exists(file_path)) return true;
 
@@ -440,6 +445,17 @@ inline bool remove_last_jsonl_line(const std::filesystem::path& file_path) {
   in.close();
 
   if (lines.empty()) return true;
+
+  // Only remove if the last entry's episode_index matches
+  try {
+    auto entry = nlohmann::json::parse(lines.back());
+    if (entry.value("episode_index", -1) != expected_episode_index) {
+      return true;  // no-op: last entry belongs to a different episode
+    }
+  } catch (const std::exception&) {
+    return false;  // malformed JSON
+  }
+
   lines.pop_back();
 
   std::ofstream out(file_path, std::ios::trunc);
@@ -487,13 +503,21 @@ inline bool revert_info_json(
   int chunks_size = info_json.value("chunks_size", 1000);
   info_json["total_chunks"] = std::max(1, (total_episodes + chunks_size - 1) / chunks_size);
 
-  // Adjust train split end
-  std::string train_split = info_json["splits"].value("train", "0:0");
-  size_t colon_pos = train_split.find(':');
-  if (colon_pos != std::string::npos) {
-    int train_start = std::stoi(train_split.substr(0, colon_pos));
-    int train_end = std::max(train_start, std::stoi(train_split.substr(colon_pos + 1)) - 1);
-    info_json["splits"]["train"] = std::to_string(train_start) + ":" + std::to_string(train_end);
+  // Adjust train split end (guard against missing/malformed "splits")
+  if (info_json.contains("splits") && info_json["splits"].is_object() &&
+      info_json["splits"].contains("train")) {
+    try {
+      std::string train_split = info_json["splits"].value("train", "0:0");
+      size_t colon_pos = train_split.find(':');
+      if (colon_pos != std::string::npos) {
+        int train_start = std::stoi(train_split.substr(0, colon_pos));
+        int train_end = std::max(train_start, std::stoi(train_split.substr(colon_pos + 1)) - 1);
+        info_json["splits"]["train"] =
+            std::to_string(train_start) + ":" + std::to_string(train_end);
+      }
+    } catch (const std::exception&) {
+      // Malformed split value — leave unchanged
+    }
   }
 
   std::ofstream out(info_path);

--- a/include/trossen_sdk/io/backends/null/null_backend.hpp
+++ b/include/trossen_sdk/io/backends/null/null_backend.hpp
@@ -64,6 +64,11 @@ public:
   void close() override;
 
   /**
+   * @brief Discard episode data (no-op for null backend)
+   */
+  void discard_episode() override {}
+
+  /**
    * @brief Get the number of records "written"
    *
    * @return Count of records

--- a/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp
@@ -108,6 +108,11 @@ public:
   void close() override;
 
   /**
+   * @brief Discard episode data and delete the MCAP file
+   */
+  void discard_episode() override;
+
+  /**
    * @brief Get statistics about written records
    *
    * @return Stats structure with counts
@@ -122,6 +127,14 @@ public:
   uint32_t scan_existing_episodes() override;
 
 private:
+  /**
+   * @brief Close all channels and writer without deleting files.
+   *
+   * Shared teardown used by both close() and discard_episode().
+   * Caller must hold writer_mutex_.
+   */
+  void close_resources();
+
   /**
    * @brief Ensure an image channel exists for the given camera name
    *

--- a/src/backends/lerobot_v2/lerobot_v2_backend.cpp
+++ b/src/backends/lerobot_v2/lerobot_v2_backend.cpp
@@ -804,7 +804,9 @@ void LeRobotV2Backend::flush() {
 
 void LeRobotV2Backend::close_resources() {
   // Caller must hold open_mutex_. Closes writer, stream, and image workers.
-  if (!opened_) return;
+  // Check actual resource state, not just opened_, because open() may have
+  // started threads before a later step threw (leaving opened_ == false).
+  if (!opened_ && !writer_ && !outfile_ && image_workers_.empty()) return;
 
   try {
     if (writer_) {
@@ -840,6 +842,8 @@ void LeRobotV2Backend::close_resources() {
 
 void LeRobotV2Backend::close() {
   std::lock_guard<std::mutex> lock(open_mutex_);
+
+  if (!opened_) return;
 
   close_resources();
 
@@ -938,11 +942,12 @@ void LeRobotV2Backend::discard_episode() {
     }
   } catch (...) {}
 
-  // Remove last entries from JSONL metadata files
-  if (!remove_last_jsonl_line(discard_meta / JSONL_EPISODES)) {
+  // Remove JSONL entries only if they match this episode's index
+  int ep_idx = static_cast<int>(episode_index_);
+  if (!remove_last_jsonl_line(discard_meta / JSONL_EPISODES, ep_idx)) {
     std::cerr << "[LeRobotV2] Warning: Failed to revert episodes.jsonl" << std::endl;
   }
-  if (!remove_last_jsonl_line(discard_meta / JSONL_EPISODE_STATS)) {
+  if (!remove_last_jsonl_line(discard_meta / JSONL_EPISODE_STATS, ep_idx)) {
     std::cerr << "[LeRobotV2] Warning: Failed to revert episodes_stats.jsonl" << std::endl;
   }
 

--- a/src/backends/lerobot_v2/lerobot_v2_backend.cpp
+++ b/src/backends/lerobot_v2/lerobot_v2_backend.cpp
@@ -802,14 +802,11 @@ void LeRobotV2Backend::flush() {
   // TODO(shantanuparab-tr): flush parquet writer if needed
 }
 
-void LeRobotV2Backend::close() {
-  std::lock_guard<std::mutex> lock(open_mutex_);
-  if (!opened_) {
-    return;
-  }
+void LeRobotV2Backend::close_resources() {
+  // Caller must hold open_mutex_. Closes writer, stream, and image workers.
+  if (!opened_) return;
 
   try {
-    // 1. Flush and close writer if initialized
     if (writer_) {
       auto st = writer_->Close();
       if (!st.ok()) {
@@ -819,7 +816,6 @@ void LeRobotV2Backend::close() {
       writer_.reset();
     }
 
-    // 2. Close output stream (very important!)
     if (outfile_) {
       auto st = outfile_->Close();
       if (!st.ok()) {
@@ -828,28 +824,134 @@ void LeRobotV2Backend::close() {
       }
       outfile_.reset();
     }
-  } catch (const std::exception &e) {
+  } catch (const std::exception& e) {
     std::cerr << "[Parquet] Exception while closing: " << e.what() << std::endl;
   }
 
-  // Stop image worker
   image_worker_running_ = false;
   image_queue_cv_.notify_all();
-  for (auto &t : image_workers_) {
+  for (auto& t : image_workers_) {
     if (t.joinable()) t.join();
   }
   image_workers_.clear();
+  source_frame_indices_.clear();
+  opened_ = false;
+}
+
+void LeRobotV2Backend::close() {
+  std::lock_guard<std::mutex> lock(open_mutex_);
+
+  close_resources();
 
   // Encode any remaining images to videos
   convert_to_videos();
 
   // Compute dataset statistics
   compute_statistics();
+}
 
-  // Clear source frame indices map
-  source_frame_indices_.clear();
+void LeRobotV2Backend::discard_episode() {
+  std::lock_guard<std::mutex> lock(open_mutex_);
 
-  opened_ = false;
+  close_resources();
+
+  // Construct paths from config (works even if open() was never called)
+  // NOTE: currently only chunk 0 is supported
+  fs::path discard_root = fs::path(cfg_->root) / cfg_->repository_id / cfg_->dataset_id;
+  fs::path discard_data = discard_root / "data" / format_chunk_dir(0);
+  fs::path discard_images = discard_root / "images" / format_chunk_dir(0);
+  fs::path discard_videos = discard_root / "videos" / format_chunk_dir(0);
+  fs::path discard_meta = discard_root / "meta";
+
+  // Delete episode parquet file
+  try {
+    fs::remove(discard_data / format_episode_parquet(episode_index_));
+  } catch (const fs::filesystem_error& e) {
+    std::cerr << "[LeRobotV2] Warning: Failed to remove parquet file during discard: "
+              << e.what() << std::endl;
+  }
+
+  // Delete episode image directories for all camera streams
+  try {
+    std::string episode_folder = format_episode_folder(episode_index_);
+    if (fs::exists(discard_images)) {
+      for (const auto& cam_dir : fs::directory_iterator(discard_images)) {
+        if (!cam_dir.is_directory()) continue;
+        auto ep_dir = cam_dir.path() / episode_folder;
+        if (fs::exists(ep_dir)) {
+          fs::remove_all(ep_dir);
+        }
+      }
+    }
+  } catch (const fs::filesystem_error& e) {
+    std::cerr << "[LeRobotV2] Warning: Failed to remove image directories during discard: "
+              << e.what() << std::endl;
+  }
+
+  // Delete episode video files (created by convert_to_videos() if close() already ran)
+  try {
+    std::string video_filename = format_video_filename(episode_index_);
+    if (fs::exists(discard_videos)) {
+      for (const auto& video_dir : fs::directory_iterator(discard_videos)) {
+        if (!video_dir.is_directory()) continue;
+        auto video_file = video_dir.path() / video_filename;
+        if (fs::exists(video_file)) {
+          fs::remove(video_file);
+        }
+      }
+    }
+  } catch (const fs::filesystem_error& e) {
+    std::cerr << "[LeRobotV2] Warning: Failed to remove video files during discard: "
+              << e.what() << std::endl;
+  }
+
+  // Revert metadata written by compute_statistics() if close() already ran.
+  // Read the frame count from the episodes.jsonl entry before removing it,
+  // so we can decrement info.json counters accurately.
+  int discarded_frame_count = 0;
+  try {
+    fs::path episodes_path = discard_meta / JSONL_EPISODES;
+    if (fs::exists(episodes_path)) {
+      std::ifstream in(episodes_path);
+      std::string last_line, line;
+      while (std::getline(in, line)) {
+        if (!line.empty()) last_line = line;
+      }
+      if (!last_line.empty()) {
+        auto entry = nlohmann::json::parse(last_line);
+        if (entry.value("episode_index", -1) == static_cast<int>(episode_index_)) {
+          discarded_frame_count = entry.value("length", 0);
+        }
+      }
+    }
+  } catch (...) {
+    // Best-effort: if we can't read the frame count, counters will be approximate
+  }
+
+  // Count video streams for info.json revert
+  int num_video_streams = 0;
+  try {
+    if (fs::exists(discard_videos)) {
+      for (const auto& entry : fs::directory_iterator(discard_videos)) {
+        if (entry.is_directory()) ++num_video_streams;
+      }
+    }
+  } catch (...) {}
+
+  // Remove last entries from JSONL metadata files
+  if (!remove_last_jsonl_line(discard_meta / JSONL_EPISODES)) {
+    std::cerr << "[LeRobotV2] Warning: Failed to revert episodes.jsonl" << std::endl;
+  }
+  if (!remove_last_jsonl_line(discard_meta / JSONL_EPISODE_STATS)) {
+    std::cerr << "[LeRobotV2] Warning: Failed to revert episodes_stats.jsonl" << std::endl;
+  }
+
+  // Revert info.json counters
+  if (discarded_frame_count > 0 || num_video_streams > 0) {
+    if (!revert_info_json(discard_meta, discarded_frame_count, num_video_streams)) {
+      std::cerr << "[LeRobotV2] Warning: Failed to revert info.json" << std::endl;
+    }
+  }
 }
 
 void LeRobotV2Backend::write_joint_state(const data::RecordBase& base) {

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -165,12 +165,10 @@ bool TrossenMCAPBackend::open() {
   return true;
 }
 
-void TrossenMCAPBackend::close() {
-  std::scoped_lock lk(writer_mutex_);
-  if (!opened_) {
-    return;
-  }
-  // Close channels
+void TrossenMCAPBackend::close_resources() {
+  // Caller must hold writer_mutex_. Closes channels and writer.
+  if (!opened_) return;
+
   for (auto& [stream_id, channel] : joint_channels_) {
     channel.close();
   }
@@ -190,6 +188,28 @@ void TrossenMCAPBackend::close() {
   image_channels_.clear();
   odometry_2d_channels_.clear();
   opened_ = false;
+}
+
+void TrossenMCAPBackend::close() {
+  std::scoped_lock lk(writer_mutex_);
+  close_resources();
+}
+
+void TrossenMCAPBackend::discard_episode() {
+  std::scoped_lock lk(writer_mutex_);
+  close_resources();
+
+  // Construct and delete the episode file (works even if already closed by sink)
+  std::ostringstream oss;
+  oss << cfg_->root << "/"
+      << cfg_->dataset_id << "/"
+      << "episode_" << std::setw(6) << std::setfill('0') << episode_index_ << ".mcap";
+  try {
+    std::filesystem::remove(std::filesystem::path(oss.str()));
+  } catch (const std::filesystem::filesystem_error& e) {
+    std::cerr << "Warning: Failed to remove MCAP file during discard: "
+              << e.what() << "\n";
+  }
 }
 
 void TrossenMCAPBackend::flush() {


### PR DESCRIPTION
When an operator messes up a demonstration they need to be able to throw it away and re-record at the same episode index. The backends currently only know how to finalize an episode (flush, encode videos, write stats). They have no way to delete one.

This adds a pure virtual discard_episode() to the Backend base class. It's pure virtual rather than a default no-op because a backend that silently does nothing on discard would leave stale files on disk and corrupt the dataset. A compile error for a missing override is safer.

Both backends extract their shared teardown logic into a private close_resources() method that close() and discard_episode() both call, avoiding the duplication that would otherwise exist between the two paths.

LeRobotV2Backend cleans up everything the episode could have written: the parquet file, image directories, encoded video files, and the metadata entries in episodes.jsonl, episodes_stats.jsonl, and info.json. This matters because discard can be called during the reset phase after close() has already run, meaning videos have been encoded and metadata has been appended. The frame count is read from the episodes.jsonl entry before removing it so info.json counters can be decremented accurately.

TrossenMCAPBackend closes the writer and deletes the single .mcap file. Path is reconstructed from config so it works even if the backend was already closed by the sink.

NullBackend is a no-op since there are no files to delete.

All implementations are safe to call whether the backend is still open or was already closed.