### PR TITLE
observers: add ObserverRegistry factory and REGISTER_OBSERVER macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(trossen_sdk SHARED
   src/hw/camera/opencv_producer.cpp
   src/hw/camera/mock_producer.cpp
   src/hw/camera/mock_synced_producer.cpp
+  src/observer/observer_registry.cpp
   src/runtime/session_manager.cpp
   src/runtime/producer_registry.cpp
   src/runtime/push_producer_registry.cpp

--- a/include/trossen_sdk/observer/observer_registry.hpp
+++ b/include/trossen_sdk/observer/observer_registry.hpp
@@ -1,0 +1,128 @@
+/**
+ * @file observer_registry.hpp
+ * @brief Static factory registry for Observer types.
+ */
+
+#ifndef TROSSEN_SDK__OBSERVER__OBSERVER_REGISTRY_HPP
+#define TROSSEN_SDK__OBSERVER__OBSERVER_REGISTRY_HPP
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/observer/observer_base.hpp"
+
+namespace trossen::observer {
+
+/**
+ * @brief Static factory registry for Observer types.
+ *
+ * Each observer type advertises one factory function that turns a JSON config object into
+ * a concrete ``ObserverBase``-derived instance with its subscriptions already wired up.
+ * Lookup is by exact type-string match.
+ */
+class ObserverRegistry {
+public:
+  /**
+   * @brief Factory function signature.
+   *
+   * @param config JSON object describing the observer (the same object that lives in the
+   *               top-level ``"observers"`` array). The factory is responsible for
+   *               consuming whatever transport-specific fields it needs and for calling
+   *               ``add_subscription()`` on the returned observer per the JSON's
+   *               ``"subscriptions"`` array.
+   * @return Non-null shared_ptr to a constructed observer. Throwing or returning nullptr is
+   *         treated as a configuration error.
+   */
+  using FactoryFunc =
+    std::function<std::shared_ptr<ObserverBase>(const nlohmann::json& config)>;
+
+  /**
+   * @brief Register an observer factory.
+   *
+   * Thread-safe: serialized via an internal mutex. Intended for static-init-time
+   * use via ``REGISTER_OBSERVER``, but safe to call at any time.
+   *
+   * @param type Non-empty type string (e.g. "rerun"). Must be unique within the process.
+   * @param factory Non-null factory callable.
+   * @throws std::runtime_error if ``type`` is empty, ``factory`` is null, or ``type`` is
+   *         already registered.
+   */
+  static void register_observer(const std::string& type, FactoryFunc factory);
+
+  /**
+   * @brief Create an observer by type.
+   *
+   * Thread-safe: the registry lookup is serialized via an internal mutex. The factory is
+   * invoked without the lock held, so factories may freely call back into the registry.
+   *
+   * @param type Type string previously passed to ``register_observer``.
+   * @param config JSON object handed straight to the factory.
+   * @return Constructed observer.
+   * @throws std::runtime_error if the type is not registered, the factory yields nullptr,
+   *         or the factory itself throws (exceptions are re-thrown with the type string
+   *         annotated).
+   */
+  static std::shared_ptr<ObserverBase> create(
+    const std::string& type,
+    const nlohmann::json& config);
+
+  /// True if @p type has been registered. Thread-safe.
+  static bool is_registered(const std::string& type);
+
+  /// List of all registered type strings (no ordering guarantee). Thread-safe.
+  static std::vector<std::string> get_registered_types();
+
+private:
+  static std::map<std::string, FactoryFunc>& get_registry();
+  static std::mutex& get_mutex();
+};
+
+/**
+ * @brief Register an Observer subclass with the registry at static-init time.
+ *
+ * Generates a static registrar object whose constructor calls
+ * ``ObserverRegistry::register_observer`` with a factory that constructs ``ClassName``
+ * from the JSON config alone.
+ *
+ * @param ClassName Observer subclass. Must be constructible from
+ *                  ``const ::nlohmann::json&`` -- the factory calls
+ *                  ``std::make_shared<ClassName>(config)``.
+ * @param TypeString Unique type-string token (e.g. ``"rerun"``).
+ *
+ * Trailing semicolons are permitted: the macro absorbs one so
+ * ``REGISTER_OBSERVER(Foo, "foo");`` compiles cleanly under ``-Wpedantic``.
+ *
+ * Example:
+ * @code
+ *   // rerun_observer.cpp
+ *   namespace trossen::observer {
+ *   REGISTER_OBSERVER(RerunObserver, "rerun")
+ *   }
+ * @endcode
+ */
+#define REGISTER_OBSERVER(ClassName, TypeString)                                       \
+  namespace {                                                                          \
+  struct ClassName##Registrar {                                                        \
+    ClassName##Registrar() {                                                           \
+      ::trossen::observer::ObserverRegistry::register_observer(                        \
+        TypeString,                                                                    \
+        [](const ::nlohmann::json& cfg)                                                \
+             -> std::shared_ptr<::trossen::observer::ObserverBase> {                   \
+          return std::make_shared<ClassName>(cfg);                                     \
+        });                                                                            \
+    }                                                                                  \
+  };                                                                                   \
+  static ClassName##Registrar ClassName##_registrar_instance;                          \
+  }  /* anonymous namespace */                                                         \
+  static_assert(true, "REGISTER_OBSERVER trailing-semicolon sink")
+
+}  // namespace trossen::observer
+
+#endif  // TROSSEN_SDK__OBSERVER__OBSERVER_REGISTRY_HPP

