### PR TITLE
observers: integrate with SessionManager via producer fan-out and lazy lifecycle

### DIFF
--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -26,6 +26,7 @@
 #include "trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp"
 #include "trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp"
 #include "trossen_sdk/io/sink.hpp"
+#include "trossen_sdk/observer/observer_base.hpp"
 #include "trossen_sdk/runtime/scheduler.hpp"
 #include "trossen_sdk/configuration/global_config.hpp"
 #include "trossen_sdk/configuration/types/runtime/session_manager_config.hpp"
@@ -51,6 +52,12 @@ enum class UserAction {
  * - Tracking episode index and duration
  * - Auto-stopping episodes when duration limits are reached
  * - Draining queued records before closing episodes
+ *
+ * Thread safety: add_*, start_episode, stop_episode, discard_*, and shutdown must be
+ * called from a single orchestrating thread. Read-only methods (stats, observer_stats,
+ * is_episode_active) are safe to call concurrently.
+ *
+ * shutdown() is terminal: once it returns, the SessionManager cannot be reused.
  */
 class SessionManager {
 public:
@@ -94,6 +101,20 @@ public:
    * Must be called before start_episode().
    */
   void add_push_producer(std::shared_ptr<hw::PushProducer> producer);
+
+  /**
+   * @brief Register a non-durable Observer.
+   *
+   * Observers fan out from each producer alongside the Sink without blocking the durable
+   * write path. They start lazily on the first ``start_episode()`` call, persist across
+   * episode boundaries, and stop at ``shutdown()``.
+   *
+   * @param observer Fully-configured observer (subscriptions already added).
+   *
+   * @throws std::invalid_argument if @p observer is null.
+   * @throws std::runtime_error if called after the first ``start_episode()``.
+   */
+  void add_observer(std::shared_ptr<observer::ObserverBase> observer);
 
   /**
    * @brief Start a new episode
@@ -233,6 +254,31 @@ public:
    * @brief Get current statistics
    */
   Stats stats() const;
+
+  /**
+   * @brief Per-observer status snapshot.
+   *
+   * (is_running, is_dead) interpretation:
+   *   - (false, false) - registered but not yet started, or stopped.
+   *   - (true,  false) - worker active; accepting records.
+   *   - (false, true)  - start() failed; terminal. Excluded from fan-out.
+   */
+  struct ObserverStatsEntry {
+    /// Observer name (as passed to its constructor).
+    std::string name;
+    /// Cumulative counters from ``ObserverBase::stats()``.
+    observer::ObserverBase::Stats stats;
+    /// True if the observer's worker thread is currently running.
+    bool is_running{false};
+    /// True if ``start()`` failed for this observer.
+    bool is_dead{false};
+  };
+
+  /**
+   * @brief Snapshot of every registered observer's counters and run-state, in
+   *        registration order.
+   */
+  std::vector<ObserverStatsEntry> observer_stats() const;
 
   // =========================================================================
   // Lifecycle callbacks
@@ -497,6 +543,16 @@ private:
 
   /// @brief Registered push producers (persists across episodes)
   std::vector<PushProducerEntry> push_producer_entries_;
+
+  /// @brief Registered observers; persist across episodes
+  std::vector<std::shared_ptr<observer::ObserverBase>> observers_;
+
+  /// @brief Set after the first start_episode(); locks observer registration and gates
+  ///        the lazy-start path.
+  bool observers_started_{false};
+
+  /// @brief Set when shutdown() has been called; start_episode() refuses afterwards.
+  bool shutdown_called_{false};
 
   /**
    * @brief Create backend instance for the given episode

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -258,10 +258,11 @@ public:
   /**
    * @brief Per-observer status snapshot.
    *
-   * (is_running, is_dead) interpretation:
-   *   - (false, false) - registered but not yet started, or stopped.
+   * (is_running, is_stopped) interpretation:
+   *   - (false, false) - registered but not yet started.
    *   - (true,  false) - worker active; accepting records.
-   *   - (false, true)  - start() failed; terminal. Excluded from fan-out.
+   *   - (false, true)  - latched stopped (clean stop or failed start); terminal
+   *                      and excluded from fan-out.
    */
   struct ObserverStatsEntry {
     /// Observer name (as passed to its constructor).
@@ -270,8 +271,8 @@ public:
     observer::ObserverBase::Stats stats;
     /// True if the observer's worker thread is currently running.
     bool is_running{false};
-    /// True if ``start()`` failed for this observer.
-    bool is_dead{false};
+    /// True if the observer is latched stopped (clean stop or failed start).
+    bool is_stopped{false};
   };
 
   /**

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -20,6 +20,28 @@
 
 namespace trossen::runtime {
 
+namespace {
+
+// Shared fan-out used by both the push-producer and polled-producer emit lambdas so the
+// per-record path stays in lockstep across them.
+void fan_out_record_(
+  io::Sink* sink,
+  const std::vector<std::shared_ptr<observer::ObserverBase>>& observers,
+  std::shared_ptr<data::RecordBase> rec)
+{
+  if (!rec) return;
+  if (observers.empty()) {
+    sink->enqueue(std::move(rec));
+    return;
+  }
+  sink->enqueue(rec);
+  for (const auto& obs : observers) {
+    obs->offer(rec);
+  }
+}
+
+}  // namespace
+
 SessionManager::SessionManager(){
   // This allows us to access the global configuration for the Session Manager
   // without passing it explicitly.
@@ -67,7 +89,18 @@ SessionManager::~SessionManager() {
 }
 
 void SessionManager::shutdown() {
+  // stop_episode() runs first so episode-ended callbacks fire against a still-non-
+  // terminal SessionManager; shutdown_called_ latches afterwards and gates start_episode().
   stop_episode();
+  shutdown_called_ = true;
+
+  // Observers stop here, not at episode boundaries. Producers have already stopped
+  // emitting via stop_episode(), so no in-flight offer() can race.
+  for (auto& obs : observers_) {
+    if (obs) {
+      obs->stop();
+    }
+  }
 
   // Fire pre-shutdown callbacks once, after recording has stopped.
   // Useful for returning hardware to safe positions while post-processing runs.
@@ -118,7 +151,24 @@ void SessionManager::add_push_producer(std::shared_ptr<hw::PushProducer> produce
   push_producer_entries_.push_back(PushProducerEntry{.producer = std::move(producer)});
 }
 
+void SessionManager::add_observer(std::shared_ptr<observer::ObserverBase> observer) {
+  if (!observer) {
+    throw std::invalid_argument("Cannot add null observer");
+  }
+  if (observers_started_) {
+    throw std::runtime_error(
+      "Cannot add observers after the first start_episode(). Register all observers "
+      "before starting the first episode.");
+  }
+  observers_.push_back(std::move(observer));
+}
+
 bool SessionManager::start_episode() {
+  if (shutdown_called_) {
+    std::cerr << "SessionManager::start_episode() refused: shutdown() has been called; "
+              << "SessionManager is terminal." << std::endl;
+    return false;
+  }
   // Guard: already active
   if (episode_active_) {
     std::cerr << "Episode already active. Call stop_episode() first." << std::endl;
@@ -189,6 +239,18 @@ bool SessionManager::start_episode() {
   // Capture initial record count for this episode (for stats delta calculation)
   episode_start_record_count_ = current_sink_->processed_count();
 
+  // Lazy-start observers on the first episode. Failed observers are marked dead and
+  // skipped from the fan-out snapshot; the session continues without them.
+  if (!observers_started_) {
+    observers_started_ = true;
+    for (auto& obs : observers_) {
+      if (!obs->start()) {
+        std::cerr << "Observer '" << obs->name()
+                  << "' failed to start; continuing session without it." << std::endl;
+      }
+    }
+  }
+
   // Helper to tear down push producers, sink, and backend on early abort
   auto cleanup_and_abort = [&]() -> bool {
     for (const auto& ppe : push_producer_entries_) {
@@ -200,15 +262,24 @@ bool SessionManager::start_episode() {
     return false;
   };
 
+  // Snapshot of healthy observers for the per-record fan-out. Dead observers
+  // (start() failure) are filtered out so the emit lambdas never dispatch into them.
+  std::vector<std::shared_ptr<observer::ObserverBase>> observers_snapshot;
+  observers_snapshot.reserve(observers_.size());
+  for (const auto& obs : observers_) {
+    if (obs && !obs->is_dead()) {
+      observers_snapshot.push_back(obs);
+    }
+  }
+
   // Start push producers (own threads, emit into current sink)
   // Capture shared_ptr to ensure Sink lifetime outlives any in-flight emit callbacks
   std::shared_ptr<io::Sink> sink_shared = current_sink_;
   for (const auto& ppe : push_producer_entries_) {
-    bool started = ppe.producer->start([sink_shared](std::shared_ptr<data::RecordBase> rec) {
-      if (rec) {
-        sink_shared->enqueue(std::move(rec));
-      }
-    });
+    bool started = ppe.producer->start(
+      [sink_shared, observers_snapshot](std::shared_ptr<data::RecordBase> rec) {
+        fan_out_record_(sink_shared.get(), observers_snapshot, std::move(rec));
+      });
     if (!started) {
       std::cerr << "Failed to start push producer; aborting episode startup." << std::endl;
       return cleanup_and_abort();
@@ -238,14 +309,16 @@ bool SessionManager::start_episode() {
     // Capture raw pointer to sink (safe: sink lifetime managed by Session Manager)
     auto* sink_ptr = current_sink_.get();
 
-    // Add task that polls producer and enqueues records
-    scheduler_->add_task(pt.period, [producer = pt.producer, sink_ptr]() {
-      producer->poll([sink_ptr](std::shared_ptr<data::RecordBase> rec) {
-        if (rec) {
-          sink_ptr->enqueue(std::move(rec));
-        }
-      });
-    }, pt.opts);
+    // The outer lambda owns observers_snapshot by value (its lifetime spans the task);
+    // the inner lambda captures it by reference since poll() invokes emit synchronously
+    // and never stores it, avoiding a per-tick vector copy.
+    scheduler_->add_task(pt.period,
+      [producer = pt.producer, sink_ptr, observers_snapshot]() {
+        producer->poll(
+          [sink_ptr, &observers_snapshot](std::shared_ptr<data::RecordBase> rec) {
+            fan_out_record_(sink_ptr, observers_snapshot, std::move(rec));
+          });
+      }, pt.opts);
   }
 
   // Start scheduler (begins polling producers)
@@ -548,6 +621,23 @@ SessionManager::Stats SessionManager::stats_unlocked() const {
 SessionManager::Stats SessionManager::stats() const {
   std::lock_guard<std::mutex> lock(episode_mutex_);
   return stats_unlocked();
+}
+
+std::vector<SessionManager::ObserverStatsEntry>
+SessionManager::observer_stats() const {
+  std::lock_guard<std::mutex> lock(episode_mutex_);
+  std::vector<ObserverStatsEntry> out;
+  out.reserve(observers_.size());
+  for (const auto& obs : observers_) {
+    if (!obs) continue;
+    ObserverStatsEntry e;
+    e.name = obs->name();
+    e.stats = obs->stats();
+    e.is_running = obs->is_running();
+    e.is_dead = obs->is_dead();
+    out.push_back(std::move(e));
+  }
+  return out;
 }
 
 void SessionManager::on_pre_episode(PreEpisodeCallback cb) {

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -262,12 +262,13 @@ bool SessionManager::start_episode() {
     return false;
   };
 
-  // Snapshot of healthy observers for the per-record fan-out. Dead observers
-  // (start() failure) are filtered out so the emit lambdas never dispatch into them.
+  // Snapshot of healthy observers for the per-record fan-out. Stopped observers
+  // (clean stop or failed start) are filtered out so the emit lambdas never
+  // dispatch into them.
   std::vector<std::shared_ptr<observer::ObserverBase>> observers_snapshot;
   observers_snapshot.reserve(observers_.size());
   for (const auto& obs : observers_) {
-    if (obs && !obs->is_dead()) {
+    if (obs && !obs->is_stopped()) {
       observers_snapshot.push_back(obs);
     }
   }
@@ -634,7 +635,7 @@ SessionManager::observer_stats() const {
     e.name = obs->name();
     e.stats = obs->stats();
     e.is_running = obs->is_running();
-    e.is_dead = obs->is_dead();
+    e.is_stopped = obs->is_stopped();
     out.push_back(std::move(e));
   }
   return out;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,9 @@ target_link_libraries(test_observer_base PRIVATE trossen_sdk GTest::gtest_main)
 add_executable(test_observer_registry test_observer_registry.cpp)
 target_link_libraries(test_observer_registry PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_session_manager_observers test_session_manager_observers.cpp)
+target_link_libraries(test_session_manager_observers PRIVATE trossen_sdk GTest::gtest_main)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -115,3 +118,4 @@ gtest_discover_tests(test_teleop_controller)
 gtest_discover_tests(test_teleop_config)
 gtest_discover_tests(test_observer_base)
 gtest_discover_tests(test_observer_registry)
+gtest_discover_tests(test_session_manager_observers)

--- a/tests/test_session_manager_observers.cpp
+++ b/tests/test_session_manager_observers.cpp
@@ -1,0 +1,387 @@
+/**
+ * @file test_session_manager_observers.cpp
+ * @brief End-to-end tests for SessionManager observer fan-out and lifecycle.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+#include "trossen_sdk/observer/observer_base.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
+
+using trossen::data::JointStateRecord;
+using trossen::data::RecordBase;
+using trossen::hw::PolledProducer;
+using trossen::observer::ObserverBase;
+using trossen::runtime::SessionManager;
+
+namespace {
+
+class MockPolledProducer : public PolledProducer {
+public:
+  explicit MockPolledProducer(std::string stream_id = "mock/joints")
+    : stream_id_(std::move(stream_id)) {}
+  ~MockPolledProducer() override = default;
+
+  void poll(const std::function<void(std::shared_ptr<RecordBase>)>& emit) override {
+    auto rec = std::make_shared<JointStateRecord>();
+    rec->seq = seq_++;
+    rec->id = stream_id_;
+    rec->positions = {1.0f, 2.0f, 3.0f};
+    emit(rec);
+    ++stats_.produced;
+  }
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    auto meta = std::make_shared<ProducerMetadata>();
+    meta->type = "mock";
+    meta->id = stream_id_;
+    meta->name = "Mock Producer";
+    return meta;
+  }
+
+private:
+  std::string stream_id_;
+};
+
+class CountingObserver : public ObserverBase {
+public:
+  explicit CountingObserver(std::string name, std::string record_id,
+                            double throttle_hz, std::atomic<int>* counter)
+    : ObserverBase(std::move(name)) {
+    add_subscription(std::move(record_id), throttle_hz,
+                     [counter](const std::shared_ptr<RecordBase>&) {
+                       counter->fetch_add(1);
+                     });
+  }
+};
+
+class DeadObserver : public ObserverBase {
+public:
+  DeadObserver() : ObserverBase("dead") {
+    add_subscription("mock/joints", 100.0,
+                     [](const std::shared_ptr<RecordBase>&) {});
+  }
+
+protected:
+  bool on_start() override { return false; }
+};
+
+class SessionManagerObserversTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    nlohmann::json cfg = {
+      {"session_manager", {
+        {"type", "session_manager"},
+        {"max_duration", 5.0},
+        {"max_episodes", 100},
+        {"backend_type", "null"}
+      }}
+    };
+    trossen::configuration::GlobalConfig::instance().load_from_json(cfg);
+  }
+};
+
+}  // namespace
+
+// ----------------------------------------------------------------------------
+// add_observer guards
+// ----------------------------------------------------------------------------
+
+TEST_F(SessionManagerObserversTest, AddObserver_NullThrows) {
+  SessionManager sm;
+  EXPECT_THROW(sm.add_observer(nullptr), std::invalid_argument);
+}
+
+TEST_F(SessionManagerObserversTest, AddObserver_AfterFirstEpisode_Throws) {
+  SessionManager sm;
+  std::atomic<int> counter{0};
+  sm.add_observer(std::make_shared<CountingObserver>(
+    "obs", "mock/joints", 100.0, &counter));
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(10));
+  ASSERT_TRUE(sm.start_episode());
+  sm.stop_episode();
+
+  // observers_started_ is true now - new observers must be rejected.
+  EXPECT_THROW(sm.add_observer(std::make_shared<CountingObserver>(
+                 "obs2", "mock/joints", 100.0, &counter)),
+               std::runtime_error);
+}
+
+// ----------------------------------------------------------------------------
+// Fan-out end-to-end
+// ----------------------------------------------------------------------------
+
+TEST_F(SessionManagerObserversTest, Records_ReachObservers_DuringEpisode) {
+  SessionManager sm;
+  std::atomic<int> handler_calls{0};
+  auto obs = std::make_shared<CountingObserver>(
+    "obs", "mock/joints", 200.0, &handler_calls);
+  sm.add_observer(obs);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  sm.stop_episode();
+
+  // Producer was polled at 200 Hz × 150 ms → ~30 records offered.
+  EXPECT_GT(obs->stats().offered, 5u);
+  EXPECT_GT(obs->stats().accepted, 5u);
+  EXPECT_GE(handler_calls.load(), 1);
+}
+
+TEST_F(SessionManagerObserversTest, UnsubscribedRecords_AreNotDispatched) {
+  SessionManager sm;
+  std::atomic<int> handler_calls{0};
+  // Subscribe to "other" - producer emits "mock/joints".
+  auto obs = std::make_shared<CountingObserver>(
+    "obs", "other", 100.0, &handler_calls);
+  sm.add_observer(obs);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  sm.stop_episode();
+
+  EXPECT_GT(obs->stats().offered, 0u);   // offered all records
+  EXPECT_EQ(obs->stats().accepted, 0u);  // none matched the subscription
+  EXPECT_EQ(handler_calls.load(), 0);
+}
+
+// ----------------------------------------------------------------------------
+// Lifecycle: lazy start, cross-episode persistence, shutdown
+// ----------------------------------------------------------------------------
+
+TEST_F(SessionManagerObserversTest, Observer_StartsLazily_OnFirstEpisode) {
+  SessionManager sm;
+  std::atomic<int> counter{0};
+  auto obs = std::make_shared<CountingObserver>(
+    "obs", "mock/joints", 100.0, &counter);
+  sm.add_observer(obs);
+
+  EXPECT_FALSE(obs->is_running());
+
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+  ASSERT_TRUE(sm.start_episode());
+
+  EXPECT_TRUE(obs->is_running());
+
+  sm.stop_episode();
+
+  // Cross-episode: observer must still be running between episodes.
+  EXPECT_TRUE(obs->is_running());
+}
+
+TEST_F(SessionManagerObserversTest, Observer_PersistsAcross_Episodes) {
+  SessionManager sm;
+  std::atomic<int> counter{0};
+  auto obs = std::make_shared<CountingObserver>(
+    "obs", "mock/joints", 100.0, &counter);
+  sm.add_observer(obs);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(80));
+  const auto consumed_after_e0 = obs->stats().consumed;
+  sm.stop_episode();
+  EXPECT_TRUE(obs->is_running());
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(80));
+  sm.stop_episode();
+
+  // Observer's worker thread was never restarted; counters accumulate across episodes.
+  EXPECT_GE(obs->stats().consumed, consumed_after_e0);
+  EXPECT_TRUE(obs->is_running());
+}
+
+TEST_F(SessionManagerObserversTest, Shutdown_StopsObservers) {
+  std::atomic<int> counter{0};
+  auto obs = std::make_shared<CountingObserver>(
+    "obs", "mock/joints", 100.0, &counter);
+  {
+    SessionManager sm;
+    sm.add_observer(obs);
+    sm.add_producer(std::make_shared<MockPolledProducer>(),
+                    std::chrono::milliseconds(5));
+    ASSERT_TRUE(sm.start_episode());
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    sm.shutdown();
+    EXPECT_FALSE(obs->is_running());
+  }
+  // Destructor implicitly shuts down again; observer must remain stopped.
+  EXPECT_FALSE(obs->is_running());
+}
+
+TEST_F(SessionManagerObserversTest, DeadObserver_DoesNotAbortEpisode) {
+  SessionManager sm;
+  sm.add_observer(std::make_shared<DeadObserver>());
+  std::atomic<int> healthy_counter{0};
+  auto healthy = std::make_shared<CountingObserver>(
+    "healthy", "mock/joints", 100.0, &healthy_counter);
+  sm.add_observer(healthy);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  // start_episode must succeed even with one dead observer; the healthy one keeps
+  // receiving records normally.
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(80));
+  sm.stop_episode();
+
+  EXPECT_GT(healthy->stats().accepted, 0u);
+}
+
+// ----------------------------------------------------------------------------
+// PR4: failure-policy hardening + stats aggregation
+// ----------------------------------------------------------------------------
+
+namespace {
+
+// Observer whose subscription handler throws on every record. Used to verify that
+// per-record handler exceptions are isolated and never reach the producer thread.
+class ThrowingObserver : public ObserverBase {
+public:
+  ThrowingObserver() : ObserverBase("throwing") {
+    add_subscription("mock/joints", 100.0,
+                     [](const std::shared_ptr<RecordBase>&) {
+                       throw std::runtime_error("boom");
+                     });
+  }
+};
+
+}  // namespace
+
+TEST_F(SessionManagerObserversTest, DeadObserver_NotOfferedRecords) {
+  // Dead observers must be filtered from the producer fan-out snapshot, so their
+  // offered/accepted counters stay at zero even while the session is running.
+  SessionManager sm;
+  auto dead = std::make_shared<DeadObserver>();
+  sm.add_observer(dead);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(80));
+  sm.stop_episode();
+
+  EXPECT_TRUE(dead->is_dead());
+  EXPECT_EQ(dead->stats().offered, 0u);
+}
+
+TEST_F(SessionManagerObserversTest, ThrowingHandler_DoesNotAffectSession) {
+  // A handler that throws on every record must not abort the episode, slow the Sink
+  // perceptibly, or break other observers. handler_exceptions counter advances.
+  //
+  // Coverage notes:
+  //  - "offered > 0" anchors a producer-thread fact: if 0, the test environment is too
+  //    slow to schedule the producer at all, not a regression in the throwing-isolation
+  //    contract.
+  //  - "healthy.accepted > 0" anchors that the healthy observer keeps receiving records
+  //    on a separate slot mutex; the throwing handler stays isolated.
+  //  - The duration bump (250 ms) absorbs CI scheduler jitter.
+  SessionManager sm;
+  auto throwing = std::make_shared<ThrowingObserver>();
+  std::atomic<int> healthy_counter{0};
+  auto healthy = std::make_shared<CountingObserver>(
+    "healthy", "mock/joints", 100.0, &healthy_counter);
+  sm.add_observer(throwing);
+  sm.add_observer(healthy);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  sm.stop_episode();
+
+  EXPECT_GT(throwing->stats().offered, 0u) << "producer was never scheduled";
+  EXPECT_GT(throwing->stats().handler_exceptions, 0u);
+  EXPECT_GT(healthy->stats().accepted, 0u);
+  EXPECT_FALSE(throwing->is_dead());  // handler exceptions don't kill the observer
+  EXPECT_TRUE(throwing->is_running());
+}
+
+TEST_F(SessionManagerObserversTest, ObserverStats_ReturnsAllObservers) {
+  SessionManager sm;
+  std::atomic<int> a{0}, b{0};
+  sm.add_observer(std::make_shared<CountingObserver>(
+    "obs_a", "mock/joints", 100.0, &a));
+  sm.add_observer(std::make_shared<CountingObserver>(
+    "obs_b", "other_stream", 100.0, &b));
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(80));
+  sm.stop_episode();
+
+  const auto stats = sm.observer_stats();
+  ASSERT_EQ(stats.size(), 2u);
+  EXPECT_EQ(stats[0].name, "obs_a");
+  EXPECT_EQ(stats[1].name, "obs_b");
+  EXPECT_TRUE(stats[0].is_running);
+  EXPECT_FALSE(stats[0].is_dead);
+  EXPECT_GT(stats[0].stats.offered, 0u);
+  EXPECT_GT(stats[0].stats.accepted, 0u);
+  // obs_b is offered records but accepts none (different stream).
+  EXPECT_GT(stats[1].stats.offered, 0u);
+  EXPECT_EQ(stats[1].stats.accepted, 0u);
+}
+
+TEST_F(SessionManagerObserversTest, StartEpisode_AfterShutdown_IsRefused) {
+  // shutdown() is terminal: observers are one-shot, so a subsequent start_episode()
+  // must refuse rather than silently push records into joined workers.
+  SessionManager sm;
+  std::atomic<int> counter{0};
+  sm.add_observer(std::make_shared<CountingObserver>(
+    "obs", "mock/joints", 100.0, &counter));
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+  ASSERT_TRUE(sm.start_episode());
+  sm.stop_episode();
+  sm.shutdown();
+
+  EXPECT_FALSE(sm.start_episode());
+}
+
+TEST_F(SessionManagerObserversTest, DiscardEpisode_PreservesObservers) {
+  // Discarding an episode tears down sink/backend but must NOT stop observers; observer
+  // state persists across episode boundaries, including discards.
+  SessionManager sm;
+  std::atomic<int> counter{0};
+  auto obs = std::make_shared<CountingObserver>(
+    "obs", "mock/joints", 100.0, &counter);
+  sm.add_observer(obs);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(60));
+  const auto accepted_before = obs->stats().accepted;
+  sm.discard_current_episode();
+
+  EXPECT_TRUE(obs->is_running());
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(60));
+  sm.stop_episode();
+
+  EXPECT_GE(obs->stats().accepted, accepted_before);
+  EXPECT_TRUE(obs->is_running());
+}

--- a/tests/test_session_manager_observers.cpp
+++ b/tests/test_session_manager_observers.cpp
@@ -281,7 +281,7 @@ TEST_F(SessionManagerObserversTest, DeadObserver_NotOfferedRecords) {
   std::this_thread::sleep_for(std::chrono::milliseconds(80));
   sm.stop_episode();
 
-  EXPECT_TRUE(dead->is_dead());
+  EXPECT_TRUE(dead->is_stopped());
   EXPECT_EQ(dead->stats().offered, 0u);
 }
 
@@ -313,7 +313,7 @@ TEST_F(SessionManagerObserversTest, ThrowingHandler_DoesNotAffectSession) {
   EXPECT_GT(throwing->stats().offered, 0u) << "producer was never scheduled";
   EXPECT_GT(throwing->stats().handler_exceptions, 0u);
   EXPECT_GT(healthy->stats().accepted, 0u);
-  EXPECT_FALSE(throwing->is_dead());  // handler exceptions don't kill the observer
+  EXPECT_FALSE(throwing->is_stopped());  // handler exceptions don't latch stopped
   EXPECT_TRUE(throwing->is_running());
 }
 
@@ -336,7 +336,7 @@ TEST_F(SessionManagerObserversTest, ObserverStats_ReturnsAllObservers) {
   EXPECT_EQ(stats[0].name, "obs_a");
   EXPECT_EQ(stats[1].name, "obs_b");
   EXPECT_TRUE(stats[0].is_running);
-  EXPECT_FALSE(stats[0].is_dead);
+  EXPECT_FALSE(stats[0].is_stopped);
   EXPECT_GT(stats[0].stats.offered, 0u);
   EXPECT_GT(stats[0].stats.accepted, 0u);
   // obs_b is offered records but accepts none (different stream).


### PR DESCRIPTION
## Summary

Wire observers into `SessionManager`. Producers now fan out each record to `sink.enqueue `plus `observer.offer × N` inline in their emit callback. Observers start lazily on the first `start_episode()`, persist across episode boundaries, and are stopped at `shutdown()` (ADR-003 L2 lifecycle). A failed `start()` marks the observer dead and the session continues without it.

## Changes

- Add `SessionManager::add_observer()` to register an observer before the first episode.
- Add producer-side fan-out: a single `fan_out_record_()` helper used by both polled and push producer emit lambdas, with a no-observer fast path that is one branch over the pre-existing sink-only flow.
- Lazy-start observers at first `start_episode()`; snapshot the live (non-dead) observers into the producer lambdas for the episode.
- Stop observers in `shutdown()` after recording has stopped, and refuse `start_episode()` once shutdown has been called.
- Add `SessionManager::observer_stats()` returning per-observer counters + `is_running` / `is_dead` so example apps can surface observer health.
- Add `tests/test_session_manager_observers.cpp` covering: null-observer rejection, late-add rejection, dead-observer exclusion from fan-out, fan-out reaches every observer, observer survives episode boundaries, shutdown gates further episodes.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`) — new `test_session_manager_observers` suite plus the existing session-manager suites
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware — pending; covered by the example wiring in PR 6

## Breaking Changes

None. All additions are new public methods; existing `SessionManager` callers keep working without changes.

## Related Issues

Relates to TDS-116

Relates to TDS-170
