### PR TITLE
teleop: add factory and teleop config type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(trossen_sdk SHARED
   src/hw/base/slate_base_component.cpp
   src/hw/base/slate_base_producer.cpp
   src/hw/teleop/teleop_controller.cpp
+  src/hw/teleop/teleop_factory.cpp
   src/hw/camera/opencv_camera_component.cpp
   src/hw/camera/opencv_producer.cpp
   src/hw/camera/mock_producer.cpp

--- a/include/trossen_sdk/configuration/types/teleop_config.hpp
+++ b/include/trossen_sdk/configuration/types/teleop_config.hpp
@@ -11,6 +11,9 @@
 
 #include "nlohmann/json.hpp"
 
+#include "trossen_sdk/configuration/base_config.hpp"
+#include "trossen_sdk/configuration/config_registry.hpp"
+
 namespace trossen::configuration {
 
 /**
@@ -23,10 +26,19 @@ struct TeleoperationPair {
   /// @brief Key in hardware.arms map for the follower arm
   std::string follower;
 
+  /// @brief Teleop space: "joint" or "cartesian". Defaults to "joint".
+  ///
+  /// The factory converts this to teleop::TeleopCapable::Space. The chosen
+  /// space must be implemented (via JointSpaceTeleop / CartesianSpaceTeleop)
+  /// by both the leader and the follower — otherwise the controller throws
+  /// at construction.
+  std::string space{"joint"};
+
   static TeleoperationPair from_json(const nlohmann::json& j) {
     TeleoperationPair p;
     if (j.contains("leader")) j.at("leader").get_to(p.leader);
     if (j.contains("follower")) j.at("follower").get_to(p.follower);
+    if (j.contains("space")) j.at("space").get_to(p.space);
     return p;
   }
 };
@@ -44,10 +56,15 @@ struct TeleoperationPair {
  *   ]
  * }
  *
- * The teleop loop mirrors each leader arm's joint positions to its paired follower
- * at the specified rate. Set "enabled" to false to skip teleop (e.g. replay mode).
+ * The teleop loop mirrors each leader arm's state to its paired follower at
+ * the specified rate. Set "enabled" to false to skip teleop (e.g. replay
+ * mode).
+ *
+ * Per-arm tuning (staging pose, trajectory time, gripper tolerance, etc.)
+ * lives in each arm's own hardware configuration block — see the relevant
+ * component headers for supported fields.
  */
-struct TeleoperationConfig {
+struct TeleoperationConfig : public BaseConfig {
   /// @brief Whether teleoperation is active
   bool enabled{true};
 
@@ -56,6 +73,8 @@ struct TeleoperationConfig {
 
   /// @brief Leader->follower pairings
   std::vector<TeleoperationPair> pairs;
+
+  std::string type() const override { return "teleop"; }
 
   static TeleoperationConfig from_json(const nlohmann::json& j) {
     TeleoperationConfig c;
@@ -69,6 +88,8 @@ struct TeleoperationConfig {
     return c;
   }
 };
+
+REGISTER_CONFIG(TeleoperationConfig, "teleop");
 
 }  // namespace trossen::configuration
 

--- a/include/trossen_sdk/configuration/types/teleop_config.hpp
+++ b/include/trossen_sdk/configuration/types/teleop_config.hpp
@@ -51,18 +51,18 @@ struct TeleoperationPair {
  *   "enabled": true,
  *   "rate_hz": 1000.0,
  *   "pairs": [
- *     { "leader": "leader_left",  "follower": "follower_left"  },
- *     { "leader": "leader_right", "follower": "follower_right" }
+ *     { "leader": "leader_left",  "follower": "follower_left",  "space": "joint" },
+ *     { "leader": "leader_right", "follower": "follower_right", "space": "joint" }
  *   ]
  * }
  *
- * The teleop loop mirrors each leader arm's state to its paired follower at
- * the specified rate. Set "enabled" to false to skip teleop (e.g. replay
- * mode).
+ * The teleop loop mirrors each leader's state to its paired follower at the
+ * specified rate. Set "enabled" to false to skip teleop (e.g. replay mode).
+ * The "space" field on each pair selects the teleop space ("joint" or
+ * "cartesian"); it defaults to "joint" if omitted.
  *
- * Per-arm tuning (staging pose, trajectory time, gripper tolerance, etc.)
- * lives in each arm's own hardware configuration block — see the relevant
- * component headers for supported fields.
+ * Per-arm tuning (staging pose, trajectory time, etc.) lives in each arm's
+ * own hardware configuration block.
  */
 struct TeleoperationConfig : public BaseConfig {
   /// @brief Whether teleoperation is active

--- a/include/trossen_sdk/hw/teleop/teleop_factory.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_factory.hpp
@@ -2,25 +2,13 @@
  * @file teleop_factory.hpp
  * @brief Factory for constructing TeleopControllers from the global config.
  *
- * Mirrors the SessionManager pattern: read teleop wiring from
- * `GlobalConfig::instance()`, resolve hardware references via
- * `ActiveHardwareRegistry`, and return ready-to-start `TeleopController`
- * instances.
+ * Reads the teleop block from `GlobalConfig::instance()`, resolves the
+ * leader and follower referenced in each pair via `ActiveHardwareRegistry`,
+ * and returns one ready-to-run `TeleopController` per pair.
  *
- * Prerequisite: `SdkConfig::populate_global_config()` must have been called,
- * and the hardware components referenced in the teleop pairs must already be
- * registered in `ActiveHardwareRegistry` (typically by `HardwareRegistry::create`
- * with `mark_active=true`).
- *
- * Usage:
- * @code
- *   auto cfg = trossen::configuration::SdkConfig::from_json(j);
- *   cfg.populate_global_config();
- *   // ... create hardware via HardwareRegistry::create(..., mark_active=true) ...
- *
- *   auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
- *   for (auto& c : controllers) c->start();
- * @endcode
+ * Prerequisite: the global config must already carry the teleop section,
+ * and the hardware components referenced in each pair must be present in
+ * `ActiveHardwareRegistry`.
  */
 
 #ifndef TROSSEN_SDK__HW__TELEOP__TELEOP_FACTORY_HPP_
@@ -39,16 +27,16 @@ namespace trossen::hw::teleop {
  * Behavior:
  * - If teleop is disabled (`enabled = false`), returns an empty vector.
  * - For each pair: looks up `leader` and `follower` IDs in
- *   `ActiveHardwareRegistry`. If the leader is missing, prints a warning and
- *   skips that pair. If the follower is missing or absent, the controller is
- *   constructed in leader-only mode (UMI-style).
- * - If a referenced component does not implement `TeleopCapable` (e.g. a
- *   camera was named by mistake), prints a warning and skips that pair.
- * - Each returned controller is constructed but **not yet started**; the
- *   caller is responsible for invoking `start()` and `stop()`.
+ *   `ActiveHardwareRegistry`. If the leader is missing, prints a warning
+ *   and skips that pair. If the follower is missing or absent, the
+ *   controller is constructed in leader-only mode.
+ * - If a referenced component does not implement `TeleopCapable`, prints
+ *   a warning and skips that pair.
+ * - Each returned controller is constructed but not yet running; the
+ *   caller drives its lifecycle via `prepare_teleop()`, `teleop()`,
+ *   `reset_teleop()`, and `stop_teleop()`.
  *
- * Throws `std::runtime_error` if the global "teleop" key is missing
- * (i.e. `populate_global_config()` was never called).
+ * Throws `std::runtime_error` if the global "teleop" key is missing.
  */
 std::vector<std::unique_ptr<TeleopController>>
 create_controllers_from_global_config();

--- a/include/trossen_sdk/hw/teleop/teleop_factory.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_factory.hpp
@@ -1,0 +1,58 @@
+/**
+ * @file teleop_factory.hpp
+ * @brief Factory for constructing TeleopControllers from the global config.
+ *
+ * Mirrors the SessionManager pattern: read teleop wiring from
+ * `GlobalConfig::instance()`, resolve hardware references via
+ * `ActiveHardwareRegistry`, and return ready-to-start `TeleopController`
+ * instances.
+ *
+ * Prerequisite: `SdkConfig::populate_global_config()` must have been called,
+ * and the hardware components referenced in the teleop pairs must already be
+ * registered in `ActiveHardwareRegistry` (typically by `HardwareRegistry::create`
+ * with `mark_active=true`).
+ *
+ * Usage:
+ * @code
+ *   auto cfg = trossen::configuration::SdkConfig::from_json(j);
+ *   cfg.populate_global_config();
+ *   // ... create hardware via HardwareRegistry::create(..., mark_active=true) ...
+ *
+ *   auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+ *   for (auto& c : controllers) c->start();
+ * @endcode
+ */
+
+#ifndef TROSSEN_SDK__HW__TELEOP__TELEOP_FACTORY_HPP_
+#define TROSSEN_SDK__HW__TELEOP__TELEOP_FACTORY_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "trossen_sdk/hw/teleop/teleop_controller.hpp"
+
+namespace trossen::hw::teleop {
+
+/**
+ * @brief Construct one TeleopController per pair declared in the global config.
+ *
+ * Behavior:
+ * - If teleop is disabled (`enabled = false`), returns an empty vector.
+ * - For each pair: looks up `leader` and `follower` IDs in
+ *   `ActiveHardwareRegistry`. If the leader is missing, prints a warning and
+ *   skips that pair. If the follower is missing or absent, the controller is
+ *   constructed in leader-only mode (UMI-style).
+ * - If a referenced component does not implement `TeleopCapable` (e.g. a
+ *   camera was named by mistake), prints a warning and skips that pair.
+ * - Each returned controller is constructed but **not yet started**; the
+ *   caller is responsible for invoking `start()` and `stop()`.
+ *
+ * Throws `std::runtime_error` if the global "teleop" key is missing
+ * (i.e. `populate_global_config()` was never called).
+ */
+std::vector<std::unique_ptr<TeleopController>>
+create_controllers_from_global_config();
+
+}  // namespace trossen::hw::teleop
+
+#endif  // TROSSEN_SDK__HW__TELEOP__TELEOP_FACTORY_HPP_

--- a/src/hw/teleop/teleop_factory.cpp
+++ b/src/hw/teleop/teleop_factory.cpp
@@ -1,0 +1,87 @@
+/**
+ * @file teleop_factory.cpp
+ * @brief Implementation of create_controllers_from_global_config()
+ */
+
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
+
+#include <iostream>
+#include <stdexcept>
+#include <utility>
+
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/types/teleop_config.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+
+namespace trossen::hw::teleop {
+
+namespace {
+
+TeleopCapable::Space parse_space(const std::string& s) {
+  if (auto space = space_from_name(s)) {
+    return *space;
+  }
+  throw std::invalid_argument(
+    "teleop pair: unknown space '" + s +
+    "' (must match one of the names in kSpaceDescriptors)");
+}
+
+}  // namespace
+
+std::vector<std::unique_ptr<TeleopController>>
+create_controllers_from_global_config() {
+  auto cfg = trossen::configuration::GlobalConfig::instance()
+               .get_as<trossen::configuration::TeleoperationConfig>("teleop");
+
+  std::vector<std::unique_ptr<TeleopController>> controllers;
+  if (!cfg->enabled) {
+    return controllers;
+  }
+
+  std::cout << "Starting teleop controllers...\n";
+  for (const auto& pair : cfg->pairs) {
+    auto leader_hw = ActiveHardwareRegistry::get(pair.leader);
+    if (!leader_hw) {
+      std::cout << "  [warn] Leader '" << pair.leader
+                << "' not registered, skipping pair\n";
+      continue;
+    }
+    auto leader = as_capable<TeleopCapable>(leader_hw);
+    if (!leader) {
+      std::cout << "  [warn] Leader '" << pair.leader
+                << "' is not teleop-capable, skipping pair\n";
+      continue;
+    }
+
+    std::shared_ptr<TeleopCapable> follower;
+    if (!pair.follower.empty()) {
+      auto follower_hw = ActiveHardwareRegistry::get(pair.follower);
+      if (!follower_hw) {
+        std::cout << "  [warn] Follower '" << pair.follower
+                  << "' not registered, running leader-only for '"
+                  << pair.leader << "'\n";
+      } else {
+        follower = as_capable<TeleopCapable>(follower_hw);
+        if (!follower) {
+          std::cout << "  [warn] Follower '" << pair.follower
+                    << "' is not teleop-capable, running leader-only for '"
+                    << pair.leader << "'\n";
+        }
+      }
+    }
+
+    TeleopController::Config tc{};
+    tc.space = parse_space(pair.space);
+    tc.control_rate_hz = cfg->rate_hz;
+    controllers.push_back(std::make_unique<TeleopController>(
+      std::move(leader), std::move(follower), std::move(tc)));
+
+    std::cout << "  [ok] " << pair.leader << " -> "
+              << (pair.follower.empty() ? "(none)" : pair.follower)
+              << " @ " << cfg->rate_hz << " Hz (" << pair.space << ")\n";
+  }
+  return controllers;
+}
+
+}  // namespace trossen::hw::teleop

--- a/src/hw/teleop/teleop_factory.cpp
+++ b/src/hw/teleop/teleop_factory.cpp
@@ -39,7 +39,7 @@ create_controllers_from_global_config() {
     return controllers;
   }
 
-  std::cout << "Starting teleop controllers...\n";
+  std::cout << "Constructing teleop controllers...\n";
   for (const auto& pair : cfg->pairs) {
     auto leader_hw = ActiveHardwareRegistry::get(pair.leader);
     if (!leader_hw) {
@@ -71,15 +71,23 @@ create_controllers_from_global_config() {
       }
     }
 
-    TeleopController::Config tc{};
-    tc.space = parse_space(pair.space);
-    tc.control_rate_hz = cfg->rate_hz;
-    controllers.push_back(std::make_unique<TeleopController>(
-      std::move(leader), std::move(follower), std::move(tc)));
+    try {
+      TeleopController::Config tc{};
+      tc.space = parse_space(pair.space);
+      tc.control_rate_hz = cfg->rate_hz;
+      controllers.push_back(std::make_unique<TeleopController>(
+        std::move(leader), std::move(follower), std::move(tc)));
 
-    std::cout << "  [ok] " << pair.leader << " -> "
-              << (pair.follower.empty() ? "(none)" : pair.follower)
-              << " @ " << cfg->rate_hz << " Hz (" << pair.space << ")\n";
+      const std::string follower_label =
+        pair.follower.empty() ? "(none)"
+        : (follower ? pair.follower : pair.follower + " (leader-only)");
+      std::cout << "  [ok] " << pair.leader << " -> " << follower_label
+                << " @ " << cfg->rate_hz << " Hz (" << pair.space << ")\n";
+    } catch (const std::exception& e) {
+      std::cout << "  [warn] Failed to create pair '" << pair.leader
+                << "' -> '" << pair.follower << "' (" << pair.space
+                << "): " << e.what() << ", skipping\n";
+    }
   }
   return controllers;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,9 @@ target_link_libraries(test_teleop_space_helpers PRIVATE trossen_sdk GTest::gtest
 add_executable(test_teleop_controller test_teleop_controller.cpp)
 target_link_libraries(test_teleop_controller PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_teleop_config test_teleop_config.cpp)
+target_link_libraries(test_teleop_config PRIVATE trossen_sdk GTest::gtest_main)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -103,3 +106,4 @@ gtest_discover_tests(test_keyboard_input_utils)
 gtest_discover_tests(test_announce)
 gtest_discover_tests(test_teleop_space_helpers)
 gtest_discover_tests(test_teleop_controller)
+gtest_discover_tests(test_teleop_config)

--- a/tests/test_teleop_config.cpp
+++ b/tests/test_teleop_config.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file test_teleop_config.cpp
+ * @brief Unit tests for TeleoperationConfig and TeleoperationPair parsing.
+ */
+
+#include "gtest/gtest.h"
+
+#include "nlohmann/json.hpp"
+#include "trossen_sdk/configuration/types/teleop_config.hpp"
+
+namespace {
+
+using trossen::configuration::TeleoperationConfig;
+using trossen::configuration::TeleoperationPair;
+
+TEST(TeleoperationPairTest, DefaultSpaceIsJoint) {
+  auto j = nlohmann::json::parse(R"({ "leader": "l", "follower": "f" })");
+  auto p = TeleoperationPair::from_json(j);
+  EXPECT_EQ(p.leader, "l");
+  EXPECT_EQ(p.follower, "f");
+  EXPECT_EQ(p.space, "joint");
+}
+
+TEST(TeleoperationPairTest, ExplicitSpace) {
+  auto j = nlohmann::json::parse(
+    R"({ "leader": "l", "follower": "f", "space": "cartesian" })");
+  auto p = TeleoperationPair::from_json(j);
+  EXPECT_EQ(p.space, "cartesian");
+}
+
+TEST(TeleoperationConfigTest, Defaults) {
+  TeleoperationConfig c = TeleoperationConfig::from_json(nlohmann::json::object());
+  EXPECT_TRUE(c.enabled);
+  EXPECT_FLOAT_EQ(c.rate_hz, 1000.0f);
+  EXPECT_TRUE(c.pairs.empty());
+}
+
+TEST(TeleoperationConfigTest, FullParse) {
+  auto j = nlohmann::json::parse(R"({
+    "enabled": false,
+    "rate_hz": 500.0,
+    "pairs": [
+      { "leader": "a", "follower": "b", "space": "cartesian" },
+      { "leader": "c", "follower": "d" }
+    ]
+  })");
+  auto c = TeleoperationConfig::from_json(j);
+  EXPECT_FALSE(c.enabled);
+  EXPECT_FLOAT_EQ(c.rate_hz, 500.0f);
+  ASSERT_EQ(c.pairs.size(), 2);
+  EXPECT_EQ(c.pairs[0].space, "cartesian");
+  EXPECT_EQ(c.pairs[1].space, "joint");  // default
+}
+
+}  // namespace


### PR DESCRIPTION
Adds the JSON schema for the teleop block (pairings, rate, space) plus a factory that builds controllers straight from the global config. This is the glue so a user can describe their setup in JSON and get working controllers back without manually constructing anything.