### PR TITLE
observers: wire rerun observer into solo, stationary, and mobile examples

### DIFF
--- a/examples/trossen_mobile_ai/README.md
+++ b/examples/trossen_mobile_ai/README.md
@@ -144,6 +144,46 @@ Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
 ./build/examples/trossen_mobile_ai --set teleop.enabled=false
 ```
 
+**Stream to a live ReRun viewer (optional):**
+
+Build with `-DTROSSEN_ENABLE_RERUN_OBSERVER=ON`, launch a ReRun viewer
+listening on the default gRPC port (`rerun` — the native viewer listens on
+`127.0.0.1:9876` by default), and add an `observers` array to your top-level
+`config.json` object (alongside `hardware`, `producers`, etc.):
+
+```jsonc
+{
+  // ...existing top-level keys...
+  "observers": [
+    {
+      "type":      "rerun",
+      "id":        "live_viewer",
+      "rerun_url": "rerun+http://127.0.0.1:9876/proxy",
+      "app_id":    "trossen_mobile_ai",
+      "enabled":   true,
+      "subscriptions": [
+        { "record_id": "leader_left",        "throttle_hz": 30.0 },
+        { "record_id": "leader_right",       "throttle_hz": 30.0 },
+        { "record_id": "follower_left",      "throttle_hz": 30.0 },
+        { "record_id": "follower_right",     "throttle_hz": 30.0 },
+        { "record_id": "slate_base",         "throttle_hz": 30.0 },
+        { "record_id": "camera_high",        "throttle_hz": 15.0 },
+        { "record_id": "camera_left_wrist",  "throttle_hz": 15.0 },
+        { "record_id": "camera_right_wrist", "throttle_hz": 15.0 }
+      ]
+    }
+  ]
+}
+```
+
+Each subscription's `record_id` must match a producer's `stream_id` exactly —
+note the `slate_base` subscription routes the mobile base's `Odometry2DRecord`
+through the rerun observer's odom dispatch arm (pose + body-frame twist as
+scalar timelines).
+`SdkConfig::from_json` prints a warning to stderr at config parse time for any
+subscription whose `record_id` does not match a producer in the same config.
+Set `"enabled": false` to silence an observer without deleting its block.
+
 ---
 
 ## Converting to LeRobot V2

--- a/examples/trossen_mobile_ai/config.json
+++ b/examples/trossen_mobile_ai/config.json
@@ -131,6 +131,26 @@
     "chunk_size_bytes": 4194304
   },
 
+  "observers": [
+    {
+      "type":      "rerun",
+      "id":        "live_viewer",
+      "rerun_url": "rerun+http://127.0.0.1:9876/proxy",
+      "app_id":    "trossen_mobile_ai",
+      "enabled":   true,
+      "subscriptions": [
+        { "record_id": "leader_left",        "throttle_hz": 30.0 },
+        { "record_id": "leader_right",       "throttle_hz": 30.0 },
+        { "record_id": "follower_left",      "throttle_hz": 30.0 },
+        { "record_id": "follower_right",     "throttle_hz": 30.0 },
+        { "record_id": "slate_base",         "throttle_hz": 30.0 },
+        { "record_id": "camera_high",        "throttle_hz": 15.0 },
+        { "record_id": "camera_left_wrist",  "throttle_hz": 15.0 },
+        { "record_id": "camera_right_wrist", "throttle_hz": 15.0 }
+      ]
+    }
+  ],
+
   "session": {
     "max_duration":  20.0,
     "max_episodes":  5,

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -43,6 +43,7 @@
 #include "trossen_sdk/hw/base/slate_base_component.hpp"
 #include "trossen_sdk/hw/base/slate_base_producer.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/observer/observer_registry.hpp"
 #include "trossen_sdk/hw/teleop/teleop_factory.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
@@ -262,6 +263,52 @@ int main(int argc, char** argv) {
   }
 
   std::cout << "\nProducers registered. Ready to record.\n";
+
+  // ──────────────────────────────────────────────────────────
+  // Observers: registered once, started lazily on first episode, persist across episodes.
+  // ──────────────────────────────────────────────────────────
+
+  if (!cfg.observers.empty()) {
+    std::cout << "Creating observers...\n";
+    // Fail loud on construction errors so a typo'd observer type or missing build flag
+    // does not silently leave the operator with an empty viewer. On failure we print a
+    // diagnostic hint (registered types + rerun build flag) and `return 1`. Returning
+    // (rather than rethrowing) keeps `mgr` in scope so its destructor runs ~SessionManager
+    // -> shutdown(), which joins producer threads cleanly; an exception escaping main()
+    // would invoke std::terminate before unwinding on most GCC builds.
+    for (const auto& obs_cfg : cfg.observers) {
+      if (!obs_cfg.enabled) {
+        std::cout << "  [disabled] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " (skipped: enabled=false)\n";
+        continue;
+      }
+      try {
+        auto obs = trossen::observer::ObserverRegistry::create(
+          obs_cfg.type, obs_cfg.raw_json);
+        mgr.add_observer(obs);
+        std::cout << "  [ok] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " subscriptions=" << obs_cfg.subscriptions.size() << "\n";
+      } catch (const std::exception& e) {
+        // Observers are non-essential by design: a missing/misconfigured one logs and
+        // is skipped, so recording continues without the visual stream. The hint below
+        // points at the build flag for the common "type not registered" case.
+        std::cerr << "  [skip] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " failed to construct: " << e.what() << "\n";
+        const auto types =
+          trossen::observer::ObserverRegistry::get_registered_types();
+        std::cerr << "         Registered observer types:";
+        for (const auto& t : types) std::cerr << " " << t;
+        std::cerr << "\n";
+        if (!trossen::observer::ObserverRegistry::is_registered(obs_cfg.type)) {
+          std::cerr << "         Hint: type '" << obs_cfg.type
+                    << "' is not registered. Rebuild with the matching CMake option "
+                    << "(e.g. -DTROSSEN_ENABLE_RERUN_OBSERVER=ON for the 'rerun' type) "
+                    << "or set 'enabled': false on this observer to silence the warning.\n";
+        }
+        continue;
+      }
+    }
+  }
 
   // ──────────────────────────────────────────────────────────
   // Teleop controllers (constructor stages arms)

--- a/examples/trossen_solo_ai/README.md
+++ b/examples/trossen_solo_ai/README.md
@@ -122,6 +122,39 @@ All settings are in [config.json](config.json) and can be overridden with `--set
 ./build/examples/trossen_solo_ai --set teleop.enabled=false
 ```
 
+**Stream to a live ReRun viewer (optional):**
+
+Build with `-DTROSSEN_ENABLE_RERUN_OBSERVER=ON`, launch a ReRun viewer
+listening on the default gRPC port (`rerun` — the native viewer listens on
+`127.0.0.1:9876` by default), and add an `observers` array to your top-level
+`config.json` object (alongside `hardware`, `producers`, etc.):
+
+```jsonc
+{
+  // ...existing top-level keys...
+  "observers": [
+    {
+      "type":      "rerun",
+      "id":        "live_viewer",
+      "rerun_url": "rerun+http://127.0.0.1:9876/proxy",
+      "app_id":    "trossen_solo_ai",
+      "enabled":   true,
+      "subscriptions": [
+        { "record_id": "leader",       "throttle_hz": 30.0 },
+        { "record_id": "follower",     "throttle_hz": 30.0 },
+        { "record_id": "camera_main",  "throttle_hz": 15.0 },
+        { "record_id": "camera_wrist", "throttle_hz": 15.0 }
+      ]
+    }
+  ]
+}
+```
+
+Each subscription's `record_id` must match a producer's `stream_id` exactly.
+`SdkConfig::from_json` prints a warning to stderr at config parse time for any
+subscription whose `record_id` does not match a producer in the same config.
+Set `"enabled": false` to silence an observer without deleting its block.
+
 ---
 
 ## Converting to LeRobot V2

--- a/examples/trossen_solo_ai/config.json
+++ b/examples/trossen_solo_ai/config.json
@@ -84,6 +84,22 @@
     "chunk_size_bytes": 4194304
   },
 
+  "observers": [
+    {
+      "type":      "rerun",
+      "id":        "live_viewer",
+      "rerun_url": "rerun+http://127.0.0.1:9876/proxy",
+      "app_id":    "trossen_solo_ai",
+      "enabled":   true,
+      "subscriptions": [
+        { "record_id": "leader",       "throttle_hz": 30.0 },
+        { "record_id": "follower",     "throttle_hz": 30.0 },
+        { "record_id": "camera_main",  "throttle_hz": 15.0 },
+        { "record_id": "camera_wrist", "throttle_hz": 15.0 }
+      ]
+    }
+  ],
+
   "session": {
     "max_duration":  10.0,
     "max_episodes":  5,

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -40,6 +40,7 @@
 #include "trossen_sdk/hw/arm/trossen_arm_producer.hpp"
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/observer/observer_registry.hpp"
 #include "trossen_sdk/hw/teleop/teleop_factory.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
@@ -228,6 +229,52 @@ int main(int argc, char** argv) {
   }
 
   std::cout << "\nProducers registered. Ready to record.\n";
+
+  // ──────────────────────────────────────────────────────────
+  // Observers: registered once, started lazily on first episode, persist across episodes.
+  // ──────────────────────────────────────────────────────────
+
+  if (!cfg.observers.empty()) {
+    std::cout << "Creating observers...\n";
+    // Fail loud on construction errors so a typo'd observer type or missing build flag
+    // does not silently leave the operator with an empty viewer. On failure we print a
+    // diagnostic hint (registered types + rerun build flag) and `return 1`. Returning
+    // (rather than rethrowing) keeps `mgr` in scope so its destructor runs ~SessionManager
+    // -> shutdown(), which joins producer threads cleanly; an exception escaping main()
+    // would invoke std::terminate before unwinding on most GCC builds.
+    for (const auto& obs_cfg : cfg.observers) {
+      if (!obs_cfg.enabled) {
+        std::cout << "  [disabled] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " (skipped: enabled=false)\n";
+        continue;
+      }
+      try {
+        auto obs = trossen::observer::ObserverRegistry::create(
+          obs_cfg.type, obs_cfg.raw_json);
+        mgr.add_observer(obs);
+        std::cout << "  [ok] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " subscriptions=" << obs_cfg.subscriptions.size() << "\n";
+      } catch (const std::exception& e) {
+        // Observers are non-essential by design: a missing/misconfigured one logs and
+        // is skipped, so recording continues without the visual stream. The hint below
+        // points at the build flag for the common "type not registered" case.
+        std::cerr << "  [skip] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " failed to construct: " << e.what() << "\n";
+        const auto types =
+          trossen::observer::ObserverRegistry::get_registered_types();
+        std::cerr << "         Registered observer types:";
+        for (const auto& t : types) std::cerr << " " << t;
+        std::cerr << "\n";
+        if (!trossen::observer::ObserverRegistry::is_registered(obs_cfg.type)) {
+          std::cerr << "         Hint: type '" << obs_cfg.type
+                    << "' is not registered. Rebuild with the matching CMake option "
+                    << "(e.g. -DTROSSEN_ENABLE_RERUN_OBSERVER=ON for the 'rerun' type) "
+                    << "or set 'enabled': false on this observer to silence the warning.\n";
+        }
+        continue;
+      }
+    }
+  }
 
   // ──────────────────────────────────────────────────────────
   // Teleop controllers (constructor stages arms)

--- a/examples/trossen_stationary_ai/README.md
+++ b/examples/trossen_stationary_ai/README.md
@@ -124,6 +124,43 @@ Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
 ./build/examples/trossen_stationary_ai --set teleop.enabled=false
 ```
 
