### PR TITLE
trossen_arm: implement TeleopCapable with adapter views

### DIFF
--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -1,26 +1,38 @@
 /**
  * @file trossen_arm_component.hpp
- * @brief Hardware component wrapper for Trossen Robotics arms
+ * @brief Hardware component wrapper for Trossen Robotics arms.
  */
 
 #ifndef TROSSEN_SDK__HW__ARM__TROSSEN_ARM_COMPONENT_HPP_
 #define TROSSEN_SDK__HW__ARM__TROSSEN_ARM_COMPONENT_HPP_
 
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "libtrossen_arm/trossen_arm.hpp"
 
 #include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
 
 namespace trossen::hw::arm {
 
 /**
- * @brief Hardware component for Trossen Robotics robot arms
+ * @brief Hardware component for Trossen Robotics robot arms.
  *
  * Wraps trossen_arm::TrossenArmDriver and provides JSON configuration.
+ *
+ * Implements teleop::TeleopCapable and supports both joint and cartesian
+ * teleop spaces. Because C++ cannot disambiguate two same-signature virtual
+ * `read()`/`write()` methods inherited from sibling bases (JointSpaceTeleop
+ * and CartesianSpaceTeleop both provide TeleopSpaceIO), each space is
+ * exposed through a small nested adapter sub-object (JointView, CartView)
+ * whose `read()` / `write()` forward to private space-specific helpers on
+ * this class. The controller selects the active space via `as_space_io()`.
  */
-class TrossenArmComponent : public HardwareComponent {
+class TrossenArmComponent : public HardwareComponent,
+                            public teleop::TeleopCapable {
 public:
   /**
    * @brief Constructor
@@ -37,7 +49,10 @@ public:
    * {
    *   "ip_address": "192.168.1.100",
    *   "model": "wxai_v0",
-   *   "end_effector": "wxai_v0_follower"
+   *   "end_effector": "wxai_v0_follower",
+   *   "gripper_tolerance": 0.01,          // optional, follower arms
+   *   "staged_position": [0, 1.0, 0.5, 0.6, 0, 0, 0],  // optional, joint-space
+   *   "teleop_moving_time_s": 2.0         // optional, default 2.0
    * }
    *
    * @param config JSON configuration object
@@ -66,18 +81,77 @@ public:
    */
   std::shared_ptr<trossen_arm::TrossenArmDriver> get_hardware() { return driver_; }
 
+  // ── TeleopCapable: space-view accessor ───────────────────────────────────
+  // Returns the adapter view for the requested space. Extend the switch to
+  // add a new space.
+  teleop::TeleopSpaceIO* as_space_io(Space space) override {
+    switch (space) {
+      case Space::Joint:     return &joint_view_;
+      case Space::Cartesian: return &cart_view_;
+    }
+    return nullptr;
+  }
+
+  // ── TeleopCapable: shared lifecycle ──────────────────────────────────────
+  // Space-agnostic lifecycle hooks. All inputs (role, staging pose,
+  // trajectory time) come from members populated at configure() time.
+  void prepare_for_teleop() override;
+  void end_teleop() override;
+  void stage() override;
+
 private:
-  /// @brief Underlying Trossen arm driver
+  // Space-specific IO helpers. Called by the nested adapter views.
+  std::vector<float> read_joint();
+  void               write_joint(const std::vector<float>& cmd);
+
+  std::vector<float> read_cartesian();
+  void               write_cartesian(const std::vector<float>& cmd);
+
+  // Adapter views: implement the space child classes and forward to the
+  // private helpers above. See the class-level docstring for why this
+  // indirection is necessary.
+  struct JointView : teleop::JointSpaceTeleop {
+    TrossenArmComponent* self;
+    explicit JointView(TrossenArmComponent* s) : self(s) {}
+    std::vector<float> read() override {
+      return self->read_joint();
+    }
+    void write(const std::vector<float>& cmd) override {
+      self->write_joint(cmd);
+    }
+  };
+
+  struct CartView : teleop::CartesianSpaceTeleop {
+    TrossenArmComponent* self;
+    explicit CartView(TrossenArmComponent* s) : self(s) {}
+    std::vector<float> read() override {
+      return self->read_cartesian();
+    }
+    void write(const std::vector<float>& cmd) override {
+      self->write_cartesian(cmd);
+    }
+  };
+
+  JointView joint_view_{this};
+  CartView  cart_view_{this};
+
   std::shared_ptr<trossen_arm::TrossenArmDriver> driver_;
-
-  /// @brief Arm model
   std::string model_str_;
-
-  /// @brief End effector type
   std::string end_effector_str_;
-
-  /// @brief IP address of the arm
   std::string ip_address_;
+
+  /// True if this arm is configured with a leader end-effector. Determines
+  /// whether prepare_for_teleop() enters gravity-compensation mode (leader)
+  /// or position-mode alignment (follower).
+  bool is_leader_{false};
+
+  /// Joint-space pose this arm moves to at session start (via stage()).
+  /// Empty = no staging.
+  std::vector<float> staged_position_;
+
+  /// Trajectory time used by stage() and the end_teleop() rest move. Also
+  /// used by follower arms when aligning in prepare_for_teleop().
+  float teleop_moving_time_s_{2.0f};
 };
 
 }  // namespace trossen::hw::arm

--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -22,14 +22,10 @@ namespace trossen::hw::arm {
  * @brief Hardware component for Trossen Robotics robot arms.
  *
  * Wraps trossen_arm::TrossenArmDriver and provides JSON configuration.
- *
  * Implements teleop::TeleopCapable and supports both joint and cartesian
- * teleop spaces. Because C++ cannot disambiguate two same-signature virtual
- * `read()`/`write()` methods inherited from sibling bases (JointSpaceTeleop
- * and CartesianSpaceTeleop both provide TeleopSpaceIO), each space is
- * exposed through a small nested adapter sub-object (JointView, CartView)
- * whose `read()` / `write()` forward to private space-specific helpers on
- * this class. The controller selects the active space via `as_space_io()`.
+ * teleop spaces; each space is exposed through a nested adapter sub-object
+ * (JointView, CartView) that forwards to space-specific helpers on this
+ * class. The controller selects the active space via `as_space_io()`.
  */
 class TrossenArmComponent : public HardwareComponent,
                             public teleop::TeleopCapable {
@@ -50,7 +46,6 @@ public:
    *   "ip_address": "192.168.1.100",
    *   "model": "wxai_v0",
    *   "end_effector": "wxai_v0_follower",
-   *   "gripper_tolerance": 0.01,          // optional, follower arms
    *   "staged_position": [0, 1.0, 0.5, 0.6, 0, 0, 0],  // optional, joint-space
    *   "teleop_moving_time_s": 2.0         // optional, default 2.0
    * }

--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -6,7 +6,6 @@
 #ifndef TROSSEN_SDK__HW__ARM__TROSSEN_ARM_COMPONENT_HPP_
 #define TROSSEN_SDK__HW__ARM__TROSSEN_ARM_COMPONENT_HPP_
 
-#include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>
@@ -37,6 +36,13 @@ public:
    */
   explicit TrossenArmComponent(std::string identifier) : HardwareComponent(identifier) {}
   ~TrossenArmComponent() override = default;
+
+  // Non-copyable, non-movable: the nested adapter views hold raw back-
+  // pointers to `this` that would dangle after a copy or move.
+  TrossenArmComponent(const TrossenArmComponent&) = delete;
+  TrossenArmComponent& operator=(const TrossenArmComponent&) = delete;
+  TrossenArmComponent(TrossenArmComponent&&) = delete;
+  TrossenArmComponent& operator=(TrossenArmComponent&&) = delete;
 
   /**
    * @brief Configure the arm from JSON
@@ -144,8 +150,7 @@ private:
   /// Empty = no staging.
   std::vector<float> staged_position_;
 
-  /// Trajectory time used by stage() and the end_teleop() rest move. Also
-  /// used by follower arms when aligning in prepare_for_teleop().
+  /// Trajectory time used by stage() and the end_teleop() rest move.
   float teleop_moving_time_s_{2.0f};
 };
 

--- a/src/hw/arm/trossen_arm_component.cpp
+++ b/src/hw/arm/trossen_arm_component.cpp
@@ -1,6 +1,6 @@
 /**
  * @file trossen_arm_component.cpp
- * @brief Implementation of TrossenArmComponent
+ * @brief Implementation of TrossenArmComponent.
  */
 
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
@@ -11,8 +11,6 @@
 namespace trossen::hw::arm {
 
 void TrossenArmComponent::configure(const nlohmann::json& config) {
-  // Extract required configuration
-
   // Parse IP address
   if (!config.contains("ip_address")) {
     throw std::runtime_error("TrossenArmComponent: 'ip_address' is required in config");
@@ -39,8 +37,10 @@ void TrossenArmComponent::configure(const nlohmann::json& config) {
   end_effector_str_ = config.at("end_effector").get<std::string>();
   if (end_effector_str_ == "wxai_v0_leader") {
     end_effector = trossen_arm::StandardEndEffector::wxai_v0_leader;
+    is_leader_ = true;
   } else if (end_effector_str_ == "wxai_v0_follower") {
     end_effector = trossen_arm::StandardEndEffector::wxai_v0_follower;
+    is_leader_ = false;
   } else {
     throw std::runtime_error("TrossenArmComponent: Unknown end_effector: " + end_effector_str_);
   }
@@ -55,6 +55,25 @@ void TrossenArmComponent::configure(const nlohmann::json& config) {
       "TrossenArmComponent: Failed to configure driver: " + std::string(e.what()));
   }
 
+  // Optional gripper position tolerance. Primarily useful on follower arms
+  // to relax position tracking on the gripper joint.
+  if (config.contains("gripper_tolerance")) {
+    const float tol = config.at("gripper_tolerance").get<float>();
+    if (tol >= 0.0f) {
+      auto limits = driver_->get_joint_limits();
+      limits[driver_->get_num_joints() - 1].position_tolerance = tol;
+      driver_->set_joint_limits(limits);
+    }
+  }
+
+  // Optional teleop tuning — used by stage() / end_teleop() / prepare_for_teleop().
+  if (config.contains("staged_position")) {
+    staged_position_ = config.at("staged_position").get<std::vector<float>>();
+  }
+  if (config.contains("teleop_moving_time_s")) {
+    teleop_moving_time_s_ = config.at("teleop_moving_time_s").get<float>();
+  }
+
   // TODO(lukeschmitt-tr): Can do other configuration like joint characteristics here if needed
 }
 
@@ -67,6 +86,73 @@ nlohmann::json TrossenArmComponent::get_info() const {
   };
 
   return info;
+}
+
+// ── Space-specific IO ────────────────────────────────────────────────────
+
+std::vector<float> TrossenArmComponent::read_joint() {
+  if (!driver_) return {};
+  const auto& positions = driver_->get_robot_output().joint.all.positions;
+  return std::vector<float>(positions.begin(), positions.end());
+}
+
+void TrossenArmComponent::write_joint(const std::vector<float>& cmd) {
+  if (!driver_) return;
+  std::vector<double> pos_d(cmd.begin(), cmd.end());
+  driver_->set_all_positions(pos_d, 0.0, false);
+}
+
+std::vector<float> TrossenArmComponent::read_cartesian() {
+  if (!driver_) return {};
+  const auto& p = driver_->get_robot_output().cartesian.positions;
+  return std::vector<float>(p.begin(), p.end());
+}
+
+void TrossenArmComponent::write_cartesian(const std::vector<float>& cmd) {
+  if (!driver_ || cmd.size() < 6) return;
+  std::array<double, 6> goal;
+  std::copy_n(cmd.begin(), 6, goal.begin());
+  driver_->set_cartesian_positions(
+    goal, trossen_arm::InterpolationSpace::cartesian, 0.0, false);
+}
+
+// ── Shared lifecycle ─────────────────────────────────────────────────────
+
+void TrossenArmComponent::prepare_for_teleop() {
+  if (!driver_) return;
+  if (is_leader_) {
+    // Leader: enable gravity compensation.
+    driver_->set_all_modes(trossen_arm::Mode::external_effort);
+    std::vector<double> zeros(driver_->get_num_joints(), 0.0);
+    driver_->set_all_external_efforts(zeros, 0.0, false);
+    return;
+  }
+  // Follower: enter position mode. The mirror loop drives the follower's
+  // joints from here; staging aligns both arms to the same pose so no
+  // explicit runtime alignment is required.
+  driver_->set_all_modes(trossen_arm::Mode::position);
+}
+
+void TrossenArmComponent::end_teleop() {
+  if (!driver_) return;
+  // Neutralize first (safe regardless of current mode), then gracefully
+  // return to rest over the configured trajectory time, then release the
+  // driver.
+  driver_->set_all_modes(trossen_arm::Mode::idle);
+  driver_->set_all_modes(trossen_arm::Mode::position);
+  driver_->set_all_positions(
+    std::vector<double>(driver_->get_num_joints(), 0.0),
+    teleop_moving_time_s_, true);
+  driver_->cleanup();
+  driver_.reset();
+}
+
+void TrossenArmComponent::stage() {
+  if (!driver_ || staged_position_.empty()) return;
+  driver_->set_all_modes(trossen_arm::Mode::position);
+  std::vector<double> pos_d(staged_position_.begin(), staged_position_.end());
+  // Non-blocking so multiple arms can stage in parallel.
+  driver_->set_all_positions(pos_d, teleop_moving_time_s_, false);
 }
 
 REGISTER_HARDWARE(TrossenArmComponent, "trossen_arm")

--- a/src/hw/arm/trossen_arm_component.cpp
+++ b/src/hw/arm/trossen_arm_component.cpp
@@ -55,17 +55,6 @@ void TrossenArmComponent::configure(const nlohmann::json& config) {
       "TrossenArmComponent: Failed to configure driver: " + std::string(e.what()));
   }
 
-  // Optional gripper position tolerance. Primarily useful on follower arms
-  // to relax position tracking on the gripper joint.
-  if (config.contains("gripper_tolerance")) {
-    const float tol = config.at("gripper_tolerance").get<float>();
-    if (tol >= 0.0f) {
-      auto limits = driver_->get_joint_limits();
-      limits[driver_->get_num_joints() - 1].position_tolerance = tol;
-      driver_->set_joint_limits(limits);
-    }
-  }
-
   // Optional teleop tuning — used by stage() / end_teleop() / prepare_for_teleop().
   if (config.contains("staged_position")) {
     staged_position_ = config.at("staged_position").get<std::vector<float>>();
@@ -128,8 +117,7 @@ void TrossenArmComponent::prepare_for_teleop() {
     return;
   }
   // Follower: enter position mode. The mirror loop drives the follower's
-  // joints from here; staging aligns both arms to the same pose so no
-  // explicit runtime alignment is required.
+  // joints from here.
   driver_->set_all_modes(trossen_arm::Mode::position);
 }
 

--- a/src/hw/arm/trossen_arm_component.cpp
+++ b/src/hw/arm/trossen_arm_component.cpp
@@ -5,6 +5,8 @@
 
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include <algorithm>
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -55,12 +57,23 @@ void TrossenArmComponent::configure(const nlohmann::json& config) {
       "TrossenArmComponent: Failed to configure driver: " + std::string(e.what()));
   }
 
-  // Optional teleop tuning — used by stage() / end_teleop() / prepare_for_teleop().
+  // Optional teleop tuning — used by stage() / end_teleop().
   if (config.contains("staged_position")) {
-    staged_position_ = config.at("staged_position").get<std::vector<float>>();
+    auto pos = config.at("staged_position").get<std::vector<float>>();
+    if (pos.size() != static_cast<size_t>(driver_->get_num_joints())) {
+      throw std::runtime_error(
+        "TrossenArmComponent: 'staged_position' length (" +
+        std::to_string(pos.size()) + ") must match joint count (" +
+        std::to_string(driver_->get_num_joints()) + ")");
+    }
+    staged_position_ = std::move(pos);
   }
   if (config.contains("teleop_moving_time_s")) {
     teleop_moving_time_s_ = config.at("teleop_moving_time_s").get<float>();
+    if (teleop_moving_time_s_ < 0.0f || !std::isfinite(teleop_moving_time_s_)) {
+      throw std::runtime_error(
+        "TrossenArmComponent: 'teleop_moving_time_s' must be non-negative and finite");
+    }
   }
 
   // TODO(lukeschmitt-tr): Can do other configuration like joint characteristics here if needed
@@ -87,6 +100,12 @@ std::vector<float> TrossenArmComponent::read_joint() {
 
 void TrossenArmComponent::write_joint(const std::vector<float>& cmd) {
   if (!driver_) return;
+  if (cmd.size() != static_cast<size_t>(driver_->get_num_joints())) {
+    throw std::runtime_error(
+      "TrossenArmComponent::write_joint: expected " +
+      std::to_string(driver_->get_num_joints()) + " joints, got " +
+      std::to_string(cmd.size()));
+  }
   std::vector<double> pos_d(cmd.begin(), cmd.end());
   driver_->set_all_positions(pos_d, 0.0, false);
 }


### PR DESCRIPTION
Retrofits TrossenArmComponent to participate in teleop. Trossen arms support both joint and cartesian teleop, and because C++ can't let one class resolve two same-signature virtual methods from sibling bases, the arm owns two tiny forwarder sub-objects (JointView, CartView) — the adapter-view pattern. Also derives leader/follower role from the arm's end_effector config so the controller stays role-agnostic.