### PR TITLE
so101_arm: implement JointSpaceTeleop

### DIFF
--- a/include/trossen_sdk/hw/arm/so101_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/so101_arm_component.hpp
@@ -1,21 +1,26 @@
 /**
  * @file so101_arm_component.hpp
- * @brief Hardware component wrapper for SO101 arms
-
+ * @brief Hardware component wrapper for SO101 arms.
  */
 #ifndef TROSSEN_SDK__HW__ARM__SO101_ARM_COMPONENT_HPP_
 #define TROSSEN_SDK__HW__ARM__SO101_ARM_COMPONENT_HPP_
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 #include "trossen_sdk/hw/arm/so101_arm_driver.hpp"
 #include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
 namespace trossen::hw::arm {
 /**
- * @brief Hardware component for SO101 arms
+ * @brief Hardware component for SO101 arms.
  *
- * Wraps SO101ArmDriver and provides JSON configuration.
+ * Wraps SO101ArmDriver and provides JSON configuration. Inherits
+ * JointSpaceTeleop directly, providing joint-space teleop IO without
+ * the adapter pattern needed by multi-space components.
  */
-class SO101ArmComponent : public HardwareComponent {
+class SO101ArmComponent : public HardwareComponent,
+                          public teleop::JointSpaceTeleop {
 public:
   /**
    * @brief Constructor
@@ -56,10 +61,23 @@ public:
    */
   std::shared_ptr<SO101ArmDriver> get_driver() const { return driver_; }
 
+  // ── JointSpaceTeleop IO (hot loop) ────────────────────────────────────
+  std::vector<float> read() override;
+  void write(const std::vector<float>& cmd) override;
+
+  // ── TeleopCapable lifecycle ──────────────────────────────────────────
+  void prepare_for_teleop() override;
+  void end_teleop() override;
+  void stage() override;
+
 private:
   std::shared_ptr<SO101ArmDriver> driver_;
   std::string port_;
   SO101EndEffector end_effector_;
+
+  /// Joint-space pose this arm moves to at session start (via stage()).
+  /// Empty = no staging.
+  std::vector<float> staged_position_;
 };
 }  // namespace trossen::hw::arm
 #endif  // TROSSEN_SDK__HW__ARM__SO101_ARM_COMPONENT_HPP_

--- a/include/trossen_sdk/hw/arm/so101_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/so101_arm_component.hpp
@@ -16,8 +16,7 @@ namespace trossen::hw::arm {
  * @brief Hardware component for SO101 arms.
  *
  * Wraps SO101ArmDriver and provides JSON configuration. Inherits
- * JointSpaceTeleop directly, providing joint-space teleop IO without
- * the adapter pattern needed by multi-space components.
+ * JointSpaceTeleop to expose joint-space teleop read/write.
  */
 class SO101ArmComponent : public HardwareComponent,
                           public teleop::JointSpaceTeleop {

--- a/include/trossen_sdk/hw/arm/so101_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/so101_arm_component.hpp
@@ -75,7 +75,8 @@ private:
   SO101EndEffector end_effector_;
 
   /// Joint-space pose this arm moves to at session start (via stage()).
-  /// Empty = no staging.
+  /// Values are in normalized servo units. Length must equal get_num_joints();
+  /// validated at configure() time. Empty = no staging.
   std::vector<float> staged_position_;
 };
 }  // namespace trossen::hw::arm

--- a/src/hw/arm/so101_arm_component.cpp
+++ b/src/hw/arm/so101_arm_component.cpp
@@ -1,6 +1,6 @@
 /**
  * @file so101_arm_component.cpp
- * @brief Implementation of SO101ArmComponent
+ * @brief Implementation of SO101ArmComponent.
  */
 
 #include "trossen_sdk/hw/arm/so101_arm_component.hpp"
@@ -31,6 +31,11 @@ void SO101ArmComponent::configure(const nlohmann::json& config) {
   if (!driver_->connect()) {
     throw std::runtime_error("Failed to connect to SO101 arm on port: " + port_);
   }
+
+  // Optional teleop staging pose.
+  if (config.contains("staged_position")) {
+    staged_position_ = config.at("staged_position").get<std::vector<float>>();
+  }
 }
 nlohmann::json SO101ArmComponent::get_info() const {
   nlohmann::json info;
@@ -42,4 +47,36 @@ nlohmann::json SO101ArmComponent::get_info() const {
   info["num_joints"] = driver_ ? driver_->get_num_joints() : 0;
   return info;
 }
+std::vector<float> SO101ArmComponent::read() {
+  if (!driver_) return {};
+  auto positions = driver_->get_joint_positions(true);
+  return std::vector<float>(positions.begin(), positions.end());
+}
+
+void SO101ArmComponent::write(const std::vector<float>& cmd) {
+  if (!driver_) return;
+  std::vector<double> pos_d(cmd.begin(), cmd.end());
+  driver_->set_joint_positions(pos_d, true);
+}
+
+void SO101ArmComponent::prepare_for_teleop() {
+  // SO101 has no teleop mode to enter — the mirror loop drives it
+  // directly. Staging puts both arms at the same pose, so no explicit
+  // runtime alignment is required.
+}
+
+void SO101ArmComponent::end_teleop() {
+  // Graceful shutdown: return to the zero pose. SO101 driver does not
+  // support trajectory timing; the move is blocking.
+  if (!driver_) return;
+  std::vector<double> zeros(driver_->get_num_joints(), 0.0);
+  driver_->set_joint_positions(zeros, true);
+}
+
+void SO101ArmComponent::stage() {
+  if (!driver_ || staged_position_.empty()) return;
+  std::vector<double> pos_d(staged_position_.begin(), staged_position_.end());
+  driver_->set_joint_positions(pos_d, true);
+}
+
 }  // namespace trossen::hw::arm

--- a/src/hw/arm/so101_arm_component.cpp
+++ b/src/hw/arm/so101_arm_component.cpp
@@ -32,9 +32,16 @@ void SO101ArmComponent::configure(const nlohmann::json& config) {
     throw std::runtime_error("Failed to connect to SO101 arm on port: " + port_);
   }
 
-  // Optional teleop staging pose.
+  // Optional teleop staging pose — length must match joint count.
   if (config.contains("staged_position")) {
-    staged_position_ = config.at("staged_position").get<std::vector<float>>();
+    auto pos = config.at("staged_position").get<std::vector<float>>();
+    if (pos.size() != static_cast<size_t>(driver_->get_num_joints())) {
+      throw std::runtime_error(
+        "SO101ArmComponent: 'staged_position' length (" +
+        std::to_string(pos.size()) + ") must match joint count (" +
+        std::to_string(driver_->get_num_joints()) + ")");
+    }
+    staged_position_ = std::move(pos);
   }
 }
 nlohmann::json SO101ArmComponent::get_info() const {
@@ -55,6 +62,12 @@ std::vector<float> SO101ArmComponent::read() {
 
 void SO101ArmComponent::write(const std::vector<float>& cmd) {
   if (!driver_) return;
+  if (cmd.size() != static_cast<size_t>(driver_->get_num_joints())) {
+    throw std::runtime_error(
+      "SO101ArmComponent::write: expected " +
+      std::to_string(driver_->get_num_joints()) + " joints, got " +
+      std::to_string(cmd.size()));
+  }
   std::vector<double> pos_d(cmd.begin(), cmd.end());
   driver_->set_joint_positions(pos_d, true);
 }
@@ -64,11 +77,16 @@ void SO101ArmComponent::prepare_for_teleop() {
 }
 
 void SO101ArmComponent::end_teleop() {
-  // Graceful shutdown: return to the zero pose. SO101 driver does not
-  // support trajectory timing; the move is blocking.
+  // Graceful shutdown: command the zero pose, then release the driver.
+  // SO101 does not support trajectory timing; the command is dispatched
+  // but does not wait for motion completion.
   if (!driver_) return;
   std::vector<double> zeros(driver_->get_num_joints(), 0.0);
   driver_->set_joint_positions(zeros, true);
+  if (driver_->is_connected()) {
+    driver_->disconnect();
+  }
+  driver_.reset();
 }
 
 void SO101ArmComponent::stage() {

--- a/src/hw/arm/so101_arm_component.cpp
+++ b/src/hw/arm/so101_arm_component.cpp
@@ -60,9 +60,7 @@ void SO101ArmComponent::write(const std::vector<float>& cmd) {
 }
 
 void SO101ArmComponent::prepare_for_teleop() {
-  // SO101 has no teleop mode to enter — the mirror loop drives it
-  // directly. Staging puts both arms at the same pose, so no explicit
-  // runtime alignment is required.
+  // SO101 has no teleop mode to enter — the mirror loop drives it directly.
 }
 
 void SO101ArmComponent::end_teleop() {


### PR DESCRIPTION
Same idea as PR 04 but easier: SO-101 only does joint-space teleop, so it inherits JointSpaceTeleop directly, no adapter views needed. A good reference for anyone adding a single-space arm in the future.