+**Stream to a live ReRun viewer (optional):**
+
+Build with `-DTROSSEN_ENABLE_RERUN_OBSERVER=ON`, launch a ReRun viewer
+listening on the default gRPC port (`rerun` — the native viewer listens on
+`127.0.0.1:9876` by default), and add an `observers` array to your top-level
+`config.json` object (alongside `hardware`, `producers`, etc.):
+
+```jsonc
+{
+  // ...existing top-level keys...
+  "observers": [
+    {
+      "type":      "rerun",
+      "id":        "live_viewer",
+      "rerun_url": "rerun+http://127.0.0.1:9876/proxy",
+      "app_id":    "trossen_stationary_ai",
+      "enabled":   true,
+      "subscriptions": [
+        { "record_id": "leader_left",        "throttle_hz": 30.0 },
+        { "record_id": "leader_right",       "throttle_hz": 30.0 },
+        { "record_id": "follower_left",      "throttle_hz": 30.0 },
+        { "record_id": "follower_right",     "throttle_hz": 30.0 },
+        { "record_id": "camera_high",        "throttle_hz": 15.0 },
+        { "record_id": "camera_low",         "throttle_hz": 15.0 },
+        { "record_id": "camera_left_wrist",  "throttle_hz": 15.0 },
+        { "record_id": "camera_right_wrist", "throttle_hz": 15.0 }
+      ]
+    }
+  ]
+}
+```
+
+Each subscription's `record_id` must match a producer's `stream_id` exactly.
+`SdkConfig::from_json` prints a warning to stderr at config parse time for any
+subscription whose `record_id` does not match a producer in the same config.
+Set `"enabled": false` to silence an observer without deleting its block.
+
 ---
 
 ## Converting to LeRobot V2

