### PR TITLE
Generate README file for LeRobot 

### DIFF
--- a/include/trossen_sdk/configuration/types/backends/lerobot_v2_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/lerobot_v2_backend_config.hpp
@@ -22,6 +22,7 @@ inline constexpr float LEROBOT_V2_DEFAULT_FPS = 30.0f;
 inline constexpr int LEROBOT_V2_DEFAULT_EPISODE_INDEX = 0;
 // Number of episodes stored per chunk folder (chunk-000, chunk-001, ...)
 inline constexpr int LEROBOT_V2_DEFAULT_CHUNK_SIZE = 1000;
+inline constexpr char LEROBOT_V2_DEFAULT_LICENSE[] = "apache-2.0";
 
 struct LeRobotV2BackendConfig : public BaseConfig {
   int encoder_threads{trossen::io::backends::DEFAULT_ENCODER_THREADS};
@@ -38,6 +39,7 @@ struct LeRobotV2BackendConfig : public BaseConfig {
   int chunk_size{LEROBOT_V2_DEFAULT_CHUNK_SIZE};
   std::string robot_name{trossen::io::backends::DEFAULT_ROBOT_NAME};
   float fps{LEROBOT_V2_DEFAULT_FPS};
+  std::string license{LEROBOT_V2_DEFAULT_LICENSE};
 
   std::string type() const override { return "lerobot_v2_backend"; }
 
@@ -63,6 +65,7 @@ struct LeRobotV2BackendConfig : public BaseConfig {
     if (j.contains("chunk_size")) j.at("chunk_size").get_to(c.chunk_size);
     if (j.contains("robot_name")) j.at("robot_name").get_to(c.robot_name);
     if (j.contains("fps")) j.at("fps").get_to(c.fps);
+    if (j.contains("license")) j.at("license").get_to(c.license);
 
     return c;
   }

--- a/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
@@ -605,23 +605,30 @@ inline bool write_episode_stats_with_data(
  * and a markdown body embedding the full info.json content.
  *
  * @param dataset_root Path to the dataset root directory (containing meta/, data/, etc.)
+ * @param license SPDX license identifier for the dataset (default: "apache-2.0")
  * @return true on success, false on failure
  */
-inline bool generate_dataset_readme(const std::filesystem::path& dataset_root) {
+inline bool generate_dataset_readme(
+    const std::filesystem::path& dataset_root,
+    const std::string& license = "apache-2.0") {
   namespace fs = std::filesystem;
 
   fs::path readme_path = dataset_root / "README.md";
   fs::path info_path = dataset_root / METADATA_DIR / JSON_INFO;
 
   // Read info.json content for embedding in the README
-  std::string info_json_str = "[More Information Needed]";
+  std::string info_json_str = "{}";
   if (fs::exists(info_path)) {
     std::ifstream info_file(info_path);
     if (info_file.is_open()) {
-      nlohmann::ordered_json info_json;
-      info_file >> info_json;
+      try {
+        nlohmann::ordered_json info_json;
+        info_file >> info_json;
+        info_json_str = info_json.dump(4);
+      } catch (const std::exception& e) {
+        std::cerr << "Warning: Failed to parse " << info_path << ": " << e.what() << "\n";
+      }
       info_file.close();
-      info_json_str = info_json.dump(4);
     }
   }
 
@@ -633,7 +640,7 @@ inline bool generate_dataset_readme(const std::filesystem::path& dataset_root) {
 
   readme_file
     << "---\n"
-    << "license: apache-2.0\n"
+    << "license: " << license << "\n"
     << "task_categories:\n"
     << "- robotics\n"
     << "tags:\n"
@@ -650,12 +657,25 @@ inline bool generate_dataset_readme(const std::filesystem::path& dataset_root) {
     << "Converted from TrossenMCAP format using the Trossen SDK "
     << "`trossen_mcap_to_lerobot_v2` tool.\n"
     << "\n"
+    << "- **Homepage:** [More Information Needed]\n"
+    << "- **Paper:** [More Information Needed]\n"
+    << "- **License:** " << license << "\n"
+    << "\n"
     << "## Dataset Structure\n"
     << "\n"
     << "[meta/info.json](meta/info.json):\n"
     << "\n"
     << "```json\n"
     << info_json_str << "\n"
+    << "```\n"
+    << "\n"
+    << "\n"
+    << "## Citation\n"
+    << "\n"
+    << "**BibTeX:**\n"
+    << "\n"
+    << "```bibtex\n"
+    << "[More Information Needed]\n"
     << "```\n";
 
   readme_file.close();

--- a/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
@@ -599,6 +599,70 @@ inline bool write_episode_stats_with_data(
 }
 
 /**
+ * @brief Generate a README.md dataset card for HuggingFace Hub compatibility
+ *
+ * Creates a README.md with YAML frontmatter (license, task_categories, tags, configs)
+ * and a markdown body embedding the full info.json content.
+ *
+ * @param dataset_root Path to the dataset root directory (containing meta/, data/, etc.)
+ * @return true on success, false on failure
+ */
+inline bool generate_dataset_readme(const std::filesystem::path& dataset_root) {
+  namespace fs = std::filesystem;
+
+  fs::path readme_path = dataset_root / "README.md";
+  fs::path info_path = dataset_root / METADATA_DIR / JSON_INFO;
+
+  // Read info.json content for embedding in the README
+  std::string info_json_str = "[More Information Needed]";
+  if (fs::exists(info_path)) {
+    std::ifstream info_file(info_path);
+    if (info_file.is_open()) {
+      nlohmann::ordered_json info_json;
+      info_file >> info_json;
+      info_file.close();
+      info_json_str = info_json.dump(4);
+    }
+  }
+
+  std::ofstream readme_file(readme_path);
+  if (!readme_file.is_open()) {
+    std::cerr << "Error: Failed to create " << readme_path << " for writing\n";
+    return false;
+  }
+
+  readme_file
+    << "---\n"
+    << "license: apache-2.0\n"
+    << "task_categories:\n"
+    << "- robotics\n"
+    << "tags:\n"
+    << "- LeRobot\n"
+    << "configs:\n"
+    << "- config_name: default\n"
+    << "  data_files: data/*/*.parquet\n"
+    << "---\n"
+    << "\n"
+    << "This dataset was created using [LeRobot](https://github.com/huggingface/lerobot).\n"
+    << "\n"
+    << "## Dataset Description\n"
+    << "\n"
+    << "Converted from TrossenMCAP format using the Trossen SDK "
+    << "`trossen_mcap_to_lerobot_v2` tool.\n"
+    << "\n"
+    << "## Dataset Structure\n"
+    << "\n"
+    << "[meta/info.json](meta/info.json):\n"
+    << "\n"
+    << "```json\n"
+    << info_json_str << "\n"
+    << "```\n";
+
+  readme_file.close();
+  return true;
+}
+
+/**
  * @brief Write all metadata files for an episode
  *
  * This is a convenience function that calls the individual metadata writing functions.

--- a/scripts/trossen_mcap_to_lerobot_v2/trossen_mcap_to_lerobot_v2.cpp
+++ b/scripts/trossen_mcap_to_lerobot_v2/trossen_mcap_to_lerobot_v2.cpp
@@ -326,6 +326,7 @@ int main(int argc, char** argv) {
   const std::string repository_id = lerobot_config->repository_id;
   const std::string dataset_id = lerobot_config->dataset_id;
   const int chunk_size = lerobot_config->chunk_size;
+  const std::string license = lerobot_config->license;
 
   // Display configuration
   std::cout << "\n" << std::string(70, '=') << "\n";
@@ -520,7 +521,7 @@ int main(int argc, char** argv) {
   }
 
   // Generate HuggingFace Hub compatibility files
-  if (trossen::io::backends::generate_dataset_readme(full_dataset_path)) {
+  if (trossen::io::backends::generate_dataset_readme(full_dataset_path, license)) {
     std::cout << "  [ok] Generated README.md\n";
   } else {
     std::cerr << "  Warning: Failed to generate README.md\n";
@@ -1579,13 +1580,6 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
   } else {
     std::cerr << "  Error: Failed to write metadata files\n";
     return 1;
-  }
-
-  // Generate HuggingFace Hub compatibility files
-  if (trossen::io::backends::generate_dataset_readme(full_dataset_path)) {
-    std::cout << "  [ok] Generated README.md\n";
-  } else {
-    std::cerr << "  Warning: Failed to generate README.md\n";
   }
 
   std::cout << "\n[ok] Successfully created LeRobotV2 dataset episode!\n";

--- a/scripts/trossen_mcap_to_lerobot_v2/trossen_mcap_to_lerobot_v2.cpp
+++ b/scripts/trossen_mcap_to_lerobot_v2/trossen_mcap_to_lerobot_v2.cpp
@@ -519,6 +519,13 @@ int main(int argc, char** argv) {
     }
   }
 
+  // Generate HuggingFace Hub compatibility files
+  if (trossen::io::backends::generate_dataset_readme(full_dataset_path)) {
+    std::cout << "  [ok] Generated README.md\n";
+  } else {
+    std::cerr << "  Warning: Failed to generate README.md\n";
+  }
+
   // Print summary
   std::cout << "\n" << std::string(70, '=') << "\n";
   std::cout << "Processing Complete\n";
@@ -1572,6 +1579,13 @@ int process_mcap_file(const std::string& mcap_file, const std::string& dataset_r
   } else {
     std::cerr << "  Error: Failed to write metadata files\n";
     return 1;
+  }
+
+  // Generate HuggingFace Hub compatibility files
+  if (trossen::io::backends::generate_dataset_readme(full_dataset_path)) {
+    std::cout << "  [ok] Generated README.md\n";
+  } else {
+    std::cerr << "  Warning: Failed to generate README.md\n";
   }
 
   std::cout << "\n[ok] Successfully created LeRobotV2 dataset episode!\n";


### PR DESCRIPTION
This is a cosmetic change and does not affect any training or evaluation framework. The README file is only needed to neatly view the dataset details in the dataset card tab on Huggingface Hub.

---
## With README:

<img width="1017" height="908" alt="image" src="https://github.com/user-attachments/assets/7fe0d484-4f2d-4f99-97f5-49560154a7be" />

---
## Without README:

<img width="1017" height="908" alt="image" src="https://github.com/user-attachments/assets/d0830dbf-f4c3-4331-a3ba-8aabe8aaf93c" />
