### PR TITLE
teleop: add capability mixin and space interfaces

### DIFF
--- a/include/trossen_sdk/hw/teleop/teleop_capable.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_capable.hpp
@@ -1,0 +1,241 @@
+/**
+ * @file teleop_capable.hpp
+ * @brief Mixin interfaces for teleop-capable hardware.
+ *
+ * Teleop capability is structured around four interfaces:
+ *
+ *   - TeleopSpaceIO          : pure IO contract (`read()` / `write()`) that
+ *                              the controller's hot loop talks to.
+ *   - TeleopCapable          : base mixin with space-agnostic lifecycle hooks
+ *                              and a single `as_space_io(Space)` accessor that
+ *                              returns the IO view for the requested space (or
+ *                              nullptr if unsupported).
+ *   - JointSpaceTeleop       : TeleopCapable + TeleopSpaceIO for joint space.
+ *   - CartesianSpaceTeleop   : TeleopCapable + TeleopSpaceIO for cartesian space.
+ *
+ * A hardware component must implement at least one space child to be usable
+ * by TeleopController. The controller calls `as_space_io(cfg.space)` at
+ * construction and throws if the return is null.
+ *
+ * Single-space hardware (e.g. SO101 arm, joint-only) inherits the relevant
+ * space child directly. The child auto-wires `as_space_io` to return `this`
+ * for its space:
+ *
+ * @code
+ *   class MyArm : public HardwareComponent, public JointSpaceTeleop {
+ *     std::vector<float> read() override { ... }
+ *     void               write(const std::vector<float>& cmd) override { ... }
+ *     // optional: override lifecycle hooks from TeleopCapable
+ *   };
+ * @endcode
+ *
+ * Multi-space hardware (e.g. TrossenArmComponent, which supports both joint
+ * and cartesian) inherits TeleopCapable directly and exposes each space
+ * through a nested adapter sub-object that implements TeleopSpaceIO. The
+ * component overrides `as_space_io` with a switch that dispatches to the
+ * correct adapter. See TrossenArmComponent for a worked example.
+ *
+ * ── Adding a new teleop space ─────────────────────────────────────────────
+ *
+ *  1. Add an entry to the `Space` enum below.
+ *  2. Add a row to `kSpaceDescriptors` (name + interface name for errors).
+ *  3. Add a child class (e.g. `VelocitySpaceTeleop`) that inherits
+ *     `TeleopCapable` virtually and `TeleopSpaceIO`, mirroring the existing
+ *     joint/cartesian children.
+ *  4. Any hardware that should support the new space either inherits the new
+ *     child (single-space) or extends its `as_space_io` switch (multi-space).
+ *
+ * Nothing in teleop_controller.{hpp,cpp} or teleop_factory.cpp needs to
+ * change — the resolver, error messages, and JSON parse all go through
+ * `kSpaceDescriptors` and `as_space_io`.
+ */
+
+#ifndef TROSSEN_SDK__HW__TELEOP__TELEOP_CAPABLE_HPP_
+#define TROSSEN_SDK__HW__TELEOP__TELEOP_CAPABLE_HPP_
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "trossen_sdk/hw/hardware_component.hpp"
+
+namespace trossen::hw::teleop {
+
+/**
+ * @brief Pure IO contract the teleop hot loop calls every tick.
+ *
+ * Each space child inherits this, allowing the controller to hold a single
+ * `TeleopSpaceIO*` regardless of which space is active. The interface is
+ * intentionally narrow: only `read()` and `write()` differ per space.
+ * Space-agnostic setup (alignment, mode changes) lives on
+ * `TeleopCapable::prepare_for_teleop`.
+ */
+class TeleopSpaceIO {
+public:
+  virtual ~TeleopSpaceIO() = default;
+
+  /// Return the component's current state in this space (leader role).
+  virtual std::vector<float> read() = 0;
+
+  /// Apply a teleop command in this space (follower role).
+  virtual void write(const std::vector<float>& cmd) = 0;
+
+  /// Optional. Called once by the controller before the mirror loop starts,
+  /// with the follower's current state in this space. Real-hardware leaders
+  /// have no internal state to sync, so the default is a no-op. Virtual
+  /// leaders (e.g. keyboard input) override this to align their starting
+  /// state with the follower, avoiding a snap when the mirror begins.
+  virtual void sync_to_state(const std::vector<float>& state) {
+    (void)state;
+  }
+};
+
+/**
+ * @brief Lifecycle base for teleop-capable hardware.
+ *
+ * Lifecycle hooks are space-agnostic: the controller invokes them on the
+ * owning hardware component (not on a per-space IO view), so shared state
+ * and mode changes live in one place. All hooks have no-op defaults;
+ * components only override what they need.
+ *
+ * Subclasses override `as_space_io(Space)` to advertise which spaces they
+ * support. A non-null return unlocks that space for this hardware.
+ */
+class TeleopCapable {
+public:
+  /// Teleop spaces a component may operate in.
+  /// When adding a new space, also update `kSpaceDescriptors` below.
+  enum class Space { Joint, Cartesian };
+
+  virtual ~TeleopCapable() = default;
+
+  /// Return the IO view for `space`, or nullptr if this hardware does not
+  /// implement that space. Called by TeleopController at construction to
+  /// resolve the leader and follower to concrete `TeleopSpaceIO*`s.
+  virtual TeleopSpaceIO* as_space_io(Space space) {
+    (void)space;
+    return nullptr;
+  }
+
+  // ── Lifecycle hooks (no-op defaults) ───────────────────────────────────
+  //
+  // All lifecycle hooks are argument-free. Each implementation reads its
+  // own tuning (trajectory times, staging poses, gripper tolerances, etc.)
+  // and role state from members populated at configure() time. This keeps
+  // the controller's contract minimal and lets hardware with wildly
+  // different tuning coexist without interface churn.
+
+  /// Prepare this hardware for teleop in its configured role (leader vs
+  /// follower is inferred from the component's own configuration).
+  virtual void prepare_for_teleop() {}
+
+  /// Gracefully end teleop: return to rest and release driver resources.
+  /// Not called from the controller's destructor — the controller only
+  /// joins its mirror thread on destruction, and each hardware component
+  /// is responsible for emergency cleanup in its own destructor.
+  virtual void end_teleop() {}
+
+  /// Move hardware to its configured staging pose at session start.
+  virtual void stage() {}
+
+  // ── Episode hooks (no-op defaults) ─────────────────────────────────────
+
+  /// Called before each teleop cycle (e.g. per-episode hardware prep).
+  virtual void pre_episode() {}
+
+  /// Called after each teleop cycle (e.g. enter reset/free-drive mode).
+  virtual void post_episode() {}
+};
+
+// ── Space metadata table ─────────────────────────────────────────────────
+//
+// Single source of truth for space names and interface names. All helpers
+// below (name lookup, JSON parse) read this table, so adding a new space
+// requires only one row here and one enum value above.
+
+struct SpaceDescriptor {
+  TeleopCapable::Space space;
+  std::string_view     name;        ///< JSON / log name, e.g. "joint".
+  std::string_view     iface_name;  ///< C++ interface, e.g. "JointSpaceTeleop".
+};
+
+inline constexpr std::array<SpaceDescriptor, 2> kSpaceDescriptors{{
+  {TeleopCapable::Space::Joint,     "joint",     "JointSpaceTeleop"},
+  {TeleopCapable::Space::Cartesian, "cartesian", "CartesianSpaceTeleop"},
+}};
+
+// Guard against adding a Space enum value without a corresponding row.
+// `std::array<_, 2>` catches a shorter initializer at compile time; this
+// static_assert catches a longer enum that outgrows the table.
+static_assert(kSpaceDescriptors.size() == 2,
+  "kSpaceDescriptors must have exactly one row per TeleopCapable::Space "
+  "value. When adding a new Space, add its row above and update this "
+  "expected count.");
+
+/// Lower-case name used in JSON and log output. Returns "unknown" if `s` is
+/// absent from `kSpaceDescriptors` (should never happen for a well-formed
+/// enum value).
+inline std::string_view space_name(TeleopCapable::Space s) {
+  for (const auto& d : kSpaceDescriptors) {
+    if (d.space == s) return d.name;
+  }
+  return "unknown";
+}
+
+/// C++ interface name used in error messages, e.g. "JointSpaceTeleop".
+inline std::string_view space_iface_name(TeleopCapable::Space s) {
+  for (const auto& d : kSpaceDescriptors) {
+    if (d.space == s) return d.iface_name;
+  }
+  return "unknown";
+}
+
+/// Parse a JSON space string ("joint", "cartesian", …) to the enum.
+/// Returns std::nullopt on unknown input.
+inline std::optional<TeleopCapable::Space>
+space_from_name(std::string_view name) {
+  for (const auto& d : kSpaceDescriptors) {
+    if (d.name == name) return d.space;
+  }
+  return std::nullopt;
+}
+
+// ── Space child classes ──────────────────────────────────────────────────
+
+/**
+ * @brief Joint-space teleop interface. Inherit to unlock joint teleop.
+ *
+ * Direct inheritance auto-wires `as_space_io(Space::Joint)` to return `this`,
+ * so single-space hardware (e.g. SO101 arm) needs no extra plumbing.
+ */
+class JointSpaceTeleop : public virtual TeleopCapable, public TeleopSpaceIO {
+public:
+  TeleopSpaceIO* as_space_io(Space s) override {
+    return s == Space::Joint ? static_cast<TeleopSpaceIO*>(this) : nullptr;
+  }
+};
+
+/**
+ * @brief Cartesian-space teleop interface. Inherit to unlock cartesian teleop.
+ */
+class CartesianSpaceTeleop : public virtual TeleopCapable, public TeleopSpaceIO {
+public:
+  TeleopSpaceIO* as_space_io(Space s) override {
+    return s == Space::Cartesian ? static_cast<TeleopSpaceIO*>(this) : nullptr;
+  }
+};
+
+/**
+ * @brief Query a HardwareComponent for the TeleopCapable interface.
+ * Returns nullptr if the component does not implement TeleopCapable.
+ */
+template <typename Capability = TeleopCapable>
+std::shared_ptr<Capability> as_capable(const std::shared_ptr<HardwareComponent>& hw) {
+  return std::dynamic_pointer_cast<Capability>(hw);
+}
+
+}  // namespace trossen::hw::teleop
+
+#endif  // TROSSEN_SDK__HW__TELEOP__TELEOP_CAPABLE_HPP_

