### PR TITLE
examples: migrate to TeleopController lifecycle

### DIFF
--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -264,7 +264,7 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
 
   // ──────────────────────────────────────────────────────────
-  // Teleop controllers (constructor stages arms + applies tuning)
+  // Teleop controllers (constructor stages arms)
   // ──────────────────────────────────────────────────────────
 
   auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
@@ -273,7 +273,7 @@ int main(int argc, char** argv) {
   // Register lifecycle callbacks
   // ──────────────────────────────────────────────────────────
 
-  // Before each episode: summon follower to leader position
+  // Before each episode: let controllers run their pre-episode lifecycle
   mgr.on_pre_episode([&]() -> bool {
     for (auto& ctrl : controllers) ctrl->prepare_teleop();
     return true;

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -282,7 +282,9 @@ int main(int argc, char** argv) {
   // Episode started: begin mirroring (alongside recording)
   mgr.on_episode_started([&]() {
     for (auto& ctrl : controllers) ctrl->teleop();
-    std::cout << "Episode started - recording and mirroring active.\n";
+    std::cout << "Episode started - recording"
+              << (controllers.empty() ? "" : " and mirroring")
+              << " active.\n";
   });
 
   // Count depth-capable cameras once for sanity checks
@@ -314,6 +316,9 @@ int main(int argc, char** argv) {
   // Shutdown: stop mirror + return arms to rest
   mgr.on_pre_shutdown([&]() {
     for (auto& ctrl : controllers) ctrl->stop_teleop();
+    if (controllers.empty()) {
+      for (auto& [id, arm] : arm_components) arm->end_teleop();
+    }
   });
 
   // ──────────────────────────────────────────────────────────

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -43,15 +43,12 @@
 #include "trossen_sdk/hw/base/slate_base_component.hpp"
 #include "trossen_sdk/hw/base/slate_base_producer.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 
 #include "trossen_sdk/utils/app_utils.hpp"
-
-static const std::vector<double> STAGED_POSITIONS = {
-  0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0
-};
 
 static void print_usage(const char* program) {
   std::cout <<
@@ -190,28 +187,6 @@ int main(int argc, char** argv) {
     std::cout << "  [ok] SLATE mobile base configured\n";
   }
 
-  // Stage all arms to starting positions
-  const float moving_time_s = 2.0f;
-  for (const auto& [id, comp] : arm_components) {
-    auto driver = comp->get_hardware();
-    driver->set_all_modes(trossen_arm::Mode::position);
-    driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
-  }
-  std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-  std::cout << "  [ok] All arms staged to starting positions\n";
-
-  // Adjust gripper tolerance for follower arms
-  for (const auto& pair : cfg.teleop.pairs) {
-    auto it = arm_components.find(pair.follower);
-    if (it == arm_components.end()) {
-      continue;
-    }
-    auto driver = it->second->get_hardware();
-    auto limits = driver->get_joint_limits();
-    limits[driver->get_num_joints() - 1].position_tolerance = 0.01;
-    driver->set_joint_limits(limits);
-  }
-
   // ──────────────────────────────────────────────────────────
   // Session Manager + producers
   // ──────────────────────────────────────────────────────────
@@ -289,8 +264,26 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
 
   // ──────────────────────────────────────────────────────────
+  // Teleop controllers (constructor stages arms + applies tuning)
+  // ──────────────────────────────────────────────────────────
+
+  auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+
+  // ──────────────────────────────────────────────────────────
   // Register lifecycle callbacks
   // ──────────────────────────────────────────────────────────
+
+  // Before each episode: summon follower to leader position
+  mgr.on_pre_episode([&]() -> bool {
+    for (auto& ctrl : controllers) ctrl->prepare_teleop();
+    return true;
+  });
+
+  // Episode started: begin mirroring (alongside recording)
+  mgr.on_episode_started([&]() {
+    for (auto& ctrl : controllers) ctrl->teleop();
+    std::cout << "Episode started - recording and mirroring active.\n";
+  });
 
   // Count depth-capable cameras once for sanity checks
   int depth_cameras = 0;
@@ -298,11 +291,10 @@ int main(int argc, char** argv) {
     if (cam.use_depth) ++depth_cameras;
   }
 
-  mgr.on_episode_started([]() {
-    std::cout << "Episode started - recording is now active.\n";
-  });
-
+  // After each episode: reset mode (mirroring continues, no recording)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
+    for (auto& ctrl : controllers) ctrl->reset_teleop();
+
     const std::string file_path =
       trossen::utils::generate_episode_path(root, stats.current_episode_index);
     trossen::utils::print_episode_summary(file_path, stats);
@@ -319,28 +311,9 @@ int main(int argc, char** argv) {
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });
 
+  // Shutdown: stop mirror + return arms to rest
   mgr.on_pre_shutdown([&]() {
-    std::cout << "\nReturning arms to starting positions...\n";
-    for (const auto& [id, comp] : arm_components) {
-      auto driver = comp->get_hardware();
-      driver->set_all_modes(trossen_arm::Mode::position);
-      driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
-    }
-    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-    std::cout << "Moving arms to sleep positions...\n";
-    for (const auto& [id, comp] : arm_components) {
-      auto driver = comp->get_hardware();
-      driver->set_all_positions(
-        std::vector<double>(driver->get_num_joints(), 0.0), moving_time_s, false);
-    }
-    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-    std::cout << "Cleaning up arm drivers...\n";
-    for (const auto& [id, comp] : arm_components) {
-      comp->get_hardware()->cleanup();
-    }
-    std::cout << "  [ok] All arm drivers cleaned up\n";
+    for (auto& ctrl : controllers) ctrl->stop_teleop();
   });
 
   // ──────────────────────────────────────────────────────────
@@ -353,40 +326,6 @@ int main(int argc, char** argv) {
       break;
     }
 
-    if (cfg.teleop.enabled) {
-      std::cout << "\nLocking leader arms and moving followers to match...\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto leader_it = arm_components.find(pair.leader);
-        auto follower_it = arm_components.find(pair.follower);
-        if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-          continue;
-        }
-        auto leader_driver = leader_it->second->get_hardware();
-        auto follower_driver = follower_it->second->get_hardware();
-        leader_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_positions(
-          leader_driver->get_all_positions(), moving_time_s, false);
-      }
-      std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-      std::cout << "  [ok] Followers moved to match leaders\n";
-
-      std::cout << "\n!! Enabling teleop mode !!\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto it = arm_components.find(pair.leader);
-        if (it == arm_components.end()) {
-          continue;
-        }
-        auto driver = it->second->get_hardware();
-        driver->set_all_modes(trossen_arm::Mode::external_effort);
-        driver->set_all_external_efforts(
-          std::vector<double>(driver->get_num_joints(), 0.0), 0.0, false);
-        std::cout << "   " << pair.leader << ": gravity compensation -> "
-                  << pair.follower << " will mirror\n";
-      }
-      std::cout << "\n";
-    }
-
     mgr.print_episode_header();
 
     if (!mgr.start_episode()) {
@@ -394,26 +333,6 @@ int main(int argc, char** argv) {
     }
 
     std::cout << "Recording...\n";
-
-    // Teleop thread mirrors leader positions to followers at configured rate
-    std::thread teleop_thread([&]() {
-      if (!cfg.teleop.enabled) {
-        return;
-      }
-      const auto sleep_ns = static_cast<int64_t>(1e9 / cfg.teleop.rate_hz);
-      while (mgr.is_episode_active() && !trossen::utils::g_stop_requested) {
-        for (const auto& pair : cfg.teleop.pairs) {
-          auto leader_it = arm_components.find(pair.leader);
-          auto follower_it = arm_components.find(pair.follower);
-          if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-            continue;
-          }
-          follower_it->second->get_hardware()->set_all_positions(
-            leader_it->second->get_hardware()->get_all_positions(), 0.0f, false);
-        }
-        std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
-      }
-    });
 
     // Velocity polling thread keeps base_prod active during the episode
     std::thread velocity_thread([&]() {
@@ -430,9 +349,6 @@ int main(int argc, char** argv) {
 
     if (action == trossen::runtime::UserAction::kReRecord) {
       mgr.discard_current_episode();
-      if (teleop_thread.joinable()) {
-        teleop_thread.join();
-      }
       if (velocity_thread.joinable()) {
         velocity_thread.join();
       }
@@ -441,9 +357,6 @@ int main(int argc, char** argv) {
 
     if (mgr.is_episode_active()) {
       mgr.stop_episode();
-    }
-    if (teleop_thread.joinable()) {
-      teleop_thread.join();
     }
     if (velocity_thread.joinable()) {
       velocity_thread.join();

--- a/examples/trossen_solo_ai/config.json
+++ b/examples/trossen_solo_ai/config.json
@@ -4,27 +4,32 @@
   "hardware": {
     "arms": {
       "leader": {
-        "ip_address":   "192.168.1.2",
-        "model":        "wxai_v0",
-        "end_effector": "wxai_v0_leader"
+        "ip_address":          "192.168.1.2",
+        "model":               "wxai_v0",
+        "end_effector":        "wxai_v0_leader",
+        "staged_position":     [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
+        "teleop_moving_time_s": 2.0
       },
       "follower": {
-        "ip_address":   "192.168.1.4",
-        "model":        "wxai_v0",
-        "end_effector": "wxai_v0_follower"
+        "ip_address":          "192.168.1.4",
+        "model":               "wxai_v0",
+        "end_effector":        "wxai_v0_follower",
+        "gripper_tolerance":   0.01,
+        "staged_position":     [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
+        "teleop_moving_time_s": 2.0
       }
     },
     "cameras": [
       {
         "id":            "camera_main",
-        "serial_number": "128422271347",
+        "serial_number": "218622270304",
         "width":         640,
         "height":        480,
         "fps":           30
       },
       {
         "id":            "camera_wrist",
-        "serial_number": "218622270304",
+        "serial_number": "128422271347",
         "width":         640,
         "height":        480,
         "fps":           30
@@ -75,15 +80,15 @@
 
   "backend": {
     "root":             "~/.trossen_sdk",
-    "dataset_id":       "solo_dataset",
+    "dataset_id":       "solo_dataset_python",
     "compression":      "",
     "chunk_size_bytes": 4194304
   },
 
   "session": {
-    "max_duration":  10.0,
-    "max_episodes":  5,
+    "max_duration":  7.0,
+    "max_episodes":  60,
     "backend_type":  "trossen_mcap",
-    "reset_duration": 5.0
+    "reset_duration": 2.0
   }
 }

--- a/examples/trossen_solo_ai/config.json
+++ b/examples/trossen_solo_ai/config.json
@@ -14,7 +14,6 @@
         "ip_address":          "192.168.1.4",
         "model":               "wxai_v0",
         "end_effector":        "wxai_v0_follower",
-        "gripper_tolerance":   0.01,
         "staged_position":     [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
         "teleop_moving_time_s": 2.0
       }
@@ -22,14 +21,14 @@
     "cameras": [
       {
         "id":            "camera_main",
-        "serial_number": "218622270304",
+        "serial_number": "128422271347",
         "width":         640,
         "height":        480,
         "fps":           30
       },
       {
         "id":            "camera_wrist",
-        "serial_number": "128422271347",
+        "serial_number": "218622270304",
         "width":         640,
         "height":        480,
         "fps":           30
@@ -80,15 +79,15 @@
 
   "backend": {
     "root":             "~/.trossen_sdk",
-    "dataset_id":       "solo_dataset_python",
+    "dataset_id":       "solo_dataset",
     "compression":      "",
     "chunk_size_bytes": 4194304
   },
 
   "session": {
-    "max_duration":  7.0,
-    "max_episodes":  60,
+    "max_duration":  10.0,
+    "max_episodes":  5,
     "backend_type":  "trossen_mcap",
-    "reset_duration": 2.0
+    "reset_duration": 5.0
   }
 }

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -40,15 +40,12 @@
 #include "trossen_sdk/hw/arm/trossen_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 
 #include "trossen_sdk/utils/app_utils.hpp"
-
-static const std::vector<double> STAGED_POSITIONS = {
-  0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0
-};
 
 static void print_usage(const char* program) {
   std::cout <<
@@ -166,28 +163,6 @@ int main(int argc, char** argv) {
     std::cout << "  [ok] Arm [" << id << "] configured (" << arm_cfg.ip_address << ")\n";
   }
 
-  // Stage all arms to starting positions
-  const float moving_time_s = 2.0f;
-  for (const auto& [id, comp] : arm_components) {
-    auto driver = comp->get_hardware();
-    driver->set_all_modes(trossen_arm::Mode::position);
-    driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
-  }
-  std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-  std::cout << "  [ok] Arms staged to starting positions\n";
-
-  // Adjust gripper tolerance for follower arms
-  for (const auto& pair : cfg.teleop.pairs) {
-    auto it = arm_components.find(pair.follower);
-    if (it == arm_components.end()) {
-      continue;
-    }
-    auto driver = it->second->get_hardware();
-    auto limits = driver->get_joint_limits();
-    limits[driver->get_num_joints() - 1].position_tolerance = 0.01;
-    driver->set_joint_limits(limits);
-  }
-
   // ──────────────────────────────────────────────────────────
   // Session Manager + producers
   // ──────────────────────────────────────────────────────────
@@ -255,8 +230,26 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
 
   // ──────────────────────────────────────────────────────────
+  // Teleop controllers (constructor stages arms + applies tuning)
+  // ──────────────────────────────────────────────────────────
+
+  auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+
+  // ──────────────────────────────────────────────────────────
   // Register lifecycle callbacks
   // ──────────────────────────────────────────────────────────
+
+  // Before each episode: summon follower to leader position
+  mgr.on_pre_episode([&]() -> bool {
+    for (auto& ctrl : controllers) ctrl->prepare_teleop();
+    return true;
+  });
+
+  // Episode started: begin mirroring (alongside recording)
+  mgr.on_episode_started([&]() {
+    for (auto& ctrl : controllers) ctrl->teleop();
+    std::cout << "Episode started - recording and mirroring active.\n";
+  });
 
   // Count depth-capable cameras once for sanity checks
   int depth_cameras = 0;
@@ -264,11 +257,10 @@ int main(int argc, char** argv) {
     if (cam.use_depth) ++depth_cameras;
   }
 
-  mgr.on_episode_started([]() {
-    std::cout << "Episode started - recording is now active.\n";
-  });
-
+  // After each episode: reset mode (mirroring continues, no recording)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
+    for (auto& ctrl : controllers) ctrl->reset_teleop();
+
     const std::string file_path =
       trossen::utils::generate_episode_path(root, stats.current_episode_index);
     trossen::utils::print_episode_summary(file_path, stats);
@@ -285,28 +277,9 @@ int main(int argc, char** argv) {
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });
 
+  // Shutdown: stop mirror + return arms to rest
   mgr.on_pre_shutdown([&]() {
-    std::cout << "\nReturning arms to starting positions...\n";
-    for (const auto& [id, comp] : arm_components) {
-      auto driver = comp->get_hardware();
-      driver->set_all_modes(trossen_arm::Mode::position);
-      driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
-    }
-    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-    std::cout << "Moving arms to sleep positions...\n";
-    for (const auto& [id, comp] : arm_components) {
-      auto driver = comp->get_hardware();
-      driver->set_all_positions(
-        std::vector<double>(driver->get_num_joints(), 0.0), moving_time_s, false);
-    }
-    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-    std::cout << "Cleaning up arm drivers...\n";
-    for (const auto& [id, comp] : arm_components) {
-      comp->get_hardware()->cleanup();
-    }
-    std::cout << "  [ok] All arm drivers cleaned up\n";
+    for (auto& ctrl : controllers) ctrl->stop_teleop();
   });
 
   // ──────────────────────────────────────────────────────────
@@ -319,40 +292,6 @@ int main(int argc, char** argv) {
       break;
     }
 
-    if (cfg.teleop.enabled) {
-      std::cout << "\nLocking leader arms and moving followers to match...\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto leader_it = arm_components.find(pair.leader);
-        auto follower_it = arm_components.find(pair.follower);
-        if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-          continue;
-        }
-        auto leader_driver = leader_it->second->get_hardware();
-        auto follower_driver = follower_it->second->get_hardware();
-        leader_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_positions(
-          leader_driver->get_all_positions(), moving_time_s, false);
-      }
-      std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-      std::cout << "  [ok] Followers moved to match leaders\n";
-
-      std::cout << "\n!! Enabling teleop mode !!\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto it = arm_components.find(pair.leader);
-        if (it == arm_components.end()) {
-          continue;
-        }
-        auto driver = it->second->get_hardware();
-        driver->set_all_modes(trossen_arm::Mode::external_effort);
-        driver->set_all_external_efforts(
-          std::vector<double>(driver->get_num_joints(), 0.0), 0.0, false);
-        std::cout << "   " << pair.leader << ": gravity compensation -> "
-                  << pair.follower << " will mirror\n";
-      }
-      std::cout << "\n";
-    }
-
     mgr.print_episode_header();
 
     if (!mgr.start_episode()) {
@@ -361,41 +300,15 @@ int main(int argc, char** argv) {
 
     std::cout << "Recording...\n";
 
-    // Teleop thread mirrors leader positions to followers at configured rate
-    std::thread teleop_thread([&]() {
-      if (!cfg.teleop.enabled) {
-        return;
-      }
-      const auto sleep_ns = static_cast<int64_t>(1e9 / cfg.teleop.rate_hz);
-      while (mgr.is_episode_active() && !trossen::utils::g_stop_requested) {
-        for (const auto& pair : cfg.teleop.pairs) {
-          auto leader_it = arm_components.find(pair.leader);
-          auto follower_it = arm_components.find(pair.follower);
-          if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-            continue;
-          }
-          follower_it->second->get_hardware()->set_all_positions(
-            leader_it->second->get_hardware()->get_all_positions(), 0.0f, false);
-        }
-        std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
-      }
-    });
-
     auto action = mgr.monitor_episode();
 
     if (action == trossen::runtime::UserAction::kReRecord) {
       mgr.discard_current_episode();
-      if (teleop_thread.joinable()) {
-        teleop_thread.join();
-      }
       continue;
     }
 
     if (mgr.is_episode_active()) {
       mgr.stop_episode();
-    }
-    if (teleop_thread.joinable()) {
-      teleop_thread.join();
     }
 
     if (trossen::utils::g_stop_requested) {

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -230,7 +230,7 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
 
   // ──────────────────────────────────────────────────────────
-  // Teleop controllers (constructor stages arms + applies tuning)
+  // Teleop controllers (constructor stages arms)
   // ──────────────────────────────────────────────────────────
 
   auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
@@ -239,7 +239,7 @@ int main(int argc, char** argv) {
   // Register lifecycle callbacks
   // ──────────────────────────────────────────────────────────
 
-  // Before each episode: summon follower to leader position
+  // Before each episode: let controllers run their pre-episode lifecycle
   mgr.on_pre_episode([&]() -> bool {
     for (auto& ctrl : controllers) ctrl->prepare_teleop();
     return true;

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -248,7 +248,9 @@ int main(int argc, char** argv) {
   // Episode started: begin mirroring (alongside recording)
   mgr.on_episode_started([&]() {
     for (auto& ctrl : controllers) ctrl->teleop();
-    std::cout << "Episode started - recording and mirroring active.\n";
+    std::cout << "Episode started - recording"
+              << (controllers.empty() ? "" : " and mirroring")
+              << " active.\n";
   });
 
   // Count depth-capable cameras once for sanity checks
@@ -277,9 +279,14 @@ int main(int argc, char** argv) {
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });
 
-  // Shutdown: stop mirror + return arms to rest
+  // Shutdown: stop mirror + return arms to rest. If teleop was disabled (no
+  // controllers), return each arm to rest directly so they don't stay in
+  // their last commanded pose.
   mgr.on_pre_shutdown([&]() {
     for (auto& ctrl : controllers) ctrl->stop_teleop();
+    if (controllers.empty()) {
+      for (auto& [id, arm] : arm_components) arm->end_teleop();
+    }
   });
 
   // ──────────────────────────────────────────────────────────

--- a/examples/trossen_stationary_ai/config.json
+++ b/examples/trossen_stationary_ai/config.json
@@ -134,15 +134,15 @@
 
   "backend": {
     "root":             "~/.trossen_sdk",
-    "dataset_id":       "stationary_sdk_edit_test_b",
+    "dataset_id":       "stationary_dataset",
     "compression":      "",
     "chunk_size_bytes": 4194304
   },
 
   "session": {
-    "max_duration":  10.0,
-    "max_episodes":  3,
+    "max_duration":  20.0,
+    "max_episodes":  5,
     "backend_type":  "trossen_mcap",
-    "reset_duration": 1.0
+    "reset_duration": 5.0
   }
 }

--- a/examples/trossen_stationary_ai/config.json
+++ b/examples/trossen_stationary_ai/config.json
@@ -134,15 +134,15 @@
 
   "backend": {
     "root":             "~/.trossen_sdk",
-    "dataset_id":       "stationary_dataset",
+    "dataset_id":       "stationary_sdk_edit_test_b",
     "compression":      "",
     "chunk_size_bytes": 4194304
   },
 
   "session": {
-    "max_duration":  20.0,
-    "max_episodes":  5,
+    "max_duration":  10.0,
+    "max_episodes":  3,
     "backend_type":  "trossen_mcap",
-    "reset_duration": 5.0
+    "reset_duration": 1.0
   }
 }

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -40,15 +40,12 @@
 #include "trossen_sdk/hw/arm/trossen_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 
 #include "trossen_sdk/utils/app_utils.hpp"
-
-static const std::vector<double> STAGED_POSITIONS = {
-  0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0
-};
 
 static void print_usage(const char* program) {
   std::cout <<
@@ -167,28 +164,6 @@ int main(int argc, char** argv) {
     std::cout << "  [ok] Arm [" << id << "] configured (" << arm_cfg.ip_address << ")\n";
   }
 
-  // Stage all arms to starting positions
-  const float moving_time_s = 2.0f;
-  for (const auto& [id, comp] : arm_components) {
-    auto driver = comp->get_hardware();
-    driver->set_all_modes(trossen_arm::Mode::position);
-    driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
-  }
-  std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-  std::cout << "  [ok] All arms staged to starting positions\n";
-
-  // Adjust gripper tolerance for follower arms
-  for (const auto& pair : cfg.teleop.pairs) {
-    auto it = arm_components.find(pair.follower);
-    if (it == arm_components.end()) {
-      continue;
-    }
-    auto driver = it->second->get_hardware();
-    auto limits = driver->get_joint_limits();
-    limits[driver->get_num_joints() - 1].position_tolerance = 0.01;
-    driver->set_joint_limits(limits);
-  }
-
   // ──────────────────────────────────────────────────────────
   // Session Manager + producers
   // ──────────────────────────────────────────────────────────
@@ -256,8 +231,26 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
 
   // ──────────────────────────────────────────────────────────
+  // Teleop controllers (constructor stages arms + applies tuning)
+  // ──────────────────────────────────────────────────────────
+
+  auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+
+  // ──────────────────────────────────────────────────────────
   // Register lifecycle callbacks
   // ──────────────────────────────────────────────────────────
+
+  // Before each episode: summon follower to leader position
+  mgr.on_pre_episode([&]() -> bool {
+    for (auto& ctrl : controllers) ctrl->prepare_teleop();
+    return true;
+  });
+
+  // Episode started: begin mirroring (alongside recording)
+  mgr.on_episode_started([&]() {
+    for (auto& ctrl : controllers) ctrl->teleop();
+    std::cout << "Episode started - recording and mirroring active.\n";
+  });
 
   // Count depth-capable cameras once for sanity checks
   int depth_cameras = 0;
@@ -265,11 +258,10 @@ int main(int argc, char** argv) {
     if (cam.use_depth) ++depth_cameras;
   }
 
-  mgr.on_episode_started([]() {
-    std::cout << "Episode started - recording is now active.\n";
-  });
-
+  // After each episode: reset mode (mirroring continues, no recording)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
+    for (auto& ctrl : controllers) ctrl->reset_teleop();
+
     const std::string file_path =
       trossen::utils::generate_episode_path(root, stats.current_episode_index);
     trossen::utils::print_episode_summary(file_path, stats);
@@ -286,28 +278,9 @@ int main(int argc, char** argv) {
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });
 
+  // Shutdown: stop mirror + return arms to rest
   mgr.on_pre_shutdown([&]() {
-    std::cout << "\nReturning arms to starting positions...\n";
-    for (const auto& [id, comp] : arm_components) {
-      auto driver = comp->get_hardware();
-      driver->set_all_modes(trossen_arm::Mode::position);
-      driver->set_all_positions(STAGED_POSITIONS, moving_time_s, false);
-    }
-    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-    std::cout << "Moving arms to sleep positions...\n";
-    for (const auto& [id, comp] : arm_components) {
-      auto driver = comp->get_hardware();
-      driver->set_all_positions(
-        std::vector<double>(driver->get_num_joints(), 0.0), moving_time_s, false);
-    }
-    std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-
-    std::cout << "Cleaning up arm drivers...\n";
-    for (const auto& [id, comp] : arm_components) {
-      comp->get_hardware()->cleanup();
-    }
-    std::cout << "  [ok] All arm drivers cleaned up\n";
+    for (auto& ctrl : controllers) ctrl->stop_teleop();
   });
 
   // ──────────────────────────────────────────────────────────
@@ -320,40 +293,6 @@ int main(int argc, char** argv) {
       break;
     }
 
-    if (cfg.teleop.enabled) {
-      std::cout << "\nLocking leader arms and moving followers to match...\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto leader_it = arm_components.find(pair.leader);
-        auto follower_it = arm_components.find(pair.follower);
-        if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-          continue;
-        }
-        auto leader_driver = leader_it->second->get_hardware();
-        auto follower_driver = follower_it->second->get_hardware();
-        leader_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_modes(trossen_arm::Mode::position);
-        follower_driver->set_all_positions(
-          leader_driver->get_all_positions(), moving_time_s, false);
-      }
-      std::this_thread::sleep_for(std::chrono::duration<float>(moving_time_s + 0.1f));
-      std::cout << "  [ok] Followers moved to match leaders\n";
-
-      std::cout << "\n!! Enabling teleop mode !!\n";
-      for (const auto& pair : cfg.teleop.pairs) {
-        auto it = arm_components.find(pair.leader);
-        if (it == arm_components.end()) {
-          continue;
-        }
-        auto driver = it->second->get_hardware();
-        driver->set_all_modes(trossen_arm::Mode::external_effort);
-        driver->set_all_external_efforts(
-          std::vector<double>(driver->get_num_joints(), 0.0), 0.0, false);
-        std::cout << "   " << pair.leader << ": gravity compensation -> "
-                  << pair.follower << " will mirror\n";
-      }
-      std::cout << "\n";
-    }
-
     mgr.print_episode_header();
 
     if (!mgr.start_episode()) {
@@ -362,41 +301,15 @@ int main(int argc, char** argv) {
 
     std::cout << "Recording...\n";
 
-    // Teleop thread mirrors leader positions to followers at configured rate
-    std::thread teleop_thread([&]() {
-      if (!cfg.teleop.enabled) {
-        return;
-      }
-      const auto sleep_ns = static_cast<int64_t>(1e9 / cfg.teleop.rate_hz);
-      while (mgr.is_episode_active() && !trossen::utils::g_stop_requested) {
-        for (const auto& pair : cfg.teleop.pairs) {
-          auto leader_it = arm_components.find(pair.leader);
-          auto follower_it = arm_components.find(pair.follower);
-          if (leader_it == arm_components.end() || follower_it == arm_components.end()) {
-            continue;
-          }
-          follower_it->second->get_hardware()->set_all_positions(
-            leader_it->second->get_hardware()->get_all_positions(), 0.0f, false);
-        }
-        std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
-      }
-    });
-
     auto action = mgr.monitor_episode();
 
     if (action == trossen::runtime::UserAction::kReRecord) {
       mgr.discard_current_episode();
-      if (teleop_thread.joinable()) {
-        teleop_thread.join();
-      }
       continue;
     }
 
     if (mgr.is_episode_active()) {
       mgr.stop_episode();
-    }
-    if (teleop_thread.joinable()) {
-      teleop_thread.join();
     }
 
     if (trossen::utils::g_stop_requested) {

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -249,7 +249,9 @@ int main(int argc, char** argv) {
   // Episode started: begin mirroring (alongside recording)
   mgr.on_episode_started([&]() {
     for (auto& ctrl : controllers) ctrl->teleop();
-    std::cout << "Episode started - recording and mirroring active.\n";
+    std::cout << "Episode started - recording"
+              << (controllers.empty() ? "" : " and mirroring")
+              << " active.\n";
   });
 
   // Count depth-capable cameras once for sanity checks
@@ -281,6 +283,9 @@ int main(int argc, char** argv) {
   // Shutdown: stop mirror + return arms to rest
   mgr.on_pre_shutdown([&]() {
     for (auto& ctrl : controllers) ctrl->stop_teleop();
+    if (controllers.empty()) {
+      for (auto& [id, arm] : arm_components) arm->end_teleop();
+    }
   });
 
   // ──────────────────────────────────────────────────────────

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -231,7 +231,7 @@ int main(int argc, char** argv) {
   std::cout << "\nProducers registered. Ready to record.\n";
 
   // ──────────────────────────────────────────────────────────
-  // Teleop controllers (constructor stages arms + applies tuning)
+  // Teleop controllers (constructor stages arms)
   // ──────────────────────────────────────────────────────────
 
   auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
@@ -240,7 +240,7 @@ int main(int argc, char** argv) {
   // Register lifecycle callbacks
   // ──────────────────────────────────────────────────────────
 
-  // Before each episode: summon follower to leader position
+  // Before each episode: let controllers run their pre-episode lifecycle
   mgr.on_pre_episode([&]() -> bool {
     for (auto& ctrl : controllers) ctrl->prepare_teleop();
     return true;


### PR DESCRIPTION
Rips the hand-written teleop setup out of the three example apps (solo, stationary, mobile) and replaces it with a few lines that build controllers from the factory and wire them into the session lifecycle. Also moves per-arm tuning (staging pose, trajectory time, gripper tolerance) from the teleop config block into the arm blocks where they naturally belong — the headline net effect is a large LOC reduction in the examples.