--- a/src/observer/observer_registry.cpp
+++ b/src/observer/observer_registry.cpp
@@ -1,0 +1,82 @@
+/**
+ * @file observer_registry.cpp
+ * @brief Implementation of ObserverRegistry.
+ */
+
+#include "trossen_sdk/observer/observer_registry.hpp"
+
+namespace trossen::observer {
+
+std::map<std::string, ObserverRegistry::FactoryFunc>&
+ObserverRegistry::get_registry() {
+  static std::map<std::string, FactoryFunc> registry;
+  return registry;
+}
+
+std::mutex& ObserverRegistry::get_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+void ObserverRegistry::register_observer(const std::string& type, FactoryFunc factory) {
+  if (type.empty()) {
+    throw std::runtime_error("Observer type must be a non-empty string");
+  }
+  if (!factory) {
+    throw std::runtime_error("Observer factory must be callable for type: " + type);
+  }
+  std::lock_guard<std::mutex> lock(get_mutex());
+  auto& registry = get_registry();
+  if (registry.find(type) != registry.end()) {
+    throw std::runtime_error("Observer type already registered: " + type);
+  }
+  registry.emplace(type, std::move(factory));
+}
+
+std::shared_ptr<ObserverBase> ObserverRegistry::create(
+  const std::string& type,
+  const nlohmann::json& config)
+{
+  FactoryFunc factory;
+  {
+    std::lock_guard<std::mutex> lock(get_mutex());
+    auto& registry = get_registry();
+    auto it = registry.find(type);
+    if (it == registry.end()) {
+      throw std::runtime_error("Observer type not registered: " + type);
+    }
+    factory = it->second;
+  }
+  std::shared_ptr<ObserverBase> obs;
+  try {
+    obs = factory(config);
+  } catch (const std::exception& e) {
+    throw std::runtime_error(
+      "Observer factory threw for type '" + type + "': " + e.what());
+  } catch (...) {
+    throw std::runtime_error(
+      "Observer factory threw a non-std::exception for type: " + type);
+  }
+  if (!obs) {
+    throw std::runtime_error("Observer factory returned nullptr for type: " + type);
+  }
+  return obs;
+}
+
+bool ObserverRegistry::is_registered(const std::string& type) {
+  std::lock_guard<std::mutex> lock(get_mutex());
+  return get_registry().find(type) != get_registry().end();
+}
+
+std::vector<std::string> ObserverRegistry::get_registered_types() {
+  std::lock_guard<std::mutex> lock(get_mutex());
+  const auto& registry = get_registry();
+  std::vector<std::string> types;
+  types.reserve(registry.size());
+  for (const auto& kv : registry) {
+    types.push_back(kv.first);
+  }
+  return types;
+}
+
+}  // namespace trossen::observer

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,9 @@ target_link_libraries(test_teleop_config PRIVATE trossen_sdk GTest::gtest_main)
 add_executable(test_observer_base test_observer_base.cpp)
 target_link_libraries(test_observer_base PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_observer_registry test_observer_registry.cpp)