--- a/include/trossen_sdk/hw/teleop/teleop_capable.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_capable.hpp
@@ -17,9 +17,8 @@
  * by the teleop controller. The controller calls `as_space_io(cfg.space)`
  * at construction and throws if the return is null.
  *
- * Single-space hardware (e.g. SO101 arm, joint-only) inherits the relevant
- * space child directly. The child auto-wires `as_space_io` to return `this`
- * for its space:
+ * Single-space hardware inherits the relevant space child directly. The
+ * child auto-wires `as_space_io` to return `this` for its space:
  *
  * @code
  *   class MyArm : public HardwareComponent, public JointSpaceTeleop {
@@ -44,9 +43,8 @@
  *  4. Any hardware that should support the new space either inherits the new
  *     child (single-space) or extends its `as_space_io` switch (multi-space).
  *
- * Nothing in teleop_controller.{hpp,cpp} or teleop_factory.cpp needs to
- * change — the resolver, error messages, and JSON parse all go through
- * `kSpaceDescriptors` and `as_space_io`.
+ * The resolver, error messages, and JSON parse all go through
+ * `kSpaceDescriptors` and `as_space_io` — no other layer needs to change.
  */
 
 #ifndef TROSSEN_SDK__HW__TELEOP__TELEOP_CAPABLE_HPP_
@@ -90,8 +88,8 @@ public:
   /// Optional. Called once by the controller before the mirror loop starts,
   /// with the follower's current state in this space. Real-hardware leaders
   /// have no internal state to sync, so the default is a no-op. Virtual
-  /// leaders (e.g. keyboard input) override this to align their starting
-  /// state with the follower, avoiding a snap when the mirror begins.
+  /// leaders override this to align their starting state with the follower
+  /// before mirroring begins.
   virtual void sync_to_state(const std::vector<float>& state) {
     (void)state;
   }

--- a/include/trossen_sdk/hw/teleop/teleop_capable.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_capable.hpp
@@ -14,8 +14,8 @@
  *   - CartesianSpaceTeleop   : TeleopCapable + TeleopSpaceIO for cartesian space.
  *
  * A hardware component must implement at least one space child to be usable
- * by TeleopController. The controller calls `as_space_io(cfg.space)` at
- * construction and throws if the return is null.
+ * by the teleop controller. The controller calls `as_space_io(cfg.space)`
+ * at construction and throws if the return is null.
  *
  * Single-space hardware (e.g. SO101 arm, joint-only) inherits the relevant
  * space child directly. The child auto-wires `as_space_io` to return `this`
@@ -29,15 +29,14 @@
  *   };
  * @endcode
  *
