### PR TITLE
Add unit tests for episode discard, keyboard input, and announce

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,15 @@ target_link_libraries(test_scheduler PRIVATE trossen_sdk GTest::gtest_main)
 add_executable(test_session_manager test_session_manager.cpp)
 target_link_libraries(test_session_manager PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_session_manager_discard test_session_manager_discard.cpp)
+target_link_libraries(test_session_manager_discard PRIVATE trossen_sdk GTest::gtest_main)
+
+add_executable(test_keyboard_input_utils test_keyboard_input_utils.cpp)
+target_link_libraries(test_keyboard_input_utils PRIVATE trossen_sdk GTest::gtest_main)
+
+add_executable(test_announce test_announce.cpp)
+target_link_libraries(test_announce PRIVATE trossen_sdk GTest::gtest_main)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -83,3 +92,6 @@ gtest_discover_tests(test_producer_registry)
 gtest_discover_tests(test_sink)
 gtest_discover_tests(test_scheduler)
 gtest_discover_tests(test_session_manager)
+gtest_discover_tests(test_session_manager_discard)
+gtest_discover_tests(test_keyboard_input_utils)
+gtest_discover_tests(test_announce)

--- a/tests/test_announce.cpp
+++ b/tests/test_announce.cpp
@@ -2,10 +2,11 @@
  * @file test_announce.cpp
  * @brief Unit tests for the announce() text-to-speech utility
  *
- * spd-say may not be installed in CI, so these tests verify graceful
- * behavior (no crash) rather than audible output.
+ * Tests verify graceful behavior (no crash) without producing audio.
+ * PATH is temporarily cleared so posix_spawnp cannot find spd-say.
  */
 
+#include <cstdlib>
 #include <string>
 
 #include "gtest/gtest.h"
@@ -14,17 +15,31 @@
 
 using trossen::utils::announce;
 
+// RAII guard that hides spd-say by clearing PATH for the duration of the test
+class SilentAnnounceTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    const char* p = std::getenv("PATH");
+    saved_path_ = p ? p : "";
+    setenv("PATH", "", 1);
+  }
+  void TearDown() override {
+    setenv("PATH", saved_path_.c_str(), 1);
+  }
+  std::string saved_path_;
+};
+
 // AN-01: announce with empty string is a no-op (no crash)
