### PR TITLE
Fix flaky push producer test

### DIFF
--- a/tests/test_session_manager_push_producer.cpp
+++ b/tests/test_session_manager_push_producer.cpp
@@ -7,11 +7,13 @@
  */
 
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -182,8 +184,13 @@ TEST_F(SessionManagerPushProducerTest, PushProducerRecordsReachBackend) {
   sm.add_push_producer(producer);
 
   sm.start_episode();
+
+  // Check records while episode is still active (sink is valid)
+  // Sleep briefly to let the sink drain thread process the records
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_EQ(sm.stats().records_written_current, 5);
+
   sm.stop_episode();
 
   EXPECT_EQ(producer->stats().produced, 5);
-  EXPECT_EQ(sm.stats().records_written_current, 5);
 }

--- a/tests/test_session_manager_push_producer.cpp
+++ b/tests/test_session_manager_push_producer.cpp
@@ -183,11 +183,14 @@ TEST_F(SessionManagerPushProducerTest, PushProducerRecordsReachBackend) {
   producer->records_per_episode_ = 5;
   sm.add_push_producer(producer);
 
-  sm.start_episode();
+  ASSERT_TRUE(sm.start_episode());
 
-  // Check records while episode is still active (sink is valid)
-  // Sleep briefly to let the sink drain thread process the records
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  // Poll until the sink drain thread processes all records (or timeout)
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (sm.stats().records_written_current < 5 &&
+         std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
   EXPECT_EQ(sm.stats().records_written_current, 5);
 
   sm.stop_episode();


### PR DESCRIPTION
Check records_written_current while the episode is still active rather than after stop_episode(). After stop, the stats counter resets on the second call because stats_emitted_ is already set by the episode-ended callback path.