- * Multi-space hardware (e.g. TrossenArmComponent, which supports both joint
- * and cartesian) inherits TeleopCapable directly and exposes each space
- * through a nested adapter sub-object that implements TeleopSpaceIO. The
- * component overrides `as_space_io` with a switch that dispatches to the
- * correct adapter. See TrossenArmComponent for a worked example.
+ * Multi-space hardware (a component that supports more than one space)
+ * inherits TeleopCapable directly and exposes each space through a nested
+ * adapter sub-object that implements TeleopSpaceIO. The component overrides
+ * `as_space_io` with a switch that dispatches to the correct adapter.
  *
  * ── Adding a new teleop space ─────────────────────────────────────────────
  *
- *  1. Add an entry to the `Space` enum below.
+ *  1. Add a new value to the `Space` enum below, before the `Count` sentinel.
  *  2. Add a row to `kSpaceDescriptors` (name + interface name for errors).
  *  3. Add a child class (e.g. `VelocitySpaceTeleop`) that inherits
  *     `TeleopCapable` virtually and `TeleopSpaceIO`, mirroring the existing
@@ -77,6 +76,12 @@ public:
   virtual ~TeleopSpaceIO() = default;
 
   /// Return the component's current state in this space (leader role).
+  ///
+  /// TODO(shantanuparab-tr): revisit with a span / caller-owned output
+  /// buffer if profiling shows allocator pressure at high control rates.
+  /// Returning a vector by value encourages a fresh allocation per tick,
+  /// which is cheap at 1 kHz with small state vectors but becomes
+  /// meaningful at higher rates or larger payloads.
   virtual std::vector<float> read() = 0;
 
   /// Apply a teleop command in this space (follower role).
