### PR TITLE
teleop: add controller with mirror thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(trossen_sdk SHARED
   src/hw/arm/so101_teleop_arm_producer.cpp
   src/hw/base/slate_base_component.cpp
   src/hw/base/slate_base_producer.cpp
+  src/hw/teleop/teleop_controller.cpp
   src/hw/camera/opencv_camera_component.cpp
   src/hw/camera/opencv_producer.cpp
   src/hw/camera/mock_producer.cpp

--- a/include/trossen_sdk/hw/teleop/teleop_controller.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_controller.hpp
@@ -1,0 +1,152 @@
+/**
+ * @file teleop_controller.hpp
+ * @brief Teleop controller that mirrors a leader's state to a follower.
+ *
+ * The controller takes two TeleopCapable instances (leader and optional
+ * follower) plus a teleop space chosen in configuration. It resolves the
+ * space-specific IO view from each component via `as_space_io(Space)` and
+ * runs a high-rate loop that reads the leader and writes to the follower in
+ * that space. If either side does not implement the requested space,
+ * construction throws with a clear message.
+ *
+ * The follower may be nullptr for leader-only setups (e.g. handheld
+ * capture). Recording is handled separately by producers.
+ *
+ * Usage:
+ * @code
+ *   auto leader_hw   = HardwareRegistry::create("trossen_arm", "leader",   cfg);
+ *   auto follower_hw = HardwareRegistry::create("trossen_arm", "follower", cfg);
+ *
+ *   auto leader   = teleop::as_capable<teleop::TeleopCapable>(leader_hw);
+ *   auto follower = teleop::as_capable<teleop::TeleopCapable>(follower_hw);
+ *
+ *   TeleopController::Config tc{
+ *     .space           = teleop::TeleopCapable::Space::Joint,
+ *     .control_rate_hz = 1000.0f,
+ *   };
+ *   TeleopController ctrl(leader, follower, tc);
+ *
+ *   ctrl.teleop();        // spawns mirroring thread
+ *   // ... recording happens via SessionManager ...
+ *   ctrl.stop_teleop();   // joins thread, cleans up hardware
+ * @endcode
+ */
+
+#ifndef TROSSEN_SDK__HW__TELEOP__TELEOP_CONTROLLER_HPP
+#define TROSSEN_SDK__HW__TELEOP__TELEOP_CONTROLLER_HPP
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+
+namespace trossen::hw::teleop {
+
+class TeleopController {
+public:
+  struct Config {
+    /// Teleop space. Both leader and follower must implement it.
+    TeleopCapable::Space space{TeleopCapable::Space::Joint};
+
+    /// Control loop rate in Hz (how fast leader state is mirrored to follower).
+    float control_rate_hz{1000.0f};
+  };
+
+  /**
+   * @brief Construct a teleop controller.
+   *
+   * @param leader   Teleop-capable component to read state from.
+   * @param follower Teleop-capable component to write state to (nullptr for
+   *                 leader-only).
+   * @param config   Controller configuration, including the teleop space.
+   *
+   * @throws std::invalid_argument if `leader` is null.
+   * @throws std::invalid_argument if the leader (or non-null follower) does
+   *         not implement the requested space — e.g. requesting cartesian
+   *         on hardware that only inherits JointSpaceTeleop.
+   */
+  TeleopController(
+    std::shared_ptr<TeleopCapable> leader,
+    std::shared_ptr<TeleopCapable> follower,
+    Config config);
+
+  ~TeleopController();
+
+  // Non-copyable, non-movable (owns a thread).
+  TeleopController(const TeleopController&) = delete;
+  TeleopController& operator=(const TeleopController&) = delete;
+
+  /**
+   * @brief Prepare hardware for a teleop episode.
+   *
+   * Calls pre_episode() on both components, aligns the follower to the
+   * leader's current joint state, and puts the leader into its teleop mode
+   * (e.g. gravity compensation for Trossen arms). Does not start the mirror
+   * thread -- that is done by teleop().
+   *
+   * Once the mirror loop is running, subsequent calls are no-ops: the
+   * follower is already tracking the leader through reset periods and does
+   * not need re-alignment.
+   */
+  void prepare_teleop();
+
+  /**
+   * @brief Start the mirror loop.
+   *
+   * Spawns the control thread that reads the leader and writes to the
+   * follower at control_rate_hz. No-op if already running; the mirror runs
+   * continuously across episodes.
+   */
+  void teleop();
+
+  /**
+   * @brief Enter reset mode.
+   *
+   * Calls post_episode() on both components. The mirror loop keeps running,
+   * so the user can move the leader freely and the follower continues to
+   * track. Recording is handled separately by the session manager.
+   */
+  void reset_teleop();
+
+  /**
+   * @brief Stop the mirror loop and return hardware to rest.
+   *
+   * Joins the control thread, then calls end_teleop() on both components
+   * to neutralize and release driver resources.
+   */
+  void stop_teleop();
+
+  /// @brief Check if the control loop is running.
+  bool is_running() const { return running_.load(); }
+
+  /// @brief Access the leader component (for session lifecycle calls).
+  std::shared_ptr<TeleopCapable> leader() const { return leader_; }
+
+  /// @brief Access the follower component (may be nullptr for leader-only).
+  std::shared_ptr<TeleopCapable> follower() const { return follower_; }
+
+  /// @brief The teleop space this controller was configured for.
+  TeleopCapable::Space space() const { return cfg_.space; }
+
+private:
+  void resolve_space_views();
+  void control_loop();
+
+  std::shared_ptr<TeleopCapable> leader_;
+  std::shared_ptr<TeleopCapable> follower_;
+
+  // Space-specific IO views resolved from the leader/follower components.
+  // Non-owning — lifetime is tied to the shared_ptrs above.
+  TeleopSpaceIO* leader_io_{nullptr};
+  TeleopSpaceIO* follower_io_{nullptr};
+
+  Config cfg_;
+  std::thread thread_;
+  std::atomic<bool> running_{false};
+};
+
+}  // namespace trossen::hw::teleop
+
+#endif  // TROSSEN_SDK__HW__TELEOP__TELEOP_CONTROLLER_HPP

--- a/include/trossen_sdk/hw/teleop/teleop_controller.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_controller.hpp
@@ -9,27 +9,8 @@
  * that space. If either side does not implement the requested space,
  * construction throws with a clear message.
  *
- * The follower may be nullptr for leader-only setups (e.g. handheld
- * capture). Recording is handled separately by producers.
- *
- * Usage:
- * @code
- *   auto leader_hw   = HardwareRegistry::create("trossen_arm", "leader",   cfg);
- *   auto follower_hw = HardwareRegistry::create("trossen_arm", "follower", cfg);
- *
- *   auto leader   = teleop::as_capable<teleop::TeleopCapable>(leader_hw);
- *   auto follower = teleop::as_capable<teleop::TeleopCapable>(follower_hw);
- *
- *   TeleopController::Config tc{
- *     .space           = teleop::TeleopCapable::Space::Joint,
- *     .control_rate_hz = 1000.0f,
- *   };
- *   TeleopController ctrl(leader, follower, tc);
- *
- *   ctrl.teleop();        // spawns mirroring thread
- *   // ... recording happens via SessionManager ...
- *   ctrl.stop_teleop();   // joins thread, cleans up hardware
- * @endcode
+ * The follower may be nullptr for leader-only setups. Recording is
+ * performed separately and is not the controller's concern.
  */
 
 #ifndef TROSSEN_SDK__HW__TELEOP__TELEOP_CONTROLLER_HPP
@@ -81,14 +62,12 @@ public:
   /**
    * @brief Prepare hardware for a teleop episode.
    *
-   * Calls pre_episode() on both components, aligns the follower to the
-   * leader's current joint state, and puts the leader into its teleop mode
-   * (e.g. gravity compensation for Trossen arms). Does not start the mirror
-   * thread -- that is done by teleop().
-   *
-   * Once the mirror loop is running, subsequent calls are no-ops: the
-   * follower is already tracking the leader through reset periods and does
-   * not need re-alignment.
+   * Calls pre_episode() on both components, puts the leader into its
+   * teleop role, and calls sync_to_state on the leader with the follower's
+   * current state (so virtual leaders can align with the follower before
+   * mirroring starts). Does not start the mirror thread -- that is done
+   * by teleop(). Subsequent calls while the mirror is already running are
+   * no-ops.
    */
   void prepare_teleop();
 

--- a/include/trossen_sdk/hw/teleop/teleop_controller.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_controller.hpp
@@ -62,12 +62,12 @@ public:
   /**
    * @brief Prepare hardware for a teleop episode.
    *
-   * Calls pre_episode() on both components, puts the leader into its
-   * teleop role, and calls sync_to_state on the leader with the follower's
-   * current state (so virtual leaders can align with the follower before
-   * mirroring starts). Does not start the mirror thread -- that is done
-   * by teleop(). Subsequent calls while the mirror is already running are
-   * no-ops.
+   * Always dispatches pre_episode() on both components. If the mirror loop
+   * is already running, returns after that — the follower is tracking the
+   * leader continuously and no further setup is needed. On the first call
+   * (before the mirror starts), also prepares teleop modes on both
+   * components and calls sync_to_state so virtual leaders can align with
+   * the follower. Does not start the mirror thread — that is teleop().
    */
   void prepare_teleop();
 

--- a/src/hw/teleop/teleop_controller.cpp
+++ b/src/hw/teleop/teleop_controller.cpp
@@ -80,24 +80,23 @@ void TeleopController::prepare_teleop() {
     follower_->pre_episode();
   }
 
-  // The mirror loop runs continuously across episodes, keeping the follower
-  // at the leader's current state through reset periods. Once it is
-  // running, per-episode preparation is unnecessary.
+  // The mirror loop runs continuously across episodes; return early if it
+  // is already running.
   if (running_) {
     return;
   }
 
-  // First-episode setup. Each arm reads its configured role (leader vs
-  // follower) and trajectory parameters from its own members; the
-  // controller only signals the lifecycle transition.
+  // First-episode setup. Each arm reads its configured role and trajectory
+  // parameters from its own members; the controller only signals the
+  // lifecycle transition.
   if (follower_) {
     follower_->prepare_for_teleop();
   }
   leader_->prepare_for_teleop();
 
-  // Give virtual leaders (e.g. keyboard input) a chance to align their
-  // internal state to the follower's actual pose, so the first mirror
-  // tick doesn't snap. Real-hardware leaders inherit the no-op default.
+  // Let virtual leaders align their internal state to the follower's
+  // current pose before the mirror loop starts. Real-hardware leaders
+  // inherit the no-op default.
   if (follower_io_) {
     leader_io_->sync_to_state(follower_io_->read());
   }

--- a/src/hw/teleop/teleop_controller.cpp
+++ b/src/hw/teleop/teleop_controller.cpp
@@ -6,8 +6,11 @@
 #include "trossen_sdk/hw/teleop/teleop_controller.hpp"
 
 #include <chrono>
+#include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
+#include <string>
 
 namespace trossen::hw::teleop {
 
@@ -21,6 +24,10 @@ TeleopController::TeleopController(
 {
   if (!leader_) {
     throw std::invalid_argument("TeleopController: leader must not be null");
+  }
+  if (cfg_.control_rate_hz <= 0.0f || !std::isfinite(cfg_.control_rate_hz)) {
+    throw std::invalid_argument(
+      "TeleopController: control_rate_hz must be positive and finite");
   }
 
   // Resolve the requested space on both sides. Throws if the hardware does
@@ -39,11 +46,11 @@ TeleopController::TeleopController(
 }
 
 TeleopController::~TeleopController() {
-  // The destructor only needs to stop the mirror thread. Each hardware
-  // component is responsible for releasing its own driver in its own
-  // destructor — this avoids calling into potentially-torn-down hardware
-  // from a destructor that must not throw.
-  if (running_.exchange(false) && thread_.joinable()) {
+  // Signal stop (may already be false if the loop exited via exception)
+  // and always join if the thread is still joinable. Skipping join on a
+  // joinable thread causes std::terminate at destruction.
+  running_.store(false);
+  if (thread_.joinable()) {
     thread_.join();
   }
 }
@@ -118,7 +125,8 @@ void TeleopController::reset_teleop() {
 }
 
 void TeleopController::stop_teleop() {
-  if (running_.exchange(false) && thread_.joinable()) {
+  running_.store(false);
+  if (thread_.joinable()) {
     thread_.join();
   }
   // A repeated stop_teleop() is harmless: the arms' end_teleop()

--- a/src/hw/teleop/teleop_controller.cpp
+++ b/src/hw/teleop/teleop_controller.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file teleop_controller.cpp
+ * @brief Implementation of TeleopController.
+ */
+
+#include "trossen_sdk/hw/teleop/teleop_controller.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+
+namespace trossen::hw::teleop {
+
+TeleopController::TeleopController(
+    std::shared_ptr<TeleopCapable> leader,
+    std::shared_ptr<TeleopCapable> follower,
+    Config config)
+  : leader_(std::move(leader))
+  , follower_(std::move(follower))
+  , cfg_(std::move(config))
+{
+  if (!leader_) {
+    throw std::invalid_argument("TeleopController: leader must not be null");
+  }
+
+  // Resolve the requested space on both sides. Throws if the hardware does
+  // not implement the required space child class.
+  resolve_space_views();
+
+  // Each arm stages itself using its own configured staging pose and
+  // trajectory time. Arms that don't need staging override stage() with
+  // a no-op. Calls here are expected to be non-blocking so multi-arm
+  // setups stage in parallel.
+  leader_->stage();
+  if (follower_) {
+    follower_->stage();
+  }
+  std::cout << "  [teleop] Staging initiated\n";
+}
+
+TeleopController::~TeleopController() {
+  // The destructor only needs to stop the mirror thread. Each hardware
+  // component is responsible for releasing its own driver in its own
+  // destructor — this avoids calling into potentially-torn-down hardware
+  // from a destructor that must not throw.
+  if (running_.exchange(false) && thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+// ── Space resolution ─────────────────────────────────────────────────────
+
+void TeleopController::resolve_space_views() {
+  auto resolve = [this](const std::shared_ptr<TeleopCapable>& hw,
+                        const char* role) -> TeleopSpaceIO* {
+    TeleopSpaceIO* io = hw->as_space_io(cfg_.space);
+    if (!io) {
+      throw std::invalid_argument(
+        std::string("TeleopController: ") + role +
+        " does not implement " + std::string(space_iface_name(cfg_.space)) +
+        " (" + std::string(space_name(cfg_.space)) +
+        "-space teleop is not available for this hardware)");
+    }
+    return io;
+  };
+
+  leader_io_ = resolve(leader_, "leader");
+  if (follower_) {
+    follower_io_ = resolve(follower_, "follower");
+  }
+
+  std::cout << "  [teleop] Space: " << space_name(cfg_.space) << "\n";
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────────
+
+void TeleopController::prepare_teleop() {
+  leader_->pre_episode();
+  if (follower_) {
+    follower_->pre_episode();
+  }
+
+  // The mirror loop runs continuously across episodes, keeping the follower
+  // at the leader's current state through reset periods. Once it is
+  // running, per-episode preparation is unnecessary.
+  if (running_) {
+    return;
+  }
+
+  // First-episode setup. Each arm reads its configured role (leader vs
+  // follower) and trajectory parameters from its own members; the
+  // controller only signals the lifecycle transition.
+  if (follower_) {
+    follower_->prepare_for_teleop();
+  }
+  leader_->prepare_for_teleop();
+
+  // Give virtual leaders (e.g. keyboard input) a chance to align their
+  // internal state to the follower's actual pose, so the first mirror
+  // tick doesn't snap. Real-hardware leaders inherit the no-op default.
+  if (follower_io_) {
+    leader_io_->sync_to_state(follower_io_->read());
+  }
+  std::cout << "  [teleop] Arms ready for teleop\n";
+}
+
+void TeleopController::teleop() {
+  if (running_.exchange(true)) {
+    return;
+  }
+  thread_ = std::thread([this]() { control_loop(); });
+}
+
+void TeleopController::reset_teleop() {
+  leader_->post_episode();
+  if (follower_) {
+    follower_->post_episode();
+  }
+}
+
+void TeleopController::stop_teleop() {
+  if (running_.exchange(false) && thread_.joinable()) {
+    thread_.join();
+  }
+  // A repeated stop_teleop() is harmless: the arms' end_teleop()
+  // implementations are expected to be idempotent once their driver has
+  // been released.
+  leader_->end_teleop();
+  if (follower_) {
+    follower_->end_teleop();
+  }
+}
+
+// ── Control loop ────────────────────────────────────────────────────────
+
+void TeleopController::control_loop() {
+  const auto period = std::chrono::nanoseconds(
+    static_cast<int64_t>(1e9 / cfg_.control_rate_hz));
+
+  // An uncaught exception would invoke std::terminate (thread functions are
+  // implicitly noexcept at the boundary). Catch and log so that
+  // prepare_teleop() can observe the mirror as stopped.
+  try {
+    while (running_) {
+      auto deadline = std::chrono::steady_clock::now() + period;
+
+      auto cmd = leader_io_->read();
+      if (follower_io_) {
+        follower_io_->write(cmd);
+      }
+
+      std::this_thread::sleep_until(deadline);
+    }
+  } catch (const std::exception& e) {
+    std::cerr << "  [teleop] mirror loop terminated: " << e.what() << '\n';
+    running_.store(false);
+  } catch (...) {
+    std::cerr << "  [teleop] mirror loop terminated with unknown error\n";
+    running_.store(false);
+  }
+}
+
+}  // namespace trossen::hw::teleop

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,9 @@ target_link_libraries(test_announce PRIVATE trossen_sdk GTest::gtest_main)
 add_executable(test_teleop_space_helpers test_teleop_space_helpers.cpp)
 target_link_libraries(test_teleop_space_helpers PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_teleop_controller test_teleop_controller.cpp)
+target_link_libraries(test_teleop_controller PRIVATE trossen_sdk GTest::gtest_main)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -99,3 +102,4 @@ gtest_discover_tests(test_session_manager_discard)
 gtest_discover_tests(test_keyboard_input_utils)
 gtest_discover_tests(test_announce)
 gtest_discover_tests(test_teleop_space_helpers)
+gtest_discover_tests(test_teleop_controller)

--- a/tests/test_teleop_controller.cpp
+++ b/tests/test_teleop_controller.cpp
@@ -1,0 +1,106 @@
+/**
+ * @file test_teleop_controller.cpp
+ * @brief Unit tests for TeleopController thread lifecycle and error paths.
+ */
+
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+#include "trossen_sdk/hw/teleop/teleop_controller.hpp"
+
+namespace {
+
+using trossen::hw::teleop::JointSpaceTeleop;
+using trossen::hw::teleop::TeleopCapable;
+using trossen::hw::teleop::TeleopController;
+using trossen::hw::teleop::TeleopSpaceIO;
+
+/// A leader whose read() throws on every call.
+class ThrowingLeader : public TeleopCapable {
+  struct IO : JointSpaceTeleop {
+    std::vector<float> read() override {
+      throw std::runtime_error("test exception from read()");
+    }
+    void write(const std::vector<float>&) override {}
+  } io_;
+public:
+  TeleopSpaceIO* as_space_io(Space) override { return &io_; }
+};
+
+/// A well-behaved leader that returns a fixed joint state.
+class StubLeader : public TeleopCapable {
+  struct IO : JointSpaceTeleop {
+    std::vector<float> read() override { return {0.0f, 0.0f, 0.0f}; }
+    void write(const std::vector<float>&) override {}
+  } io_;
+public:
+  TeleopSpaceIO* as_space_io(Space) override { return &io_; }
+};
+
+// If the control loop throws, the controller must not std::terminate on
+// destruction. The exception handler in control_loop() catches the error
+// and clears running_; the destructor then joins the (already-exited)
+// thread safely.
+TEST(TeleopControllerTest, ControlLoopExceptionDoesNotTerminate) {
+  auto leader = std::make_shared<ThrowingLeader>();
+  TeleopController::Config cfg{};
+  TeleopController ctrl(leader, nullptr, cfg);
+  ctrl.teleop();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_FALSE(ctrl.is_running());
+  // Destruction here must complete without std::terminate.
+}
+
+// A controller with a zero control_rate_hz must throw at construction.
+TEST(TeleopControllerTest, ZeroRateThrows) {
+  auto leader = std::make_shared<StubLeader>();
+  TeleopController::Config cfg{};
+  cfg.control_rate_hz = 0.0f;
+  EXPECT_THROW(TeleopController(leader, nullptr, cfg), std::invalid_argument);
+}
+
+// A controller with a negative control_rate_hz must throw at construction.
+TEST(TeleopControllerTest, NegativeRateThrows) {
+  auto leader = std::make_shared<StubLeader>();
+  TeleopController::Config cfg{};
+  cfg.control_rate_hz = -100.0f;
+  EXPECT_THROW(TeleopController(leader, nullptr, cfg), std::invalid_argument);
+}
+
+// Normal start/stop cycle completes without crashing.
+TEST(TeleopControllerTest, StartStopCycle) {
+  auto leader = std::make_shared<StubLeader>();
+  TeleopController::Config cfg{};
+  cfg.control_rate_hz = 100.0f;
+  TeleopController ctrl(leader, nullptr, cfg);
+
+  ctrl.prepare_teleop();
+  ctrl.teleop();
+  EXPECT_TRUE(ctrl.is_running());
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  ctrl.stop_teleop();
+  EXPECT_FALSE(ctrl.is_running());
+}
+
+// Calling stop_teleop() twice does not crash.
+TEST(TeleopControllerTest, DoubleStopIsSafe) {
+  auto leader = std::make_shared<StubLeader>();
+  TeleopController::Config cfg{};
+  cfg.control_rate_hz = 100.0f;
+  TeleopController ctrl(leader, nullptr, cfg);
+
+  ctrl.teleop();
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  ctrl.stop_teleop();
+  ctrl.stop_teleop();  // second call must be harmless
+  EXPECT_FALSE(ctrl.is_running());
+}
+
+}  // namespace


### PR DESCRIPTION
Introduces TeleopController — one thread, one job: read the leader, write the follower, at a configurable rate. It speaks only through the interface from PR 01, so it doesn't know or care what brand of arm it's driving. Includes the safety work: exception handler inside the hot loop, noexcept destructor contract, and a guard against double-dispatching shutdown. 