--- a/examples/trossen_stationary_ai/config.json
+++ b/examples/trossen_stationary_ai/config.json
@@ -139,6 +139,26 @@
     "chunk_size_bytes": 4194304
   },
 
+  "observers": [
+    {
+      "type":      "rerun",
+      "id":        "live_viewer",
+      "rerun_url": "rerun+http://127.0.0.1:9876/proxy",
+      "app_id":    "trossen_stationary_ai",
+      "enabled":   true,
+      "subscriptions": [
+        { "record_id": "leader_left",        "throttle_hz": 30.0 },
+        { "record_id": "leader_right",       "throttle_hz": 30.0 },
+        { "record_id": "follower_left",      "throttle_hz": 30.0 },
+        { "record_id": "follower_right",     "throttle_hz": 30.0 },
+        { "record_id": "camera_high",        "throttle_hz": 15.0 },
+        { "record_id": "camera_low",         "throttle_hz": 15.0 },
+        { "record_id": "camera_left_wrist",  "throttle_hz": 15.0 },
+        { "record_id": "camera_right_wrist", "throttle_hz": 15.0 }
+      ]
+    }
+  ],
+
   "session": {
     "max_duration":  20.0,
     "max_episodes":  5,

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -41,6 +41,7 @@
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
 #include "trossen_sdk/hw/teleop/teleop_factory.hpp"
+#include "trossen_sdk/observer/observer_registry.hpp"
 #include "trossen_sdk/runtime/producer_registry.hpp"
 #include "trossen_sdk/runtime/push_producer_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
@@ -229,6 +230,52 @@ int main(int argc, char** argv) {
   }
 
   std::cout << "\nProducers registered. Ready to record.\n";
+
+  // ──────────────────────────────────────────────────────────
+  // Observers: registered once, started lazily on first episode, persist across episodes.
+  // ──────────────────────────────────────────────────────────
+
+  if (!cfg.observers.empty()) {
+    std::cout << "Creating observers...\n";
+    // Fail loud on construction errors so a typo'd observer type or missing build flag
+    // does not silently leave the operator with an empty viewer. On failure we print a
+    // diagnostic hint (registered types + rerun build flag) and `return 1`. Returning
+    // (rather than rethrowing) keeps `mgr` in scope so its destructor runs ~SessionManager
+    // -> shutdown(), which joins producer threads cleanly; an exception escaping main()
+    // would invoke std::terminate before unwinding on most GCC builds.
+    for (const auto& obs_cfg : cfg.observers) {
+      if (!obs_cfg.enabled) {
+        std::cout << "  [disabled] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " (skipped: enabled=false)\n";
+        continue;
+      }
+      try {
+        auto obs = trossen::observer::ObserverRegistry::create(
+          obs_cfg.type, obs_cfg.raw_json);
+        mgr.add_observer(obs);
+        std::cout << "  [ok] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " subscriptions=" << obs_cfg.subscriptions.size() << "\n";
+      } catch (const std::exception& e) {
+        // Observers are non-essential by design: a missing/misconfigured one logs and
+        // is skipped, so recording continues without the visual stream. The hint below
+        // points at the build flag for the common "type not registered" case.
+        std::cerr << "  [skip] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " failed to construct: " << e.what() << "\n";
+        const auto types =
+          trossen::observer::ObserverRegistry::get_registered_types();
+        std::cerr << "         Registered observer types:";
+        for (const auto& t : types) std::cerr << " " << t;
+        std::cerr << "\n";
+        if (!trossen::observer::ObserverRegistry::is_registered(obs_cfg.type)) {
+          std::cerr << "         Hint: type '" << obs_cfg.type
+                    << "' is not registered. Rebuild with the matching CMake option "
+                    << "(e.g. -DTROSSEN_ENABLE_RERUN_OBSERVER=ON for the 'rerun' type) "
+                    << "or set 'enabled': false on this observer to silence the warning.\n";
+        }
+        continue;
+      }
+    }
+  }
 
   // ──────────────────────────────────────────────────────────
   // Teleop controllers (constructor stages arms)


### PR DESCRIPTION
## Summary

Wire the new observer plumbing into all three example apps (solo, stationary, mobile) so users can stream a recording session to a live ReRun viewer by adding an `observers` block to the example's `config.json`. Demonstrates the full stack end-to-end across the three robot configurations.

## Changes

- In `examples/trossen_{solo,stationary,mobile}_ai/trossen_*_ai.cpp`: after producers register, walk `cfg.observers`, skip entries with `enabled=false`, construct each one via `ObserverRegistry::create()`, and hand it to `SessionManager::add_observer()`. Unregistered observer types are logged and skipped (with a hint about the matching build flag) rather than aborting startup — observers are non-essential by design, so recording continues without the viewer.
- In `examples/trossen_{solo,stationary,mobile}_ai/config.json`: populated `observers` blocks with rerun subscriptions matching each example's producer stream ids and reasonable throttle rates (30 Hz for joint states, 15 Hz for cameras).
- In `examples/trossen_{solo,stationary,mobile}_ai/README.md`: added a "Stream to a live ReRun viewer" section showing the build flag, the viewer command, and the `observers` JSON block.

## Test Plan

- [x] Builds cleanly (`make build`) with the option OFF (examples build without observers section in JSON)
- [x] Builds cleanly with `-DTROSSEN_ENABLE_RERUN_OBSERVER=ON`
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware — run `rerun --serve`, run each `trossen_*_ai` with the observers block in config.json, confirm camera frames and joint states stream into the viewer in real time

## Breaking Changes

None. Each example tolerates configs without an `observers` block (the new code is a no-op when the array is empty).

## Related Issues

Relates to TDS-116

Relates to TDS-174