+target_link_libraries(test_observer_registry PRIVATE trossen_sdk GTest::gtest_main)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -111,3 +114,4 @@ gtest_discover_tests(test_teleop_space_helpers)
 gtest_discover_tests(test_teleop_controller)
 gtest_discover_tests(test_teleop_config)
 gtest_discover_tests(test_observer_base)
+gtest_discover_tests(test_observer_registry)

--- a/tests/test_observer_registry.cpp
+++ b/tests/test_observer_registry.cpp
@@ -1,0 +1,257 @@
+/**
+ * @file test_observer_registry.cpp
+ * @brief Tests for ObserverRegistry and ObserverConfig JSON parsing.
+ */
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/configuration/sdk_config.hpp"
+#include "trossen_sdk/configuration/types/observers/observer_config.hpp"
+#include "trossen_sdk/observer/observer_base.hpp"
+#include "trossen_sdk/observer/observer_registry.hpp"
+
+using nlohmann::json;
+using trossen::configuration::ObserverConfig;
+using trossen::configuration::ObserverSubscriptionConfig;
+using trossen::configuration::SdkConfig;
+using trossen::observer::ObserverBase;
+using trossen::observer::ObserverRegistry;
+
+namespace {
+
+// Minimal concrete observer that reads its subscriptions from the JSON config.
+class DummyObserver : public ObserverBase {
+public:
+  explicit DummyObserver(const json& cfg)
+    : ObserverBase(cfg.value("id", std::string("dummy"))) {
+    if (!cfg.contains("subscriptions") || !cfg.at("subscriptions").is_array()) {
+      throw std::runtime_error("DummyObserver: missing 'subscriptions'");
+    }
+    for (const auto& sub : cfg.at("subscriptions")) {
+      add_subscription(
+        sub.at("record_id").get<std::string>(),
+        sub.at("throttle_hz").get<double>(),
+        [](const std::shared_ptr<trossen::data::RecordBase>&) {});
+    }
+  }
+};
+
+}  // namespace
+
+// ----------------------------------------------------------------------------
+// ObserverSubscriptionConfig
+// ----------------------------------------------------------------------------
+
+TEST(ObserverSubscriptionConfigTest, Parses_Valid) {
+  auto j = json::parse(R"({"record_id": "arm", "throttle_hz": 30.0})");
+  auto c = ObserverSubscriptionConfig::from_json(j);
+  EXPECT_EQ(c.record_id, "arm");
+  EXPECT_DOUBLE_EQ(c.throttle_hz, 30.0);
+}
+
+TEST(ObserverSubscriptionConfigTest, Rejects_MissingOrEmptyRecordId) {
+  EXPECT_THROW(ObserverSubscriptionConfig::from_json(json::parse(R"({"throttle_hz": 1.0})")),
+               std::runtime_error);
+  EXPECT_THROW(ObserverSubscriptionConfig::from_json(
+                 json::parse(R"({"record_id": "", "throttle_hz": 1.0})")),
+               std::runtime_error);
+}
+
+TEST(ObserverSubscriptionConfigTest, Rejects_NonPositiveThrottle) {
+  EXPECT_THROW(ObserverSubscriptionConfig::from_json(
+                 json::parse(R"({"record_id": "x", "throttle_hz": 0})")),
+               std::runtime_error);
+  EXPECT_THROW(ObserverSubscriptionConfig::from_json(
+                 json::parse(R"({"record_id": "x", "throttle_hz": -5})")),
+               std::runtime_error);
+}
+
+// ----------------------------------------------------------------------------
+// ObserverConfig
+// ----------------------------------------------------------------------------
+
+TEST(ObserverConfigTest, Parses_Valid_FullForm) {
+  auto j = json::parse(R"({
+    "type": "rerun",
+    "id":   "live",
+    "subscriptions": [
+      {"record_id": "arm",  "throttle_hz": 30.0},
+      {"record_id": "cam0", "throttle_hz": 15.0}
+    ],
+    "address": "127.0.0.1:9876"
+  })");
+  auto c = ObserverConfig::from_json(j);
+  EXPECT_EQ(c.type, "rerun");
+  EXPECT_EQ(c.id, "live");
+  ASSERT_EQ(c.subscriptions.size(), 2u);
+  EXPECT_EQ(c.subscriptions[0].record_id, "arm");
+  EXPECT_DOUBLE_EQ(c.subscriptions[1].throttle_hz, 15.0);
+  // raw_json must be preserved so the factory can read type-specific fields.
+  EXPECT_EQ(c.raw_json.at("address").get<std::string>(), "127.0.0.1:9876");
+}
+
+TEST(ObserverConfigTest, DefaultsId_ToType_WhenOmitted) {
+  auto j = json::parse(R"({
+    "type": "rerun",
+    "subscriptions": [{"record_id": "arm", "throttle_hz": 30.0}]
+  })");
+  auto c = ObserverConfig::from_json(j);
+  EXPECT_EQ(c.id, "rerun");
+}
+
+TEST(ObserverConfigTest, Rejects_MissingType) {
+  auto j = json::parse(R"({
+    "subscriptions": [{"record_id": "arm", "throttle_hz": 30.0}]
+  })");
+  EXPECT_THROW(ObserverConfig::from_json(j), std::runtime_error);
+}
+
+TEST(ObserverConfigTest, Rejects_MissingOrEmptySubscriptions) {
+  auto missing = json::parse(R"({"type": "rerun"})");
+  EXPECT_THROW(ObserverConfig::from_json(missing), std::runtime_error);
+
+  auto empty = json::parse(R"({"type": "rerun", "subscriptions": []})");
+  EXPECT_THROW(ObserverConfig::from_json(empty), std::runtime_error);
+
+  auto wrong_type =
+    json::parse(R"({"type": "rerun", "subscriptions": "not_an_array"})");
+  EXPECT_THROW(ObserverConfig::from_json(wrong_type), std::runtime_error);
+}
+
+// ----------------------------------------------------------------------------
+// SdkConfig integration
+// ----------------------------------------------------------------------------
+
+TEST(SdkConfigObserversTest, Parses_TopLevelObservers) {
+  auto j = json::parse(R"({
+    "robot_name": "test_bot",
+    "observers": [
+      {
+        "type": "rerun",
+        "subscriptions": [{"record_id": "arm", "throttle_hz": 30.0}]
+      },
+      {
+        "type": "policy_client",
+        "id":   "policy",
+        "subscriptions": [{"record_id": "cam", "throttle_hz": 15.0}]
+      }
+    ]
+  })");
+  auto cfg = SdkConfig::from_json(j);
+  ASSERT_EQ(cfg.observers.size(), 2u);
+  EXPECT_EQ(cfg.observers[0].type, "rerun");
+  EXPECT_EQ(cfg.observers[0].id,   "rerun");
+  EXPECT_EQ(cfg.observers[1].id,   "policy");
+}
+
+TEST(SdkConfigObserversTest, Allows_NoObserversKey) {
+  auto j = json::parse(R"({"robot_name": "test_bot"})");
+  auto cfg = SdkConfig::from_json(j);
+  EXPECT_TRUE(cfg.observers.empty());
+}
+
+TEST(SdkConfigObserversTest, Rejects_ObserversNotArray) {
+  auto j = json::parse(R"({
+    "robot_name": "test_bot",
+    "observers": {"type": "rerun"}
+  })");
+  EXPECT_THROW(SdkConfig::from_json(j), std::runtime_error);
+}
+
+TEST(SdkConfigObserversTest, Rejects_DuplicateObserverIds) {
+  // Two observers with the same explicit id must be rejected so logs and observer_stats()
+  // entries can distinguish them. Defaulted-from-type collisions (two {"type":"rerun"}
+  // entries with no explicit id) are also caught by the same check.
+  auto explicit_dup = json::parse(R"({
+    "observers": [
+      { "type": "rerun", "id": "live",
+        "subscriptions": [{"record_id": "arm", "throttle_hz": 30.0}] },
+      { "type": "rerun", "id": "live",
+        "subscriptions": [{"record_id": "cam", "throttle_hz": 15.0}] }
+    ]
+  })");
+  EXPECT_THROW(SdkConfig::from_json(explicit_dup), std::runtime_error);
+
+  auto defaulted_dup = json::parse(R"({
+    "observers": [
+      { "type": "rerun",
+        "subscriptions": [{"record_id": "arm", "throttle_hz": 30.0}] },
+      { "type": "rerun",
+        "subscriptions": [{"record_id": "cam", "throttle_hz": 15.0}] }
+    ]
+  })");
+  EXPECT_THROW(SdkConfig::from_json(defaulted_dup), std::runtime_error);
+}
+
+// ----------------------------------------------------------------------------
+// ObserverRegistry
+// ----------------------------------------------------------------------------
+
+TEST(ObserverRegistryTest, RegisterAndCreate_RoundTrip) {
+  const std::string type = "dummy_round_trip";
+  ASSERT_FALSE(ObserverRegistry::is_registered(type));
+
+  ObserverRegistry::register_observer(type, [](const json& cfg) {
+    return std::make_shared<DummyObserver>(cfg);
+  });
+  EXPECT_TRUE(ObserverRegistry::is_registered(type));
+
+  auto cfg = json::parse(R"({
+    "type": "dummy_round_trip",
+    "subscriptions": [{"record_id": "arm", "throttle_hz": 30.0}]
+  })");
+  auto obs = ObserverRegistry::create(type, cfg);
+  ASSERT_NE(obs, nullptr);
+  EXPECT_EQ(obs->subscription_count(), 1u);
+}
+
+TEST(ObserverRegistryTest, Register_DuplicateType_Throws) {
+  const std::string type = "dummy_duplicate";
+  ObserverRegistry::register_observer(type, [](const json& cfg) {
+    return std::make_shared<DummyObserver>(cfg);
+  });
+  EXPECT_THROW(ObserverRegistry::register_observer(type, [](const json& cfg) {
+    return std::make_shared<DummyObserver>(cfg);
+  }), std::runtime_error);
+}
+
+TEST(ObserverRegistryTest, Register_NullFactory_Throws) {
+  EXPECT_THROW(
+    ObserverRegistry::register_observer("dummy_null", ObserverRegistry::FactoryFunc{}),
+    std::runtime_error);
+}
+
+TEST(ObserverRegistryTest, Create_UnknownType_Throws) {
+  EXPECT_THROW(ObserverRegistry::create("never_registered_type", json::object()),
+               std::runtime_error);
+}
+
+TEST(ObserverRegistryTest, Create_NullReturningFactory_Throws) {
+  const std::string type = "dummy_returns_null";
+  ObserverRegistry::register_observer(type, [](const json&) {
+    return std::shared_ptr<ObserverBase>{};
+  });
+  EXPECT_THROW(ObserverRegistry::create(type, json::object()), std::runtime_error);
+}
+
+TEST(ObserverRegistryTest, GetRegisteredTypes_IncludesAdded) {
+  const std::string type = "dummy_list";
+  ObserverRegistry::register_observer(type, [](const json& cfg) {
+    return std::make_shared<DummyObserver>(cfg);
+  });
+  const auto types = ObserverRegistry::get_registered_types();
+  bool found = false;
+  for (const auto& t : types) {
+    if (t == type) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found);
+}


### PR DESCRIPTION
## Summary

Add `ObserverRegistry` and the `REGISTER_OBSERVER` macro, mirroring `ProducerRegistry` / `BackendRegistry`. Lets concrete observer types (e.g. `RerunObserver`) self-register at static-init time and be created by type-string at config load.

## Changes

- Add `include/trossen_sdk/observer/observer_registry.hpp` with the registry singleton and the `REGISTER_OBSERVER(ClassName, "type")` macro.
- Add `src/observer/observer_registry.cpp` with the registry implementation and CMake wiring to compile it into `trossen_sdk`.
- Add `tests/test_observer_registry.cpp` covering: registration, duplicate detection, factory lookup, unknown-type errors, nullptr-factory rejection.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`) - new `test_observer_registry` suite
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware (N/A — registry plumbing, no hardware path)

## Breaking Changes

None.

## Related Issues

Relates to TDS-116

Relates to TDS-171
