### PR TITLE
Fix CI: dearmor RealSense GPG key for apt verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
         # Register the RealSense signing key (official method)
         curl -sSf https://librealsense.realsenseai.com/Debian/librealsenseai.asc | \
           gpg --dearmor | sudo tee /etc/apt/keyrings/librealsenseai.gpg > /dev/null
+        sudo chmod 0644 /etc/apt/keyrings/librealsenseai.gpg
 
         # Make sure apt HTTPS support is installed
         sudo apt-get install -y apt-transport-https

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,13 +56,16 @@ jobs:
     - name: Install RealSense
       run: |
         sudo mkdir -p /etc/apt/keyrings
-        curl -sSf https://librealsense.realsenseai.com/Debian/librealsense.pgp | sudo tee /etc/apt/keyrings/librealsense.pgp > /dev/null
+
+        # Register the RealSense signing key (official method)
+        curl -sSf https://librealsense.realsenseai.com/Debian/librealsenseai.asc | \
+          gpg --dearmor | sudo tee /etc/apt/keyrings/librealsenseai.gpg > /dev/null
 
         # Make sure apt HTTPS support is installed
         sudo apt-get install -y apt-transport-https
 
         # Add the server to the list of repositories
-        echo "deb [signed-by=/etc/apt/keyrings/librealsense.pgp] https://librealsense.realsenseai.com/Debian/apt-repo $(lsb_release -cs) main" | \
+        echo "deb [signed-by=/etc/apt/keyrings/librealsenseai.gpg] https://librealsense.realsenseai.com/Debian/apt-repo $(lsb_release -cs) main" | \
           sudo tee /etc/apt/sources.list.d/librealsense.list
 
         sudo apt-get update


### PR DESCRIPTION
The old key URL (librealsense.pgp) no longer matches the signing key used by the RealSense apt repo (FB0B24895113F120). Switch to the official installation method from the RealSense docs which uses librealsenseai.asc, dearmors it to .gpg format, and updates the sources list to reference the new keyring.