@@ -106,8 +111,11 @@ public:
 class TeleopCapable {
 public:
   /// Teleop spaces a component may operate in.
-  /// When adding a new space, also update `kSpaceDescriptors` below.
-  enum class Space { Joint, Cartesian };
+  ///
+  /// `Count` is a sentinel (not a real space) used to make the descriptor
+  /// table's compile-time check meaningful. When adding a new space,
+  /// insert it before `Count` and add a matching row to `kSpaceDescriptors`.
+  enum class Space { Joint, Cartesian, Count };
 
   virtual ~TeleopCapable() = default;
 
@@ -166,13 +174,14 @@ inline constexpr std::array<SpaceDescriptor, 2> kSpaceDescriptors{{
   {TeleopCapable::Space::Cartesian, "cartesian", "CartesianSpaceTeleop"},
 }};
 
-// Guard against adding a Space enum value without a corresponding row.
-// `std::array<_, 2>` catches a shorter initializer at compile time; this
-// static_assert catches a longer enum that outgrows the table.
-static_assert(kSpaceDescriptors.size() == 2,
-  "kSpaceDescriptors must have exactly one row per TeleopCapable::Space "
-  "value. When adding a new Space, add its row above and update this "
-  "expected count.");
+// Compile-time check: every Space enum value has a descriptor row. The
+// `Space::Count` sentinel gives this assertion teeth — adding a new enum
+// value without adding its row fails to compile here.
+static_assert(
+  kSpaceDescriptors.size() ==
+    static_cast<std::size_t>(TeleopCapable::Space::Count),
+  "kSpaceDescriptors must have one row per TeleopCapable::Space value. "
+  "Add the new row above; the compiler will then be satisfied.");
 
 /// Lower-case name used in JSON and log output. Returns "unknown" if `s` is
 /// absent from `kSpaceDescriptors` (should never happen for a well-formed

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,9 @@ target_link_libraries(test_keyboard_input_utils PRIVATE trossen_sdk GTest::gtest
 add_executable(test_announce test_announce.cpp)
 target_link_libraries(test_announce PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_teleop_space_helpers test_teleop_space_helpers.cpp)
+target_link_libraries(test_teleop_space_helpers PRIVATE trossen_sdk GTest::gtest_main)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -95,3 +98,4 @@ gtest_discover_tests(test_session_manager)
 gtest_discover_tests(test_session_manager_discard)
 gtest_discover_tests(test_keyboard_input_utils)
 gtest_discover_tests(test_announce)
+gtest_discover_tests(test_teleop_space_helpers)

--- a/tests/test_teleop_space_helpers.cpp
+++ b/tests/test_teleop_space_helpers.cpp
@@ -1,0 +1,65 @@
+/**
+ * @file test_teleop_space_helpers.cpp
+ * @brief Unit tests for the teleop space descriptor table and helpers.
+ *
+ * Locks down the mapping between Space enum values, JSON names, and C++
+ * interface names. These helpers drive user-visible configuration parsing
+ * and error messages, so silent drift here breaks real configs.
+ */
+
+#include <optional>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+
+namespace {
+
+using trossen::hw::teleop::space_from_name;
+using trossen::hw::teleop::space_iface_name;
+using trossen::hw::teleop::space_name;
+using Space = trossen::hw::teleop::TeleopCapable::Space;
+
+// space_name: every Space value returns the expected JSON name.
+TEST(TeleopSpaceHelpersTest, SpaceNameReturnsLowerCaseJsonName) {
+  EXPECT_EQ(space_name(Space::Joint),     "joint");
+  EXPECT_EQ(space_name(Space::Cartesian), "cartesian");
+}
+
+// space_iface_name: every Space value returns the expected C++ interface name.
+TEST(TeleopSpaceHelpersTest, IfaceNameReturnsCppClassName) {
+  EXPECT_EQ(space_iface_name(Space::Joint),     "JointSpaceTeleop");
+  EXPECT_EQ(space_iface_name(Space::Cartesian), "CartesianSpaceTeleop");
+}
+
+// space_from_name: known names resolve to the matching Space value.
+TEST(TeleopSpaceHelpersTest, FromNameResolvesKnownSpaces) {
+  auto joint = space_from_name("joint");
+  ASSERT_TRUE(joint.has_value());
+  EXPECT_EQ(*joint, Space::Joint);
+
+  auto cart = space_from_name("cartesian");
+  ASSERT_TRUE(cart.has_value());
+  EXPECT_EQ(*cart, Space::Cartesian);
+}
+
+// space_from_name: unknown inputs return nullopt, never fall through silently.
+TEST(TeleopSpaceHelpersTest, FromNameReturnsNulloptForUnknown) {
+  EXPECT_FALSE(space_from_name("velocity").has_value());
+  EXPECT_FALSE(space_from_name("JOINT").has_value());  // case-sensitive
+  EXPECT_FALSE(space_from_name("").has_value());
+  EXPECT_FALSE(space_from_name(" joint ").has_value());  // no trimming
+}
+
+// Round-trip: for every known space, name → Space → name returns the same name.
+TEST(TeleopSpaceHelpersTest, RoundTripNameThroughEnum) {
+  for (const auto s : {Space::Joint, Space::Cartesian}) {
+    auto name = space_name(s);
+    auto parsed = space_from_name(std::string{name});
+    ASSERT_TRUE(parsed.has_value()) << "Failed to parse " << name;
+    EXPECT_EQ(*parsed, s);
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
Adds the header that defines what "teleop-capable hardware" means — a small TeleopCapable mixin plus two space-specific children JointSpaceTeleop, CartesianSpaceTeleop) built on a tiny TeleopSpaceIO interface the hot loop talks to. Pure plumbing; nothing in the repo uses it yet. Sets up the contract everything else depends on. 