### PR TITLE
Add teleoperation controller and capability mixin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ add_library(trossen_sdk SHARED
   src/runtime/push_producer_registry.cpp
   src/utils/app_utils.cpp
   src/utils/keyboard_input_utils.cpp
+  src/hw/teleop/teleop_controller.cpp
+  src/hw/teleop/teleop_factory.cpp
 )
 
 if(TROSSEN_ENABLE_REALSENSE)

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -43,6 +43,8 @@
 #include "trossen_sdk/hw/base/slate_base_component.hpp"
 #include "trossen_sdk/hw/base/slate_base_producer.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/teleop/teleop_controller.hpp"
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
@@ -353,38 +355,14 @@ int main(int argc, char** argv) {
       break;
     }
 
-    if (cfg.teleop.enabled) {
-      std::cout << "\nLocking leader arms and moving followers to match...\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto leader_it = arm_components.find(pair.leader);
-        auto follower_it = arm_components.find(pair.follower);
-        if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-          continue;
-        }
-        auto leader_driver = leader_it->second->get_hardware();
-        auto follower_driver = follower_it->second->get_hardware();
-        leader_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_positions(
-          leader_driver->get_all_positions(), moving_time_s, false);
-      }
-      std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-      std::cout << "  [ok] Followers moved to match leaders\n";
-
-      std::cout << "\n!! Enabling teleop mode !!\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto it = arm_components.find(pair.leader);
-        if (it == arm_components.end()) {
-          continue;
-        }
-        auto driver = it->second->get_hardware();
-        driver->set_all_modes(trossen_arm::Mode::external_effort);
-        driver->set_all_external_efforts(
-          std::vector<double>(driver->get_num_joints(), 0.0), 0.0, false);
-        std::cout << "   " << pair.leader << ": gravity compensation -> "
-                  << pair.follower << " will mirror\n";
-      }
-      std::cout << "\n";
+    // Construct one TeleopController per configured pair (resolved from the
+    // global teleop config + ActiveHardwareRegistry), then start each. Each
+    // controller's start() prepares the hardware (matches follower to leader,
+    // enables gravity compensation on leader) and spawns its own mirror thread;
+    // stop() joins the thread and returns the hardware to idle.
+    auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+    for (auto& ctrl : controllers) {
+      ctrl->start();
     }
 
     mgr.print_episode_header();
@@ -394,26 +372,6 @@ int main(int argc, char** argv) {
     }
 
     std::cout << "Recording...\n";
