### PR TITLE
sdk_config: serialize teleop pair with space field

### DIFF
--- a/include/trossen_sdk/configuration/sdk_config.hpp
+++ b/include/trossen_sdk/configuration/sdk_config.hpp
@@ -39,7 +39,7 @@
  *   "teleop": {
  *     "enabled": true,
  *     "rate_hz": 1000.0,
- *     "pairs": [ { "leader": "<id>", "follower": "<id>" }, ... ]
+ *     "pairs": [ { "leader": "<id>", "follower": "<id>", "space": "joint" }, ... ]
  *   },
  *   "backend": {
  *     "root": "~/trossen_data",
@@ -131,9 +131,10 @@ struct SdkConfig {
   static SdkConfig from_json(const nlohmann::json& j);
 
   /**
-   * @brief Load session and backend configs into the GlobalConfig singleton
+   * @brief Load session, backend, and teleop configs into the GlobalConfig singleton
    *
-   * Must be called before constructing a SessionManager.
+   * Must be called before constructing a SessionManager or using the teleop
+   * factory.
    */
   void populate_global_config() const;
 };

--- a/src/configuration/sdk_config.cpp
+++ b/src/configuration/sdk_config.cpp
@@ -105,6 +105,24 @@ void SdkConfig::populate_global_config() const {
     gc_json["trossen_mcap_backend"] = bj;
   }
 
+  // Teleop (consumed by trossen::hw::teleop::create_controllers_from_global_config)
+  {
+    nlohmann::json tj;
+    tj["type"] = "teleop";
+    tj["enabled"] = teleop.enabled;
+    tj["rate_hz"] = teleop.rate_hz;
+    nlohmann::json pairs_j = nlohmann::json::array();
+    for (const auto& p : teleop.pairs) {
+      pairs_j.push_back({
+        {"leader",   p.leader},
+        {"follower", p.follower},
+        {"space",    p.space},
+      });
+    }
+    tj["pairs"] = pairs_j;
+    gc_json["teleop"] = tj;
+  }
+
   GlobalConfig::instance().load_from_json(gc_json);
 }
 


### PR DESCRIPTION
Small plumbing fix. The global-config serializer learns about the new per-pair space field so the config round-trips correctly through GlobalConfig.