### PR TITLE
observers: add ObserverConfig schema and SdkConfig observer validation

### DIFF
--- a/include/trossen_sdk/configuration/sdk_config.hpp
+++ b/include/trossen_sdk/configuration/sdk_config.hpp
@@ -36,6 +36,9 @@
  *     { "type": "realsense_camera", "hardware_id": "<id>", "stream_id": "<id>", "poll_rate_hz": 30.0, "encoding": "bgr8", "use_device_time": true },
  *     { "type": "slate_base",       "hardware_id": "slate_base", "stream_id": "slate_base", "poll_rate_hz": 30.0, "use_device_time": false }
  *   ],
+ *   "observers": [
+ *     { "type": "rerun", "id": "live", "subscriptions": [ { "record_id": "<id>", "throttle_hz": 30.0 } ] }
+ *   ],
  *   "teleop": {
  *     "enabled": true,
  *     "rate_hz": 1000.0,
@@ -72,6 +75,7 @@
 #include "trossen_sdk/configuration/types/hardware/arm_config.hpp"
 #include "trossen_sdk/configuration/types/hardware/camera_config.hpp"
 #include "trossen_sdk/configuration/types/hardware/mobile_base_config.hpp"
+#include "trossen_sdk/configuration/types/observers/observer_config.hpp"
 #include "trossen_sdk/configuration/types/producers/producer_config.hpp"
 #include "trossen_sdk/configuration/types/teleop_config.hpp"
 #include "trossen_sdk/configuration/types/backends/trossen_mcap_backend_config.hpp"
@@ -112,6 +116,9 @@ struct SdkConfig {
 
   /// @brief Per-producer configurations (ordered list)
   std::vector<ProducerConfig> producers;
+
+  /// @brief Per-observer configurations (ordered list, optional)
+  std::vector<ObserverConfig> observers;
 
   /// @brief Teleoperation setup
   TeleoperationConfig teleop;

--- a/include/trossen_sdk/configuration/types/observers/observer_config.hpp
+++ b/include/trossen_sdk/configuration/types/observers/observer_config.hpp
@@ -1,0 +1,180 @@
+/**
+ * @file observer_config.hpp
+ * @brief Configuration for a single non-durable Observer.
+ *
+ * Common fields (``type``, ``id``, ``subscriptions``) are parsed up front; type-specific
+ * fields stay in ``raw_json`` for the ``ObserverRegistry`` factory.
+ *
+ * JSON format:
+ * @code
+ * {
+ *   "type": "rerun",
+ *   "id":   "live_viewer",
+ *   "subscriptions": [
+ *     { "record_id": "follower_left",  "throttle_hz": 30.0 },
+ *     { "record_id": "cam_high/color", "throttle_hz": 15.0 }
+ *   ],
+ *   "address": "127.0.0.1:9876"
+ * }
+ * @endcode
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__OBSERVERS__OBSERVER_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__OBSERVERS__OBSERVER_CONFIG_HPP_
+
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Per-stream subscription for one Observer.
+ */
+struct ObserverSubscriptionConfig {
+  /// Exact match against ``RecordBase::id``.
+  std::string record_id;
+
+  /// Maximum handler dispatch rate (Hz); must lie within [1e-3, 1e4].
+  double throttle_hz{0.0};
+
+  static ObserverSubscriptionConfig from_json(const nlohmann::json& j) {
+    ObserverSubscriptionConfig c;
+    if (!j.is_object()) {
+      throw std::runtime_error(
+        "ObserverSubscriptionConfig: entry must be a JSON object");
+    }
+    if (j.contains("record_id")) {
+      if (!j.at("record_id").is_string()) {
+        throw std::runtime_error(
+          "ObserverSubscriptionConfig: 'record_id' must be a string");
+      }
+      j.at("record_id").get_to(c.record_id);
+    }
+    if (j.contains("throttle_hz")) {
+      if (!j.at("throttle_hz").is_number()) {
+        throw std::runtime_error(
+          "ObserverSubscriptionConfig: 'throttle_hz' must be a number for record_id '" +
+          c.record_id + "'");
+      }
+      j.at("throttle_hz").get_to(c.throttle_hz);
+    }
+    if (c.record_id.empty()) {
+      throw std::runtime_error(
+        "ObserverSubscriptionConfig: 'record_id' is required and must be non-empty");
+    }
+    // Mirror ObserverBase::add_subscription range so configs fail fast at parse time
+    // rather than later at construction. The bounded-range check below also rejects
+    // NaN (any comparison with NaN is false, so the negation throws).
+    constexpr double kMinThrottleHz = 1e-3;
+    constexpr double kMaxThrottleHz = 1e4;
+    if (!(c.throttle_hz >= kMinThrottleHz && c.throttle_hz <= kMaxThrottleHz)) {
+      throw std::runtime_error(
+        "ObserverSubscriptionConfig: 'throttle_hz' must be within [1e-3, 1e4] for "
+        "record_id '" + c.record_id + "'");
+    }
+    return c;
+  }
+};
+
+/**
+ * @brief Configuration for one Observer instance.
+ *
+ * Common fields are parsed up front; the full JSON object is also retained in ``raw_json``
+ * so the registry factory can read any type-specific fields without bouncing through
+ * another schema.
+ */
+struct ObserverConfig {
+  /// Registry key (e.g. "rerun", "policy_client"). Required.
+  std::string type;
+
+  /// Logging identifier. Defaults to ``type`` if omitted.
+  std::string id;
+
+  /// Per-stream subscriptions. At least one required.
+  std::vector<ObserverSubscriptionConfig> subscriptions;
+
+  /// When false, this observer is parsed and validated but not instantiated. Defaults
+  /// to true.
+  bool enabled{true};
+
+  /// Original JSON object; preserved so the factory can read type-specific fields.
+  nlohmann::json raw_json;
+
+  static ObserverConfig from_json(const nlohmann::json& j) {
+    ObserverConfig c;
+    if (!j.is_object()) {
+      throw std::runtime_error(
+        "ObserverConfig: entry must be a JSON object");
+    }
+    c.raw_json = j;
+
+    if (j.contains("type")) {
+      if (!j.at("type").is_string()) {
+        throw std::runtime_error(
+          "ObserverConfig: 'type' must be a string");
+      }
+      j.at("type").get_to(c.type);
+    }
+    if (c.type.empty()) {
+      throw std::runtime_error(
+        "ObserverConfig: 'type' is required and must be non-empty");
+    }
+
+    if (j.contains("id")) {
+      if (!j.at("id").is_string()) {
+        throw std::runtime_error(
+          "ObserverConfig: 'id' must be a string for observer of type '" + c.type + "'");
+      }
+      j.at("id").get_to(c.id);
+    }
+    if (c.id.empty()) {
+      c.id = c.type;
+    }
+    if (j.contains("enabled")) {
+      if (!j.at("enabled").is_boolean()) {
+        throw std::runtime_error(
+          "ObserverConfig: 'enabled' must be a boolean for observer '" + c.id + "'");
+      }
+      j.at("enabled").get_to(c.enabled);
+    }
+
+    if (!j.contains("subscriptions") || !j.at("subscriptions").is_array()) {
+      throw std::runtime_error(
+        "ObserverConfig: 'subscriptions' (array) is required for observer '" + c.id + "'");
+    }
+    for (const auto& sub_j : j.at("subscriptions")) {
+      try {
+        c.subscriptions.push_back(ObserverSubscriptionConfig::from_json(sub_j));
+      } catch (const std::exception& e) {
+        throw std::runtime_error(
+          "ObserverConfig: failed to parse subscription for observer '" + c.id + "': " +
+          e.what());
+      }
+    }
+    if (c.subscriptions.empty()) {
+      throw std::runtime_error(
+        "ObserverConfig: 'subscriptions' array must be non-empty for observer '" +
+        c.id + "'");
+    }
+    // Reject duplicate record_ids inside a single observer's subscriptions; mirrors
+    // ObserverBase::add_subscription which throws on duplicates at construction.
+    std::unordered_set<std::string> seen_record_ids;
+    for (const auto& sub : c.subscriptions) {
+      if (!seen_record_ids.insert(sub.record_id).second) {
+        throw std::runtime_error(
+          "ObserverConfig: duplicate record_id '" + sub.record_id +
+          "' in subscriptions for observer '" + c.id + "'");
+      }
+    }
+
+    return c;
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__OBSERVERS__OBSERVER_CONFIG_HPP_

--- a/src/configuration/sdk_config.cpp
+++ b/src/configuration/sdk_config.cpp
@@ -5,6 +5,11 @@
 
 #include "trossen_sdk/configuration/sdk_config.hpp"
 
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
 #include "trossen_sdk/configuration/global_config.hpp"
 
 namespace trossen::configuration {
@@ -47,6 +52,59 @@ SdkConfig SdkConfig::from_json(const nlohmann::json& j) {
   if (j.contains("producers") && j.at("producers").is_array()) {
     for (const auto& p : j.at("producers")) {
       c.producers.push_back(ProducerConfig::from_json(p));
+    }
+  }
+
+  if (j.contains("observers")) {
+    if (!j.at("observers").is_array()) {
+      throw std::runtime_error(
+        "SdkConfig: top-level 'observers' must be an array");
+    }
+    {
+      size_t i = 0;
+      for (const auto& o : j.at("observers")) {
+        try {
+          c.observers.push_back(ObserverConfig::from_json(o));
+        } catch (const std::exception& e) {
+          throw std::runtime_error(
+            "SdkConfig: failed to parse observers[" + std::to_string(i) + "]: " +
+            e.what());
+        }
+        ++i;
+      }
+    }
+    std::unordered_map<std::string, size_t> seen_ids;
+    for (size_t i = 0; i < c.observers.size(); ++i) {
+      const auto& id = c.observers[i].id;
+      auto it = seen_ids.find(id);
+      if (it != seen_ids.end()) {
+        throw std::runtime_error(
+          "SdkConfig: duplicate observer id '" + id + "' (observers[" +
+          std::to_string(it->second) + "] and observers[" + std::to_string(i) +
+          "]). Provide an explicit 'id' field so observers can be distinguished in "
+          "logs and stats.");
+      }
+      seen_ids.emplace(id, i);
+    }
+
+    // Warn (rather than error) on observer subscriptions whose record_id doesn't match
+    // any producer stream_id, since records may come from non-producer sources. The
+    // warning fires even when there are no producers - an observer subscribing to a
+    // stream nothing in this config emits is still worth flagging.
+    std::unordered_set<std::string> producer_stream_ids;
+    for (const auto& p : c.producers) {
+      if (!p.stream_id.empty()) producer_stream_ids.insert(p.stream_id);
+    }
+    for (const auto& obs : c.observers) {
+      if (!obs.enabled) continue;
+      for (const auto& sub : obs.subscriptions) {
+        if (producer_stream_ids.find(sub.record_id) == producer_stream_ids.end()) {
+          std::cerr << "SdkConfig: observer '" << obs.id << "' subscribes to '"
+                    << sub.record_id << "' but no producer in this config emits "
+                    << "that stream_id. The subscription will receive no records "
+                    << "unless another source produces it." << std::endl;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Add `ObserverConfig` JSON schema and wire it into the top-level `SdkConfig` so observers can be declared in the unified robot config alongside producers and backends. Validates duplicate observer ids and warns when a subscription's `record_id` doesn't match any
producer's `stream_id` (catches typos that would otherwise silently no-op).

## Changes

- Add `include/trossen_sdk/configuration/types/observers/observer_config.hpp` with `ObserverConfig` + `ObserverSubscriptionConfig`. Common fields parsed; raw JSON preserved so registry factories can read transport-specific fields.
- Update `SdkConfig::from_json()` to parse the optional `"observers"` array, reject duplicate ids, and warn on subscription `record_id`s that no producer emits.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware (N/A — config parsing only)

## Breaking Changes

None — the `observers` JSON key is optional; configs without it continue to load unchanged.

## Related Issues

Relates to TDS-116

Relates to TDS-172