-
-    // Teleop thread mirrors leader positions to followers at configured rate
-    std::thread teleop_thread([&]() {
-      if (!cfg.teleop.enabled) {
-        return;
-      }
-      const auto sleep_ns = static_cast<int64_t>(1e9 / cfg.teleop.rate_hz);
-      while (mgr.is_episode_active() && !trossen::utils::g_stop_requested) {
-        for (const auto& pair : cfg.teleop.pairs) {
-          auto leader_it = arm_components.find(pair.leader);
-          auto follower_it = arm_components.find(pair.follower);
-          if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-            continue;
-          }
-          follower_it->second->get_hardware()->set_all_positions(
-            leader_it->second->get_hardware()->get_all_positions(), 0.0f, false);
-        }
-        std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
-      }
-    });
 
     // Velocity polling thread keeps base_prod active during the episode
     std::thread velocity_thread([&]() {
@@ -430,9 +388,7 @@ int main(int argc, char** argv) {
 
     if (action == trossen::runtime::UserAction::kReRecord) {
       mgr.discard_current_episode();
-      if (teleop_thread.joinable()) {
-        teleop_thread.join();
-      }
+      for (auto& ctrl : controllers) ctrl->stop();
       if (velocity_thread.joinable()) {
         velocity_thread.join();
       }
@@ -442,9 +398,7 @@ int main(int argc, char** argv) {
     if (mgr.is_episode_active()) {
       mgr.stop_episode();
     }
-    if (teleop_thread.joinable()) {
-      teleop_thread.join();
-    }
+    for (auto& ctrl : controllers) ctrl->stop();
     if (velocity_thread.joinable()) {
       velocity_thread.join();
     }

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -40,6 +40,8 @@
 #include "trossen_sdk/hw/arm/trossen_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/teleop/teleop_controller.hpp"
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
@@ -319,38 +321,14 @@ int main(int argc, char** argv) {
       break;
     }
 
-    if (cfg.teleop.enabled) {
-      std::cout << "\nLocking leader arms and moving followers to match...\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto leader_it = arm_components.find(pair.leader);
-        auto follower_it = arm_components.find(pair.follower);
-        if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-          continue;
-        }
-        auto leader_driver = leader_it->second->get_hardware();
-        auto follower_driver = follower_it->second->get_hardware();
-        leader_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_positions(
-          leader_driver->get_all_positions(), moving_time_s, false);
-      }
-      std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-      std::cout << "  [ok] Followers moved to match leaders\n";
-
-      std::cout << "\n!! Enabling teleop mode !!\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto it = arm_components.find(pair.leader);
-        if (it == arm_components.end()) {
-          continue;
-        }
-        auto driver = it->second->get_hardware();
-        driver->set_all_modes(trossen_arm::Mode::external_effort);
-        driver->set_all_external_efforts(
-          std::vector<double>(driver->get_num_joints(), 0.0), 0.0, false);
-        std::cout << "   " << pair.leader << ": gravity compensation -> "
-                  << pair.follower << " will mirror\n";
-      }
-      std::cout << "\n";
+    // Construct one TeleopController per configured pair (resolved from the
+    // global teleop config + ActiveHardwareRegistry), then start each. Each
+    // controller's start() prepares the hardware (matches follower to leader,
+    // enables gravity compensation on leader) and spawns its own mirror thread;
+    // stop() joins the thread and returns the hardware to idle.
+    auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+    for (auto& ctrl : controllers) {
+      ctrl->start();
     }
 
     mgr.print_episode_header();
@@ -361,42 +339,18 @@ int main(int argc, char** argv) {
 
     std::cout << "Recording...\n";
 
-    // Teleop thread mirrors leader positions to followers at configured rate
-    std::thread teleop_thread([&]() {
-      if (!cfg.teleop.enabled) {
-        return;
-      }
-      const auto sleep_ns = static_cast<int64_t>(1e9 / cfg.teleop.rate_hz);
-      while (mgr.is_episode_active() && !trossen::utils::g_stop_requested) {
-        for (const auto& pair : cfg.teleop.pairs) {
-          auto leader_it = arm_components.find(pair.leader);
-          auto follower_it = arm_components.find(pair.follower);
-          if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-            continue;
-          }
-          follower_it->second->get_hardware()->set_all_positions(
-            leader_it->second->get_hardware()->get_all_positions(), 0.0f, false);
-        }
-        std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
-      }
-    });
-
     auto action = mgr.monitor_episode();
 
     if (action == trossen::runtime::UserAction::kReRecord) {
       mgr.discard_current_episode();
-      if (teleop_thread.joinable()) {
-        teleop_thread.join();
-      }
+      for (auto& ctrl : controllers) ctrl->stop();
       continue;
     }
 
     if (mgr.is_episode_active()) {
       mgr.stop_episode();
     }
-    if (teleop_thread.joinable()) {
-      teleop_thread.join();
-    }
+    for (auto& ctrl : controllers) ctrl->stop();
 
     if (trossen::utils::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -40,6 +40,8 @@
 #include "trossen_sdk/hw/arm/trossen_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/teleop/teleop_controller.hpp"
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
@@ -320,38 +322,14 @@ int main(int argc, char** argv) {
       break;
     }
 
-    if (cfg.teleop.enabled) {
-      std::cout << "\nLocking leader arms and moving followers to match...\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto leader_it = arm_components.find(pair.leader);
-        auto follower_it = arm_components.find(pair.follower);
-        if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-          continue;
-        }
-        auto leader_driver = leader_it->second->get_hardware();
-        auto follower_driver = follower_it->second->get_hardware();
-        leader_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_positions(
-          leader_driver->get_all_positions(), moving_time_s, false);
-      }
-      std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-      std::cout << "  [ok] Followers moved to match leaders\n";
-
-      std::cout << "\n!! Enabling teleop mode !!\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto it = arm_components.find(pair.leader);
-        if (it == arm_components.end()) {
-          continue;
-        }
-        auto driver = it->second->get_hardware();
-        driver->set_all_modes(trossen_arm::Mode::external_effort);
-        driver->set_all_external_efforts(
-          std::vector<double>(driver->get_num_joints(), 0.0), 0.0, false);
-        std::cout << "   " << pair.leader << ": gravity compensation -> "
-                  << pair.follower << " will mirror\n";
-      }
-      std::cout << "\n";
+    // Construct one TeleopController per configured pair (resolved from the
+    // global teleop config + ActiveHardwareRegistry), then start each. Each
+    // controller's start() prepares the hardware (matches follower to leader,
+    // enables gravity compensation on leader) and spawns its own mirror thread;
+    // stop() joins the thread and returns the hardware to idle.
+    auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+    for (auto& ctrl : controllers) {
+      ctrl->start();
     }
 
     mgr.print_episode_header();
@@ -362,42 +340,18 @@ int main(int argc, char** argv) {
 
     std::cout << "Recording...\n";
 
-    // Teleop thread mirrors leader positions to followers at configured rate
-    std::thread teleop_thread([&]() {
-      if (!cfg.teleop.enabled) {
-        return;
-      }
-      const auto sleep_ns = static_cast<int64_t>(1e9 / cfg.teleop.rate_hz);
-      while (mgr.is_episode_active() && !trossen::utils::g_stop_requested) {
-        for (const auto& pair : cfg.teleop.pairs) {
-          auto leader_it = arm_components.find(pair.leader);
-          auto follower_it = arm_components.find(pair.follower);
-          if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-            continue;
-          }
-          follower_it->second->get_hardware()->set_all_positions(
-            leader_it->second->get_hardware()->get_all_positions(), 0.0f, false);
-        }
-        std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
-      }
-    });
-
     auto action = mgr.monitor_episode();
 
     if (action == trossen::runtime::UserAction::kReRecord) {
       mgr.discard_current_episode();
-      if (teleop_thread.joinable()) {
-        teleop_thread.join();
-      }
+      for (auto& ctrl : controllers) ctrl->stop();
       continue;
     }
 
     if (mgr.is_episode_active()) {
       mgr.stop_episode();
     }
-    if (teleop_thread.joinable()) {
-      teleop_thread.join();
-    }
+    for (auto& ctrl : controllers) ctrl->stop();
 
     if (trossen::utils::g_stop_requested) {
       std::cout << "\nStopping at user request (Ctrl+C).\n";

--- a/include/trossen_sdk/configuration/types/teleop_config.hpp
+++ b/include/trossen_sdk/configuration/types/teleop_config.hpp
@@ -11,6 +11,9 @@
 
 #include "nlohmann/json.hpp"
 
+#include "trossen_sdk/configuration/base_config.hpp"
+#include "trossen_sdk/configuration/config_registry.hpp"
+
 namespace trossen::configuration {
 
 /**
@@ -47,7 +50,7 @@ struct TeleoperationPair {
  * The teleop loop mirrors each leader arm's joint positions to its paired follower
  * at the specified rate. Set "enabled" to false to skip teleop (e.g. replay mode).
  */
-struct TeleoperationConfig {
+struct TeleoperationConfig : public BaseConfig {
   /// @brief Whether teleoperation is active
   bool enabled{true};
 
@@ -56,6 +59,8 @@ struct TeleoperationConfig {
 
   /// @brief Leader->follower pairings
   std::vector<TeleoperationPair> pairs;
+
+  std::string type() const override { return "teleop"; }
 
   static TeleoperationConfig from_json(const nlohmann::json& j) {
     TeleoperationConfig c;
@@ -69,6 +74,8 @@ struct TeleoperationConfig {
     return c;
   }
 };
+
+REGISTER_CONFIG(TeleoperationConfig, "teleop");
 
 }  // namespace trossen::configuration
 

--- a/include/trossen_sdk/hw/arm/so101_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/so101_arm_component.hpp
@@ -5,17 +5,21 @@
  */
 #ifndef TROSSEN_SDK__HW__ARM__SO101_ARM_COMPONENT_HPP_
 #define TROSSEN_SDK__HW__ARM__SO101_ARM_COMPONENT_HPP_
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 #include "trossen_sdk/hw/arm/so101_arm_driver.hpp"
 #include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
 namespace trossen::hw::arm {
 /**
  * @brief Hardware component for SO101 arms
  *
  * Wraps SO101ArmDriver and provides JSON configuration.
+ * Implements TeleopCapable so it can act as a teleop leader or follower.
  */
-class SO101ArmComponent : public HardwareComponent {
+class SO101ArmComponent : public HardwareComponent, public teleop::TeleopCapable {
 public:
   /**
    * @brief Constructor
@@ -55,6 +59,14 @@ public:
    * @return Shared pointer to driver
    */
   std::shared_ptr<SO101ArmDriver> get_driver() const { return driver_; }
+
+  // ── TeleopCapable overrides ──────────────────────────────────────────
+  std::size_t num_joints() const override;
+  std::vector<float> get_joint_positions() override;
+  void set_joint_positions(const std::vector<float>& positions) override;
+  void prepare_for_leader() override;
+  void prepare_for_follower(const std::vector<float>& initial_positions) override;
+  void cleanup_teleop() override;
 
 private:
   std::shared_ptr<SO101ArmDriver> driver_;

--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -6,12 +6,15 @@
 #ifndef TROSSEN_SDK__HW__ARM__TROSSEN_ARM_COMPONENT_HPP_
 #define TROSSEN_SDK__HW__ARM__TROSSEN_ARM_COMPONENT_HPP_
 
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "libtrossen_arm/trossen_arm.hpp"
 
 #include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
 
 namespace trossen::hw::arm {
 
@@ -19,8 +22,9 @@ namespace trossen::hw::arm {
  * @brief Hardware component for Trossen Robotics robot arms
  *
  * Wraps trossen_arm::TrossenArmDriver and provides JSON configuration.
+ * Implements TeleopCapable so it can act as a teleop leader or follower.
  */
-class TrossenArmComponent : public HardwareComponent {
+class TrossenArmComponent : public HardwareComponent, public teleop::TeleopCapable {
 public:
   /**
    * @brief Constructor
@@ -65,6 +69,14 @@ public:
    * @return Shared pointer to driver
    */
   std::shared_ptr<trossen_arm::TrossenArmDriver> get_hardware() { return driver_; }
+
+  // ── TeleopCapable overrides ──────────────────────────────────────────
+  std::size_t num_joints() const override;
+  std::vector<float> get_joint_positions() override;
+  void set_joint_positions(const std::vector<float>& positions) override;
+  void prepare_for_leader() override;
+  void prepare_for_follower(const std::vector<float>& initial_positions) override;
+  void cleanup_teleop() override;
 
 private:
   /// @brief Underlying Trossen arm driver

--- a/include/trossen_sdk/hw/teleop/teleop_capable.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_capable.hpp
@@ -1,0 +1,111 @@
+/**
+ * @file teleop_capable.hpp
+ * @brief Mixin interface for hardware components that can participate in teleoperation.
+ *
+ * A hardware component that can act as a teleop leader or follower (i.e. an arm)
+ * implements this interface in addition to inheriting from HardwareComponent.
+ * Components that cannot teleoperate (cameras, mobile bases, sensors) simply do not
+ * implement it, which keeps the HardwareComponent base interface free of capability-
+ * specific vocabulary and lets TeleopController accept only valid inputs at compile
+ * time instead of guarding at runtime.
+ *
+ * Example:
+ * @code
+ *   class TrossenArmComponent : public HardwareComponent, public TeleopCapable { ... };
+ *
+ *   auto hw = HardwareRegistry::create("trossen_arm", "leader", cfg);
+ *   auto leader = trossen::hw::teleop::as_capable<TeleopCapable>(hw);
+ *   if (!leader) {
+ *     throw std::invalid_argument("'leader' is not teleop-capable");
+ *   }
+ *   TeleopController ctrl(leader, follower, {});
+ * @endcode
+ */
+
+#ifndef TROSSEN_SDK__HW__TELEOP__TELEOP_CAPABLE_HPP_
+#define TROSSEN_SDK__HW__TELEOP__TELEOP_CAPABLE_HPP_
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "trossen_sdk/hw/hardware_component.hpp"
+
+namespace trossen::hw::teleop {
+
+/**
+ * @brief Mixin interface for hardware that supports teleoperation.
+ *
+ * Concrete teleop-capable components inherit from this in addition to
+ * HardwareComponent. The interface is intentionally stateless — implementations
+ * keep their state on the concrete class (typically the underlying driver).
+ */
+class TeleopCapable {
+public:
+  virtual ~TeleopCapable() = default;
+
+  /**
+   * @brief Number of controllable joints exposed by this component.
+   */
+  virtual std::size_t num_joints() const = 0;
+
+  /**
+   * @brief Read the current joint positions.
+   *
+   * Used by TeleopController to read the leader's state each control tick.
+   */
+  virtual std::vector<float> get_joint_positions() = 0;
+
+  /**
+   * @brief Command joint positions on this component.
+   *
+   * Used by TeleopController to drive the follower each control tick.
+   */
+  virtual void set_joint_positions(const std::vector<float>& positions) = 0;
+
+  /**
+   * @brief Prepare this component to act as a teleop leader.
+   *
+   * Called once when the teleop session starts. For arms, this typically
+   * enables gravity compensation (external_effort mode).
+   */
+  virtual void prepare_for_leader() = 0;
+
+  /**
+   * @brief Prepare this component to act as a teleop follower.
+   *
+   * Called once when the teleop session starts. For arms, this typically
+   * sets position mode and moves to match the leader's initial positions.
+   *
+   * @param initial_positions Leader's current positions to match.
+   */
+  virtual void prepare_for_follower(const std::vector<float>& initial_positions) = 0;
+
+  /**
+   * @brief Clean up after a teleop session ends.
+   *
+   * Called when the teleop session stops. For arms, this typically returns the
+   * hardware to a safe idle state.
+   */
+  virtual void cleanup_teleop() = 0;
+};
+
+/**
+ * @brief Convenience helper to query a HardwareComponent for a capability.
+ *
+ * Returns a shared_ptr to the requested capability interface if the component
+ * implements it, or nullptr otherwise. Wraps std::dynamic_pointer_cast so call
+ * sites read as a domain-level capability check rather than a raw RTTI cast.
+ *
+ * @tparam Capability The capability interface to query (e.g. TeleopCapable).
+ * @param hw Hardware component to inspect.
+ * @return Shared pointer to the capability, or nullptr if not implemented.
+ */
+template <typename Capability>
+std::shared_ptr<Capability> as_capable(const std::shared_ptr<HardwareComponent>& hw) {
+  return std::dynamic_pointer_cast<Capability>(hw);
+}
+
+}  // namespace trossen::hw::teleop
+
+#endif  // TROSSEN_SDK__HW__TELEOP__TELEOP_CAPABLE_HPP_

--- a/include/trossen_sdk/hw/teleop/teleop_controller.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_controller.hpp
@@ -1,0 +1,112 @@
+/**
+ * @file teleop_controller.hpp
+ * @brief Teleop controller that mirrors leader joint positions to a follower.
+ *
+ * The controller takes two TeleopCapable instances (leader and optional follower)
+ * and runs a high-rate control loop that reads joint positions from the leader and
+ * writes them to the follower. The follower may be nullptr for leader-only setups
+ * (e.g. UMI-style handheld capture).
+ *
+ * Capability is enforced at compile time: passing a non-teleop HardwareComponent
+ * (a camera, mobile base, etc.) is a type error rather than a runtime exception.
+ * Use trossen::hw::teleop::as_capable<TeleopCapable>(hw) at wiring sites to obtain
+ * the typed pointer.
+ *
+ * Recording is handled separately by existing arm producers — this controller only
+ * manages the real-time mirroring loop.
+ *
+ * Usage:
+ * @code
+ *   auto leader_hw = HardwareRegistry::create("trossen_arm", "leader", cfg);
+ *   auto follower_hw = HardwareRegistry::create("trossen_arm", "follower", cfg);
+ *
+ *   auto leader = teleop::as_capable<teleop::TeleopCapable>(leader_hw);
+ *   auto follower = teleop::as_capable<teleop::TeleopCapable>(follower_hw);
+ *
+ *   TeleopController::Config tc{.control_rate_hz = 1000.0f};
+ *   TeleopController ctrl(leader, follower, tc);
+ *
+ *   ctrl.start();   // spawns mirroring thread
+ *   // ... recording happens via SessionManager ...
+ *   ctrl.stop();    // joins thread, cleans up hardware
+ * @endcode
+ */
+
+#ifndef TROSSEN_SDK__HW__TELEOP__TELEOP_CONTROLLER_HPP
+#define TROSSEN_SDK__HW__TELEOP__TELEOP_CONTROLLER_HPP
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+
+namespace trossen::hw::teleop {
+
+class TeleopController {
+public:
+  struct Config {
+    /// Control loop rate in Hz (how fast leader positions are mirrored to follower)
+    float control_rate_hz{1000.0f};
+
+    /// Optional joint index remapping from leader to follower.
+    /// If empty, positions are passed through directly.
+    /// mapping[i] = leader joint index that maps to follower joint i.
+    std::vector<int> joint_mapping;
+  };
+
+  /**
+   * @brief Construct a teleop controller
+   *
+   * @param leader Teleop-capable component to read joint positions from
+   * @param follower Teleop-capable component to write positions to (nullptr for leader-only)
+   * @param config Controller configuration
+   * @throws std::invalid_argument if leader is null
+   */
+  TeleopController(
+    std::shared_ptr<TeleopCapable> leader,
+    std::shared_ptr<TeleopCapable> follower,
+    Config config);
+
+  ~TeleopController();
+
+  // Non-copyable, non-movable (owns a thread)
+  TeleopController(const TeleopController&) = delete;
+  TeleopController& operator=(const TeleopController&) = delete;
+
+  /**
+   * @brief Start the mirroring loop
+   *
+   * Calls prepare_for_follower() then prepare_for_leader() on the hardware,
+   * then spawns a thread that continuously mirrors positions at the configured rate.
+   * No-op if already running.
+   */
+  void start();
+
+  /**
+   * @brief Stop the mirroring loop
+   *
+   * Joins the control thread, then calls cleanup_teleop() on both components.
+   * No-op if not running.
+   */
+  void stop();
+
+  /**
+   * @brief Check if the control loop is running
+   */
+  bool is_running() const { return running_.load(); }
+
+private:
+  void control_loop();
+
+  std::shared_ptr<TeleopCapable> leader_;
+  std::shared_ptr<TeleopCapable> follower_;
+  Config cfg_;
+  std::thread thread_;
+  std::atomic<bool> running_{false};
+};
+
+}  // namespace trossen::hw::teleop
+
+#endif  // TROSSEN_SDK__HW__TELEOP__TELEOP_CONTROLLER_HPP

--- a/include/trossen_sdk/hw/teleop/teleop_factory.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_factory.hpp
@@ -1,0 +1,58 @@
+/**
+ * @file teleop_factory.hpp
+ * @brief Factory for constructing TeleopControllers from the global config.
+ *
+ * Mirrors the SessionManager pattern: read teleop wiring from
+ * `GlobalConfig::instance()`, resolve hardware references via
+ * `ActiveHardwareRegistry`, and return ready-to-start `TeleopController`
+ * instances.
+ *
+ * Prerequisite: `SdkConfig::populate_global_config()` must have been called,
+ * and the hardware components referenced in the teleop pairs must already be
+ * registered in `ActiveHardwareRegistry` (typically by `HardwareRegistry::create`
+ * with `mark_active=true`).
+ *
+ * Usage:
+ * @code
+ *   auto cfg = trossen::configuration::SdkConfig::from_json(j);
+ *   cfg.populate_global_config();
+ *   // ... create hardware via HardwareRegistry::create(..., mark_active=true) ...
+ *
+ *   auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+ *   for (auto& c : controllers) c->start();
+ * @endcode
+ */
+
+#ifndef TROSSEN_SDK__HW__TELEOP__TELEOP_FACTORY_HPP_
+#define TROSSEN_SDK__HW__TELEOP__TELEOP_FACTORY_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "trossen_sdk/hw/teleop/teleop_controller.hpp"
+
+namespace trossen::hw::teleop {
+
+/**
+ * @brief Construct one TeleopController per pair declared in the global config.
+ *
+ * Behavior:
+ * - If teleop is disabled (`enabled = false`), returns an empty vector.
+ * - For each pair: looks up `leader` and `follower` IDs in
+ *   `ActiveHardwareRegistry`. If the leader is missing, prints a warning and
+ *   skips that pair. If the follower is missing or absent, the controller is
+ *   constructed in leader-only mode (UMI-style).
+ * - If a referenced component does not implement `TeleopCapable` (e.g. a
+ *   camera was named by mistake), prints a warning and skips that pair.
+ * - Each returned controller is constructed but **not yet started**; the
+ *   caller is responsible for invoking `start()` and `stop()`.
+ *
+ * Throws `std::runtime_error` if the global "teleop" key is missing
+ * (i.e. `populate_global_config()` was never called).
+ */
+std::vector<std::unique_ptr<TeleopController>>
+create_controllers_from_global_config();
+
+}  // namespace trossen::hw::teleop
+
+#endif  // TROSSEN_SDK__HW__TELEOP__TELEOP_FACTORY_HPP_

--- a/src/configuration/sdk_config.cpp
+++ b/src/configuration/sdk_config.cpp
@@ -105,6 +105,20 @@ void SdkConfig::populate_global_config() const {
     gc_json["trossen_mcap_backend"] = bj;
   }
 
+  // Teleop (consumed by trossen::hw::teleop::create_controllers_from_global_config)
+  {
+    nlohmann::json tj;
+    tj["type"] = "teleop";
+    tj["enabled"] = teleop.enabled;
+    tj["rate_hz"] = teleop.rate_hz;
+    nlohmann::json pairs_j = nlohmann::json::array();
+    for (const auto& p : teleop.pairs) {
+      pairs_j.push_back({{"leader", p.leader}, {"follower", p.follower}});
+    }
+    tj["pairs"] = pairs_j;
+    gc_json["teleop"] = tj;
+  }
+
   GlobalConfig::instance().load_from_json(gc_json);
 }
 

--- a/src/hw/arm/so101_arm_component.cpp
+++ b/src/hw/arm/so101_arm_component.cpp
@@ -42,4 +42,35 @@ nlohmann::json SO101ArmComponent::get_info() const {
   info["num_joints"] = driver_ ? driver_->get_num_joints() : 0;
   return info;
 }
+size_t SO101ArmComponent::num_joints() const {
+  return driver_ ? driver_->get_num_joints() : 0;
+}
+
+std::vector<float> SO101ArmComponent::get_joint_positions() {
+  if (!driver_) return {};
+  auto positions = driver_->get_joint_positions(true);
+  return std::vector<float>(positions.begin(), positions.end());
+}
+
+void SO101ArmComponent::set_joint_positions(const std::vector<float>& positions) {
+  if (!driver_) return;
+  std::vector<double> pos_d(positions.begin(), positions.end());
+  driver_->set_joint_positions(pos_d, true);
+}
+
+void SO101ArmComponent::prepare_for_leader() {
+  // SO101 leader: read-only, no special mode needed
+}
+
+void SO101ArmComponent::prepare_for_follower(
+    const std::vector<float>& initial_positions) {
+  if (!driver_ || initial_positions.empty()) return;
+  std::vector<double> pos_d(initial_positions.begin(), initial_positions.end());
+  driver_->set_joint_positions(pos_d, true);
+}
+
+void SO101ArmComponent::cleanup_teleop() {
+  // SO101: no special cleanup needed
+}
+
 }  // namespace trossen::hw::arm

--- a/src/hw/arm/trossen_arm_component.cpp
+++ b/src/hw/arm/trossen_arm_component.cpp
@@ -69,6 +69,45 @@ nlohmann::json TrossenArmComponent::get_info() const {
   return info;
 }
 
+size_t TrossenArmComponent::num_joints() const {
+  return driver_ ? static_cast<size_t>(driver_->get_num_joints()) : 0;
+}
+
+std::vector<float> TrossenArmComponent::get_joint_positions() {
+  if (!driver_) return {};
+  auto output = driver_->get_robot_output();
+  const auto& positions = output.joint.all.positions;
+  return std::vector<float>(positions.begin(), positions.end());
+}
+
+void TrossenArmComponent::set_joint_positions(const std::vector<float>& positions) {
+  if (!driver_) return;
+  std::vector<double> pos_d(positions.begin(), positions.end());
+  driver_->set_all_positions(pos_d, 0.0, false);
+}
+
+void TrossenArmComponent::prepare_for_leader() {
+  if (!driver_) return;
+  driver_->set_all_modes(trossen_arm::Mode::external_effort);
+  std::vector<double> zeros(driver_->get_num_joints(), 0.0);
+  driver_->set_all_external_efforts(zeros, 0.0, false);
+}
+
+void TrossenArmComponent::prepare_for_follower(
+    const std::vector<float>& initial_positions) {
+  if (!driver_) return;
+  driver_->set_all_modes(trossen_arm::Mode::position);
+  if (!initial_positions.empty()) {
+    std::vector<double> pos_d(initial_positions.begin(), initial_positions.end());
+    driver_->set_all_positions(pos_d, 2.0, true);
+  }
+}
+
+void TrossenArmComponent::cleanup_teleop() {
+  if (!driver_) return;
+  driver_->set_all_modes(trossen_arm::Mode::idle);
+}
+
 REGISTER_HARDWARE(TrossenArmComponent, "trossen_arm")
 
 }  // namespace trossen::hw::arm

--- a/src/hw/teleop/teleop_controller.cpp
+++ b/src/hw/teleop/teleop_controller.cpp
@@ -1,0 +1,99 @@
+/**
+ * @file teleop_controller.cpp
+ * @brief Implementation of TeleopController
+ */
+
+#include "trossen_sdk/hw/teleop/teleop_controller.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+
+namespace trossen::hw::teleop {
+
+TeleopController::TeleopController(
+    std::shared_ptr<TeleopCapable> leader,
+    std::shared_ptr<TeleopCapable> follower,
+    Config config)
+  : leader_(std::move(leader))
+  , follower_(std::move(follower))
+  , cfg_(std::move(config))
+{
+  if (!leader_) {
+    throw std::invalid_argument("TeleopController: leader must not be null");
+  }
+}
+
+TeleopController::~TeleopController() {
+  stop();
+}
+
+void TeleopController::start() {
+  if (running_.exchange(true)) {
+    return;  // already running
+  }
+
+  // Prepare hardware: follower first (move to match), then leader (enable gravity comp)
+  if (follower_) {
+    auto initial_positions = leader_->get_joint_positions();
+    follower_->prepare_for_follower(initial_positions);
+    std::cout << "  [teleop] Follower prepared (matched leader positions)\n";
+  }
+
+  leader_->prepare_for_leader();
+  std::cout << "  [teleop] Leader prepared (gravity compensation enabled)\n";
+
+  thread_ = std::thread([this]() { control_loop(); });
+}
+
+void TeleopController::stop() {
+  if (!running_.exchange(false)) {
+    return;  // not running
+  }
+
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+
+  // Clean up hardware
+  leader_->cleanup_teleop();
+  if (follower_) {
+    follower_->cleanup_teleop();
+  }
+}
+
+void TeleopController::control_loop() {
+  const auto period = std::chrono::nanoseconds(
+    static_cast<int64_t>(1e9 / cfg_.control_rate_hz));
+
+  std::vector<float> mapped_cmd;
+
+  while (running_) {
+    auto deadline = std::chrono::steady_clock::now() + period;
+
+    // Read leader positions
+    auto cmd = leader_->get_joint_positions();
+
+    // Send to follower (if present)
+    if (follower_) {
+      if (!cfg_.joint_mapping.empty()) {
+        // Apply joint remapping
+        mapped_cmd.resize(cfg_.joint_mapping.size());
+        for (size_t i = 0; i < cfg_.joint_mapping.size(); ++i) {
+          int src_idx = cfg_.joint_mapping[i];
+          mapped_cmd[i] = (src_idx >= 0 && src_idx < static_cast<int>(cmd.size()))
+                              ? cmd[src_idx]
+                              : 0.0f;
+        }
+        follower_->set_joint_positions(mapped_cmd);
+      } else {
+        follower_->set_joint_positions(cmd);
+      }
+    }
+
+    // Sleep until next tick
+    std::this_thread::sleep_until(deadline);
+  }
+}
+
+}  // namespace trossen::hw::teleop

--- a/src/hw/teleop/teleop_factory.cpp
+++ b/src/hw/teleop/teleop_factory.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file teleop_factory.cpp
+ * @brief Implementation of create_controllers_from_global_config()
+ */
+
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
+
+#include <iostream>
+#include <utility>
+
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/types/teleop_config.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+
+namespace trossen::hw::teleop {
+
+std::vector<std::unique_ptr<TeleopController>>
+create_controllers_from_global_config() {
+  auto cfg = trossen::configuration::GlobalConfig::instance()
+               .get_as<trossen::configuration::TeleoperationConfig>("teleop");
+
+  std::vector<std::unique_ptr<TeleopController>> controllers;
+  if (!cfg->enabled) {
+    return controllers;
+  }
+
+  std::cout << "Starting teleop controllers...\n";
+  for (const auto& pair : cfg->pairs) {
+    auto leader_hw = ActiveHardwareRegistry::get(pair.leader);
+    if (!leader_hw) {
+      std::cout << "  [warn] Leader '" << pair.leader
+                << "' not registered, skipping pair\n";
+      continue;
+    }
+    auto leader = as_capable<TeleopCapable>(leader_hw);
+    if (!leader) {
+      std::cout << "  [warn] Leader '" << pair.leader
+                << "' is not teleop-capable, skipping pair\n";
+      continue;
+    }
+
+    std::shared_ptr<TeleopCapable> follower;
+    if (!pair.follower.empty()) {
+      auto follower_hw = ActiveHardwareRegistry::get(pair.follower);
+      if (!follower_hw) {
+        std::cout << "  [warn] Follower '" << pair.follower
+                  << "' not registered, running leader-only for '"
+                  << pair.leader << "'\n";
+      } else {
+        follower = as_capable<TeleopCapable>(follower_hw);
+        if (!follower) {
+          std::cout << "  [warn] Follower '" << pair.follower
+                    << "' is not teleop-capable, running leader-only for '"
+                    << pair.leader << "'\n";
+        }
+      }
+    }
+
+    TeleopController::Config tc{};
+    tc.control_rate_hz = cfg->rate_hz;
+    controllers.push_back(std::make_unique<TeleopController>(
+      std::move(leader), std::move(follower), std::move(tc)));
+
+    std::cout << "  [ok] " << pair.leader << " -> "
+              << (pair.follower.empty() ? "(none)" : pair.follower)
+              << " @ " << cfg->rate_hz << " Hz\n";
+  }
+  return controllers;
+}
+
+}  // namespace trossen::hw::teleop


### PR DESCRIPTION
- Implemented the following TeleopController class which take 2 TeleopCapable objects (hardwares) and a teleoperation config to enable teleoperation (mirroring the leader | follower)
- TeleopCapable was implemented as a Mixin class to extend the HardwareComponent class. Methods specific for teleoperation like get and set joint position are only specific to arms and not needed in the cameras. The arms will inherit this class to implement those methods
- We now inherit  the BaseConfig  in the TeleopConfig so it can be used in GlobalConfig singleton.
- create_controllers_from_global_config() helps to configure the leader| follower pairs and set the control  
 