-TEST(AnnounceTest, EmptyString_NoOp) {
+TEST_F(SilentAnnounceTest, EmptyString_NoOp) {
   EXPECT_NO_THROW(announce(""));
 }
 
 // AN-02: announce with blocking mode doesn't crash
-TEST(AnnounceTest, BlockingMode_NoCrash) {
+TEST_F(SilentAnnounceTest, BlockingMode_NoCrash) {
   EXPECT_NO_THROW(announce("test", true));
 }
 
 // AN-03: announce with non-blocking mode doesn't crash
-TEST(AnnounceTest, NonBlockingMode_NoCrash) {
+TEST_F(SilentAnnounceTest, NonBlockingMode_NoCrash) {
   EXPECT_NO_THROW(announce("test", false));
 }

--- a/tests/test_announce.cpp
+++ b/tests/test_announce.cpp
@@ -1,0 +1,30 @@
+/**
+ * @file test_announce.cpp
+ * @brief Unit tests for the announce() text-to-speech utility
+ *
+ * spd-say may not be installed in CI, so these tests verify graceful
+ * behavior (no crash) rather than audible output.
+ */
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/utils/app_utils.hpp"
+
+using trossen::utils::announce;
+
+// AN-01: announce with empty string is a no-op (no crash)
+TEST(AnnounceTest, EmptyString_NoOp) {
+  EXPECT_NO_THROW(announce(""));
+}
+
+// AN-02: announce with blocking mode doesn't crash
+TEST(AnnounceTest, BlockingMode_NoCrash) {
+  EXPECT_NO_THROW(announce("test", true));
+}
+
+// AN-03: announce with non-blocking mode doesn't crash
+TEST(AnnounceTest, NonBlockingMode_NoCrash) {
+  EXPECT_NO_THROW(announce("test", false));
+}

--- a/tests/test_keyboard_input_utils.cpp
+++ b/tests/test_keyboard_input_utils.cpp
@@ -1,0 +1,65 @@
+/**
+ * @file test_keyboard_input_utils.cpp
+ * @brief Unit tests for KeyPress enum, RawModeGuard, and poll_keypress
+ *
+ * In CI environments stdin is not a terminal, so RawModeGuard will be inactive.
+ * Tests verify graceful behavior in that scenario.
+ */
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/utils/keyboard_input_utils.hpp"
+
+using trossen::utils::KeyPress;
+using trossen::utils::RawModeGuard;
+using trossen::utils::poll_keypress;
+
+// KI-01: KeyPress::kNone exists and is the default/zero value
+TEST(KeyboardInputUtilsTest, KeyPress_kNone_IsDefaultValue) {
+  KeyPress key{};
+  EXPECT_EQ(key, KeyPress::kNone);
+  EXPECT_EQ(static_cast<int>(KeyPress::kNone), 0);
+}
+
+// KI-02: All KeyPress enum values are distinct
+TEST(KeyboardInputUtilsTest, KeyPress_AllValuesDistinct) {
+  KeyPress values[] = {
+    KeyPress::kNone,
+    KeyPress::kRightArrow,
+    KeyPress::kLeftArrow,
+    KeyPress::kUpArrow,
+    KeyPress::kDownArrow,
+    KeyPress::kSpace,
+    KeyPress::kEnter,
+    KeyPress::kQ,
+  };
+
+  constexpr size_t count = sizeof(values) / sizeof(values[0]);
+  for (size_t i = 0; i < count; ++i) {
+    for (size_t j = i + 1; j < count; ++j) {
+      EXPECT_NE(values[i], values[j])
+        << "KeyPress values at index " << i << " and " << j << " are equal";
+    }
+  }
+}
+
+// KI-03: RawModeGuard construction and destruction doesn't crash
+TEST(KeyboardInputUtilsTest, RawModeGuard_ConstructDestruct_NoCrash) {
+  EXPECT_NO_THROW({
+    RawModeGuard guard;
+  });
+}
+
+// KI-04: RawModeGuard::is_active() returns false when stdin is not a terminal
+TEST(KeyboardInputUtilsTest, RawModeGuard_IsActive_FalseInCI) {
+  RawModeGuard guard;
+  // In CI, stdin is not a terminal, so raw mode cannot be activated
+  EXPECT_FALSE(guard.is_active());
+}
+
+// KI-05: poll_keypress returns kNone when no input available
+TEST(KeyboardInputUtilsTest, PollKeypress_ReturnsNone_WhenNoInput) {
+  // Without raw mode active, poll_keypress should return kNone immediately
+  KeyPress key = poll_keypress();
+  EXPECT_EQ(key, KeyPress::kNone);
+}

--- a/tests/test_keyboard_input_utils.cpp
+++ b/tests/test_keyboard_input_utils.cpp
@@ -2,9 +2,11 @@
  * @file test_keyboard_input_utils.cpp
  * @brief Unit tests for KeyPress enum, RawModeGuard, and poll_keypress
  *
- * In CI environments stdin is not a terminal, so RawModeGuard will be inactive.
- * Tests verify graceful behavior in that scenario.
+ * Tests work both in CI (stdin is not a terminal) and interactively
+ * (stdin is a TTY) by branching on isatty() where behavior differs.
  */
+
+#include <unistd.h>
 
 #include "gtest/gtest.h"
 
@@ -50,16 +52,22 @@ TEST(KeyboardInputUtilsTest, RawModeGuard_ConstructDestruct_NoCrash) {
   });
 }
 
-// KI-04: RawModeGuard::is_active() returns false when stdin is not a terminal
-TEST(KeyboardInputUtilsTest, RawModeGuard_IsActive_FalseInCI) {
+// KI-04: RawModeGuard::is_active() matches whether stdin is a terminal
+TEST(KeyboardInputUtilsTest, RawModeGuard_IsActive_MatchesIsatty) {
   RawModeGuard guard;
-  // In CI, stdin is not a terminal, so raw mode cannot be activated
-  EXPECT_FALSE(guard.is_active());
+  if (isatty(STDIN_FILENO)) {
+    EXPECT_TRUE(guard.is_active());
+  } else {
+    EXPECT_FALSE(guard.is_active());
+  }
 }
 
 // KI-05: poll_keypress returns kNone when no input available
 TEST(KeyboardInputUtilsTest, PollKeypress_ReturnsNone_WhenNoInput) {
-  // Without raw mode active, poll_keypress should return kNone immediately
+  // Skip when running interactively — buffered terminal input could interfere
+  if (isatty(STDIN_FILENO)) {
+    GTEST_SKIP() << "Skipping: stdin is a terminal";
+  }
   KeyPress key = poll_keypress();
   EXPECT_EQ(key, KeyPress::kNone);
 }

--- a/tests/test_session_manager_discard.cpp
+++ b/tests/test_session_manager_discard.cpp
@@ -1,0 +1,228 @@
+/**
+ * @file test_session_manager_discard.cpp
+ * @brief Unit tests for SessionManager discard and re-record features
+ *
+ * Tests episode discard (current and last), re-record request, and UserAction enum.
+ * Uses NullBackend via GlobalConfig to avoid real I/O.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
+
+using trossen::data::JointStateRecord;
+using trossen::data::RecordBase;
+using trossen::data::Timestamp;
+using trossen::hw::PolledProducer;
+using trossen::runtime::SessionManager;
+using trossen::runtime::UserAction;
+
+// Mock polled producer
+//
+// Concrete PolledProducer that emits a JointStateRecord per poll() call.
+// Increments stats_.produced so tests can verify the scheduler polled it.
+class MockPolledProducer : public PolledProducer {
+public:
+  MockPolledProducer() = default;
+  ~MockPolledProducer() override = default;
+
+  void poll(const std::function<void(std::shared_ptr<RecordBase>)>& emit) override {
+    auto rec = std::make_shared<JointStateRecord>();
+    rec->seq = seq_++;
+    rec->id = "mock/joints";
+    rec->positions = {1.0f, 2.0f, 3.0f};
+    emit(rec);
+    ++stats_.produced;
+  }
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    auto meta = std::make_shared<ProducerMetadata>();
+    meta->type = "mock";
+    meta->id = "mock_producer";
+    meta->name = "Mock Producer";
+    return meta;
+  }
+};
+
+// Test fixture: loads minimal GlobalConfig with null backend
+class SessionManagerDiscardTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    nlohmann::json config = {
+      {"session_manager", {
+        {"type", "session_manager"},
+        {"max_duration", 10.0},
+        {"max_episodes", 100},
+        {"backend_type", "null"}
+      }}
+    };
+
+    trossen::configuration::GlobalConfig::instance().load_from_json(config);
+  }
+};
+
+// SD-01: UserAction enum has expected values
+TEST_F(SessionManagerDiscardTest, UserAction_HasExpectedValues) {
+  // Verify enum values exist and are distinct
+  UserAction continue_action = UserAction::kContinue;
+  UserAction rerecord_action = UserAction::kReRecord;
+  UserAction stop_action = UserAction::kStop;
+
+  EXPECT_NE(continue_action, rerecord_action);
+  EXPECT_NE(continue_action, stop_action);
+  EXPECT_NE(rerecord_action, stop_action);
+}
+
+// SD-02: discard_current_episode is no-op when no episode active
+TEST_F(SessionManagerDiscardTest, DiscardCurrentEpisode_NoOp_WhenNotActive) {
+  SessionManager sm;
+  EXPECT_FALSE(sm.is_episode_active());
+  EXPECT_NO_THROW(sm.discard_current_episode());
+  EXPECT_FALSE(sm.is_episode_active());
+}
+
+// SD-03: discard_current_episode during active episode
+TEST_F(SessionManagerDiscardTest, DiscardCurrentEpisode_DuringActiveEpisode) {
+  SessionManager sm;
+
+  // Record initial state
+  auto initial_stats = sm.stats();
+  uint64_t initial_completed = initial_stats.total_episodes_completed;
+  uint32_t initial_index = initial_stats.current_episode_index;
+
+  // Start an episode and let it run briefly
+  ASSERT_TRUE(sm.start_episode());
+  EXPECT_TRUE(sm.is_episode_active());
+
+  // Discard the active episode
+  sm.discard_current_episode();
+
+  // Episode should no longer be active
+  EXPECT_FALSE(sm.is_episode_active());
+
+  // Episode count should NOT have incremented
+  auto post_stats = sm.stats();
+  EXPECT_EQ(post_stats.total_episodes_completed, initial_completed);
+
+  // Episode index should remain the same (ready to reuse)
+  EXPECT_EQ(post_stats.current_episode_index, initial_index);
+}
+
+// SD-04: discard_current_episode does NOT fire episode-ended callbacks
+TEST_F(SessionManagerDiscardTest, DiscardCurrentEpisode_DoesNotFireEndedCallbacks) {
+  SessionManager sm;
+
+  std::atomic<bool> ended_fired{false};
+  sm.on_episode_ended([&ended_fired](const SessionManager::Stats&) {
+    ended_fired.store(true);
+  });
+
+  ASSERT_TRUE(sm.start_episode());
+  sm.discard_current_episode();
+
+  EXPECT_FALSE(ended_fired.load());
+}
+
+// SD-05: discard_last_episode when no episodes completed is a no-op
+TEST_F(SessionManagerDiscardTest, DiscardLastEpisode_NoOp_WhenNoEpisodes) {
+  SessionManager sm;
+  EXPECT_EQ(sm.stats().total_episodes_completed, 0u);
+  EXPECT_NO_THROW(sm.discard_last_episode());
+  EXPECT_EQ(sm.stats().total_episodes_completed, 0u);
+}
+
+// SD-06: discard_last_episode after one completed episode
+TEST_F(SessionManagerDiscardTest, DiscardLastEpisode_AfterOneCompletedEpisode) {
+  SessionManager sm;
+
+  // Complete one episode
+  ASSERT_TRUE(sm.start_episode());
+  sm.stop_episode();
+
+  auto stats_after_stop = sm.stats();
+  EXPECT_EQ(stats_after_stop.total_episodes_completed, 1u);
+  uint32_t index_after_stop = stats_after_stop.current_episode_index;
+
+  // Discard the last completed episode
+  sm.discard_last_episode();
+
+  auto stats_after_discard = sm.stats();
+  // total_episodes_completed should be decremented
+  EXPECT_EQ(stats_after_discard.total_episodes_completed, 0u);
+  // Next episode should reuse the same index
+  EXPECT_EQ(stats_after_discard.current_episode_index, index_after_stop - 1);
+}
+
+// SD-07: request_rerecord is thread-safe and does not crash
+TEST_F(SessionManagerDiscardTest, RequestRerecord_ThreadSafe) {
+  SessionManager sm;
+
+  // Call from main thread -- should not crash even without active episode
+  EXPECT_NO_THROW(sm.request_rerecord());
+
+  // Call from multiple threads concurrently
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 4; ++i) {
+    threads.emplace_back([&sm]() {
+      sm.request_rerecord();
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+// SD-08: After discard_current_episode, can start a new episode at same index
+TEST_F(SessionManagerDiscardTest, DiscardCurrentEpisode_CanRestartAtSameIndex) {
+  SessionManager sm;
+
+  // Note the starting index
+  uint32_t start_index = sm.stats().current_episode_index;
+
+  // Start and discard
+  ASSERT_TRUE(sm.start_episode());
+  sm.discard_current_episode();
+
+  // Index should still be the same
+  EXPECT_EQ(sm.stats().current_episode_index, start_index);
+
+  // Should be able to start a new episode
+  ASSERT_TRUE(sm.start_episode());
+  EXPECT_TRUE(sm.is_episode_active());
+
+  // Clean up
+  sm.stop_episode();
+
+  // Now the index should have advanced
+  EXPECT_EQ(sm.stats().current_episode_index, start_index + 1);
+}
+
+// SD-09: discard_current_episode with a polled producer registered
+TEST_F(SessionManagerDiscardTest, DiscardCurrentEpisode_WithProducer) {
+  SessionManager sm;
+  auto producer = std::make_shared<MockPolledProducer>();
+  sm.add_producer(producer, std::chrono::milliseconds(10));
+
+  ASSERT_TRUE(sm.start_episode());
+  // Let the scheduler poll a few times
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  sm.discard_current_episode();
+  EXPECT_FALSE(sm.is_episode_active());
+
+  // Should be able to start another episode after discard
+  ASSERT_TRUE(sm.start_episode());
+  sm.stop_episode();
+}


### PR DESCRIPTION
Add unit tests for the new episode control features introduced in PRs 201-206.

**test_session_manager_discard.cpp** - 9 tests

- UserAction enum values are distinct
- discard_current_episode -- no-op when inactive, stops episode without incrementing index, does not fire ended callbacks, allows restart at same index, works with active producers
- discard_last_episode -- no-op when no episodes exist, decrements index after completion
- request_rerecord -- thread-safe under concurrent access

**test_keyboard_input_utils.cpp** - 5 tests

- KeyPress enum default value and distinctness
- RawModeGuard safe construction/destruction in non-terminal environments
- poll_keypress returns kNone without raw mode

**test_announce.cpp** - 3 tests

- Empty string no-op, blocking and non-blocking modes graceful failure
- Uses SilentAnnounceTest fixture that clears PATH to prevent audio during test runs