### PR TITLE
observers: harden rerun observer for live hardware use

### DIFF
--- a/examples/trossen_mobile_ai/README.md
+++ b/examples/trossen_mobile_ai/README.md
@@ -151,6 +151,15 @@ listening on the default gRPC port (`rerun` — the native viewer listens on
 `127.0.0.1:9876` by default), and add an `observers` array to your top-level
 `config.json` object (alongside `hardware`, `producers`, etc.):
 
+> **Keep the viewer reasonably current.** This SDK builds against rerun-cpp
+> `0.32.0` (pinned as `RERUN_SDK_VERSION` in `CMakeLists.txt`); a viewer of
+> **0.32 or newer** is recommended. Slightly older viewers usually still render
+> but may log harmless schema-version warnings, while very old viewers fail to
+> render and log errors such as `transport error` or `dropping LogMsg ...
+> Missing row_id column`. Install with `uv tool install rerun-sdk` (or `pip
+> install rerun-sdk`, or `sudo snap install rerun`); if the viewer stays blank,
+> update it.
+
 ```jsonc
 {
   // ...existing top-level keys...

--- a/examples/trossen_solo_ai/README.md
+++ b/examples/trossen_solo_ai/README.md
@@ -129,6 +129,15 @@ listening on the default gRPC port (`rerun` — the native viewer listens on
 `127.0.0.1:9876` by default), and add an `observers` array to your top-level
 `config.json` object (alongside `hardware`, `producers`, etc.):
 
+> **Keep the viewer reasonably current.** This SDK builds against rerun-cpp
+> `0.32.0` (pinned as `RERUN_SDK_VERSION` in `CMakeLists.txt`); a viewer of
+> **0.32 or newer** is recommended. Slightly older viewers usually still render
+> but may log harmless schema-version warnings, while very old viewers fail to
+> render and log errors such as `transport error` or `dropping LogMsg ...
+> Missing row_id column`. Install with `uv tool install rerun-sdk` (or `pip
+> install rerun-sdk`, or `sudo snap install rerun`); if the viewer stays blank,
+> update it.
+
 ```jsonc
 {
   // ...existing top-level keys...

--- a/examples/trossen_stationary_ai/README.md
+++ b/examples/trossen_stationary_ai/README.md
@@ -131,6 +131,15 @@ listening on the default gRPC port (`rerun` — the native viewer listens on
 `127.0.0.1:9876` by default), and add an `observers` array to your top-level
 `config.json` object (alongside `hardware`, `producers`, etc.):
 
+> **Keep the viewer reasonably current.** This SDK builds against rerun-cpp
+> `0.32.0` (pinned as `RERUN_SDK_VERSION` in `CMakeLists.txt`); a viewer of
+> **0.32 or newer** is recommended. Slightly older viewers usually still render
+> but may log harmless schema-version warnings, while very old viewers fail to
+> render and log errors such as `transport error` or `dropping LogMsg ...
+> Missing row_id column`. Install with `uv tool install rerun-sdk` (or `pip
+> install rerun-sdk`, or `sudo snap install rerun`); if the viewer stays blank,
+> update it.
+
 ```jsonc
 {
   // ...existing top-level keys...

--- a/include/trossen_sdk/configuration/types/observers/observer_config.hpp
+++ b/include/trossen_sdk/configuration/types/observers/observer_config.hpp
@@ -41,6 +41,14 @@ struct ObserverSubscriptionConfig {
   /// Maximum handler dispatch rate (Hz); must lie within [1e-3, 1e4].
   double throttle_hz{0.0};
 
+  /// Optional per-subscription field filter. When non-empty, only the listed
+  /// record fields are forwarded to the observer's downstream (e.g. logged to
+  /// ReRun); other fields are silently dropped. Empty means "forward all fields"
+  /// (default, backward compatible). Field name semantics are observer-specific -
+  /// e.g. ``RerunObserver`` honours ``positions``/``velocities``/``efforts`` on
+  /// ``JointStateRecord``.
+  std::vector<std::string> fields;
+
   static ObserverSubscriptionConfig from_json(const nlohmann::json& j) {
     ObserverSubscriptionConfig c;
     if (!j.is_object()) {
@@ -61,6 +69,21 @@ struct ObserverSubscriptionConfig {
           c.record_id + "'");
       }
       j.at("throttle_hz").get_to(c.throttle_hz);
+    }
+    if (j.contains("fields")) {
+      if (!j.at("fields").is_array()) {
+        throw std::runtime_error(
+          "ObserverSubscriptionConfig: 'fields' must be an array of strings for "
+          "record_id '" + c.record_id + "'");
+      }
+      for (const auto& f : j.at("fields")) {
+        if (!f.is_string() || f.get<std::string>().empty()) {
+          throw std::runtime_error(
+            "ObserverSubscriptionConfig: 'fields' entries must be non-empty strings "
+            "for record_id '" + c.record_id + "'");
+        }
+        c.fields.push_back(f.get<std::string>());
+      }
     }
     if (c.record_id.empty()) {
       throw std::runtime_error(

--- a/include/trossen_sdk/observer/observer_base.hpp
+++ b/include/trossen_sdk/observer/observer_base.hpp
@@ -256,6 +256,38 @@ public:
   }
 
   /**
+   * @brief Episode-boundary hook: episode is about to start.
+   *
+   * Invoked by ``SessionManager`` once per episode start, before user
+   * ``on_episode_started`` callbacks run. Only fired on observers that are currently
+   * running (``is_running() == true``). Dispatched outside ``episode_mutex_``, so a
+   * subclass implementation is free to call back into the SessionManager.
+   *
+   * Default implementation is a no-op. Subclasses override to reset per-episode
+   * state (rolling-window counters, plot timelines) or to log per-episode markers.
+   *
+   * @param episode_index the index of the episode that is starting.
+   */
+  virtual void on_episode_start(uint32_t episode_index) noexcept {
+    (void)episode_index;
+  }
+
+  /**
+   * @brief Episode-boundary hook: episode just ended.
+   *
+   * Invoked by ``SessionManager`` once per episode end, after the sink has been
+   * drained but before user ``on_episode_ended`` callbacks fire. Same locking and
+   * filtering contract as ``on_episode_start``. Subclasses override to flush
+   * per-episode state (telemetry snapshots, plot clears) before user-visible
+   * callbacks observe the final stats.
+   *
+   * @param episode_index the index of the episode that just ended.
+   */
+  virtual void on_episode_end(uint32_t episode_index) noexcept {
+    (void)episode_index;
+  }
+
+  /**
    * @brief Hand a record from a Producer's emit callback to this observer.
    *
    * Safe to call concurrently from many threads. ``nullptr`` is silently ignored.

--- a/include/trossen_sdk/observer/observer_base.hpp
+++ b/include/trossen_sdk/observer/observer_base.hpp
@@ -258,17 +258,21 @@ public:
   /**
    * @brief Episode-boundary hook: episode is about to start.
    *
-   * Invoked by ``SessionManager`` once per episode start, before user
-   * ``on_episode_started`` callbacks run. Only fired on observers that are currently
-   * running (``is_running() == true``). Dispatched outside ``episode_mutex_``, so a
-   * subclass implementation is free to call back into the SessionManager.
+   * Invoked by ``SessionManager`` once per episode start, *before* any producer
+   * (push or scheduled) starts emitting records and before user
+   * ``on_episode_started`` callbacks run. This ordering lets the hook reset
+   * per-episode state without racing the first record.
+   *
+   * Only fired on observers that are currently running (``is_running() == true``).
+   * Dispatched outside ``episode_mutex_``, so a subclass implementation is free to
+   * call back into the SessionManager.
    *
    * Default implementation is a no-op. Subclasses override to reset per-episode
    * state (rolling-window counters, plot timelines) or to log per-episode markers.
    *
    * @param episode_index the index of the episode that is starting.
    */
-  virtual void on_episode_start(uint32_t episode_index) noexcept {
+  virtual void on_episode_started(uint32_t episode_index) noexcept {
     (void)episode_index;
   }
 
@@ -277,13 +281,13 @@ public:
    *
    * Invoked by ``SessionManager`` once per episode end, after the sink has been
    * drained but before user ``on_episode_ended`` callbacks fire. Same locking and
-   * filtering contract as ``on_episode_start``. Subclasses override to flush
+   * filtering contract as ``on_episode_started``. Subclasses override to flush
    * per-episode state (telemetry snapshots, plot clears) before user-visible
    * callbacks observe the final stats.
    *
    * @param episode_index the index of the episode that just ended.
    */
-  virtual void on_episode_end(uint32_t episode_index) noexcept {
+  virtual void on_episode_ended(uint32_t episode_index) noexcept {
     (void)episode_index;
   }
 

--- a/include/trossen_sdk/observer/rerun_observer.hpp
+++ b/include/trossen_sdk/observer/rerun_observer.hpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -171,8 +172,14 @@ private:
    * lazily by ``dispatch_`` (encoding is unknown at construction; we don't pre-populate
    * here for that reason).
    *
-   * Worker-thread invariant: ``RerunObserver`` has a single worker, and ``dispatch_``
-   * is the sole reader/writer of ``subscription_state_``. No synchronisation required.
+   * Synchronisation: ``dispatch_`` (worker thread) inserts into ``subscription_state_``
+   * on first sight of each ``record_id``, and ``on_episode_start`` (caller thread)
+   * iterates the map to log a Clear per entity. Concurrent insert-vs-iterate would be
+   * a data race, so both code paths take ``subscription_state_mutex_`` only long
+   * enough to lookup-or-insert (``dispatch_``) or snapshot the keys (``on_episode_start``).
+   * ``std::unordered_map`` guarantees that references to existing elements stay valid
+   * across rehashes, so ``dispatch_`` releases the lock before touching the entry's
+   * fields - no contention on the hot path beyond the brief map lookup.
    */
   struct PerSubscriptionState {
     /// Resolved color encoding for ``ImageRecord`` payloads on this subscription.
@@ -218,9 +225,11 @@ private:
 
   // Lazy per-record_id cache. Keyed by the ``record_id`` argument passed to
   // ``dispatch_``; ``operator[]`` inserts a default-constructed entry on first sight.
-  // Only ``dispatch_`` (worker thread) touches this map, so no synchronisation is
-  // required.
+  // ``dispatch_`` (worker thread) inserts; ``on_episode_start`` (caller thread)
+  // iterates. ``subscription_state_mutex_`` serialises insert-vs-iterate; see the
+  // ``PerSubscriptionState`` docstring for the locking discipline.
   std::unordered_map<std::string, PerSubscriptionState> subscription_state_;
+  std::mutex subscription_state_mutex_;
 
   std::atomic<uint64_t> skipped_frames_{0};
 };

--- a/include/trossen_sdk/observer/rerun_observer.hpp
+++ b/include/trossen_sdk/observer/rerun_observer.hpp
@@ -148,9 +148,9 @@ public:
    *
    * Per-record on-disk capture (MCAP, etc.) is unaffected - this only clears what the
    * live viewer renders. Dispatched outside ``episode_mutex_`` per the
-   * ``ObserverBase::on_episode_start`` contract.
+   * ``ObserverBase::on_episode_started`` contract.
    */
-  void on_episode_start(uint32_t episode_index) noexcept override;
+  void on_episode_started(uint32_t episode_index) noexcept override;
 
 protected:
   /// Open the ReRun gRPC connection. Returns ``false`` on transport failure.
@@ -173,10 +173,10 @@ private:
    * here for that reason).
    *
    * Synchronisation: ``dispatch_`` (worker thread) inserts into ``subscription_state_``
-   * on first sight of each ``record_id``, and ``on_episode_start`` (caller thread)
+   * on first sight of each ``record_id``, and ``on_episode_started`` (caller thread)
    * iterates the map to log a Clear per entity. Concurrent insert-vs-iterate would be
    * a data race, so both code paths take ``subscription_state_mutex_`` only long
-   * enough to lookup-or-insert (``dispatch_``) or snapshot the keys (``on_episode_start``).
+   * enough to lookup-or-insert (``dispatch_``) or snapshot the keys (``on_episode_started``).
    * ``std::unordered_map`` guarantees that references to existing elements stay valid
    * across rehashes, so ``dispatch_`` releases the lock before touching the entry's
    * fields - no contention on the hot path beyond the brief map lookup.
@@ -225,7 +225,7 @@ private:
 
   // Lazy per-record_id cache. Keyed by the ``record_id`` argument passed to
   // ``dispatch_``; ``operator[]`` inserts a default-constructed entry on first sight.
-  // ``dispatch_`` (worker thread) inserts; ``on_episode_start`` (caller thread)
+  // ``dispatch_`` (worker thread) inserts; ``on_episode_started`` (caller thread)
   // iterates. ``subscription_state_mutex_`` serialises insert-vs-iterate; see the
   // ``PerSubscriptionState`` docstring for the locking discipline.
   std::unordered_map<std::string, PerSubscriptionState> subscription_state_;

--- a/include/trossen_sdk/observer/rerun_observer.hpp
+++ b/include/trossen_sdk/observer/rerun_observer.hpp
@@ -97,8 +97,13 @@ public:
    *  - ``type`` (string, required) - registry key ("rerun")
    *  - ``id`` (string, optional) - logging name; defaults to ``type``
    *  - ``rerun_url`` (string, optional) - gRPC URL of the ReRun viewer. Defaults to
-   *    ``"rerun+http://127.0.0.1:9876/proxy"`` (matches rerun-cpp).
+   *    ``"rerun+http://127.0.0.1:9876/proxy"`` (matches rerun-cpp). Ignored when
+   *    ``spawn`` is true.
    *  - ``app_id`` (string, optional) - ReRun application id; defaults to ``"trossen_sdk"``.
+   *  - ``spawn`` (bool, optional) - when true, ``on_start()`` launches a local
+   *    ReRun viewer process via ``RecordingStream::spawn()`` instead of connecting
+   *    over gRPC. If a viewer is already listening on the default port, the stream
+   *    is redirected to it (no duplicate processes). Defaults to false.
    *  - ``subscriptions`` (array, required) - each entry must have ``record_id`` (string)
    *    and ``throttle_hz`` (positive number).
    *
@@ -114,11 +119,37 @@ public:
   /// gRPC URL of the connected viewer.
   const std::string& rerun_url() const noexcept { return rerun_url_; }
 
+  /// True if ``on_start()`` will launch a local viewer via ``RecordingStream::spawn``
+  /// instead of connecting to a pre-launched one via ``connect_grpc``.
+  bool spawn_enabled() const noexcept { return spawn_viewer_; }
+
   /// Records the worker reached but did not log (unsupported encoding, record type,
   /// or depth scale). Lets operators detect a silently-empty viewer.
   uint64_t skipped_frames() const noexcept {
     return skipped_frames_.load(std::memory_order_relaxed);
   }
+
+  /**
+   * @brief Clear every subscribed entity tree at the start of a new episode.
+   *
+   * Logs a recursive ``rerun::archetypes::Clear`` to each ``record_id`` we have
+   * dispatched data into, so the viewer drops the previous episode's history before
+   * the new episode's first records arrive. Two problems this fixes:
+   *
+   *   - **Autoscale collapse on cross-episode pose jumps.** A new episode that starts
+   *     at a very different pose from where the last one ended forces rerun's auto-Y
+   *     to span both clusters, squashing the dense pre-jump data against the axis
+   *     edge (it looks like the plot vanished). Clearing keeps each episode's plot
+   *     on its own auto-Y range.
+   *   - **Cross-episode line interpolation.** Without a clear, scalar plots draw a
+   *     long segment connecting the last sample of episode N to the first sample of
+   *     episode N+1; that single steep line is visually misleading.
+   *
+   * Per-record on-disk capture (MCAP, etc.) is unaffected - this only clears what the
+   * live viewer renders. Dispatched outside ``episode_mutex_`` per the
+   * ``ObserverBase::on_episode_start`` contract.
+   */
+  void on_episode_start(uint32_t episode_index) noexcept override;
 
 protected:
   /// Open the ReRun gRPC connection. Returns ``false`` on transport failure.
@@ -163,10 +194,17 @@ private:
     std::optional<ImagePaths> image_paths;
     std::optional<JointPaths> joint_paths;
     std::optional<OdomPaths> odom_paths;
+
+    /// Optional per-subscription field filter. When set (non-empty), only the
+    /// listed field names are forwarded to ReRun for ``JointStateRecord`` (subset
+    /// of ``positions`` / ``velocities`` / ``efforts``). Empty / nullopt means
+    /// "log all available fields" (default, backward compatible).
+    std::optional<std::unordered_set<std::string>> joint_field_filter;
   };
 
   std::string rerun_url_;
   std::string app_id_;
+  bool spawn_viewer_{false};
 
   // Writes (on_start/on_stop) and reads (dispatch_ on the worker) never overlap in time
   // because ObserverBase::start joins-before-on_start and joins-before-on_stop; no

--- a/include/trossen_sdk/observer/rerun_observer.hpp
+++ b/include/trossen_sdk/observer/rerun_observer.hpp
@@ -131,11 +131,15 @@ public:
   }
 
   /**
-   * @brief Clear every subscribed entity tree at the start of a new episode.
+   * @brief Request a viewer clear at the start of a new episode.
    *
-   * Logs a recursive ``rerun::archetypes::Clear`` to each ``record_id`` we have
-   * dispatched data into, so the viewer drops the previous episode's history before
-   * the new episode's first records arrive. Two problems this fixes:
+   * Sets a flag consumed by the worker thread in ``dispatch_``; the actual recursive
+   * ``rerun::archetypes::Clear`` is logged to each subscribed ``record_id`` there,
+   * just before the new episode's first record. The work is deferred off this hook
+   * because it runs on the SessionManager's ``start_episode()`` thread, where a
+   * blocked/absent viewer (gRPC backpressure) would otherwise stall episode start.
+   * Clearing drops the previous episode's history from the viewer. Two problems it
+   * fixes:
    *
    *   - **Autoscale collapse on cross-episode pose jumps.** A new episode that starts
    *     at a very different pose from where the last one ended forces rerun's auto-Y
@@ -163,6 +167,11 @@ private:
   /// Worker-thread dispatch entry point. Captured into each subscription's handler.
   void dispatch_(const std::string& record_id,
                  const std::shared_ptr<data::RecordBase>& rec);
+
+  /// Log a recursive ``Clear`` to every subscribed entity tree. Runs on the worker
+  /// thread (deferred from ``on_episode_started`` via ``episode_clear_pending_``) so a
+  /// blocked or absent viewer cannot stall the caller's ``start_episode()``.
+  void clear_subscribed_entities_();
 
   /**
    * @brief Per-subscription cached state owned by ``dispatch_``.
@@ -230,6 +239,12 @@ private:
   // ``PerSubscriptionState`` docstring for the locking discipline.
   std::unordered_map<std::string, PerSubscriptionState> subscription_state_;
   std::mutex subscription_state_mutex_;
+
+  // Set by on_episode_started (caller thread), consumed once by dispatch_ (worker
+  // thread) before the new episode's first record is logged. Deferring the viewer
+  // Clear off the caller thread keeps gRPC backpressure (e.g. no viewer draining the
+  // stream) from stalling the SessionManager's start_episode().
+  std::atomic<bool> episode_clear_pending_{false};
 
   std::atomic<uint64_t> skipped_frames_{0};
 };

--- a/src/observer/rerun_observer.cpp
+++ b/src/observer/rerun_observer.cpp
@@ -90,6 +90,7 @@ RerunObserver::RerunObserver(const nlohmann::json& cfg)
   : ObserverBase(cfg.value("id", cfg.value("type", std::string("rerun")))) {
   rerun_url_ = cfg.value("rerun_url", std::string{kDefaultRerunUrl});
   app_id_ = cfg.value("app_id", std::string{kDefaultAppId});
+  spawn_viewer_ = cfg.value("spawn", false);
 
   if (!cfg.contains("subscriptions") || !cfg.at("subscriptions").is_array()) {
     throw std::runtime_error(
@@ -111,6 +112,37 @@ RerunObserver::RerunObserver(const nlohmann::json& cfg)
     }
     const auto record_id = sub_j.at("record_id").get<std::string>();
     const auto throttle_hz = sub_j.at("throttle_hz").get<double>();
+
+    // Optional per-subscription field filter. When present, only the listed joint-state
+    // fields are forwarded; unknown field names are rejected at construction time so a
+    // typo surfaces immediately rather than silently dropping every frame.
+    if (sub_j.contains("fields")) {
+      if (!sub_j.at("fields").is_array()) {
+        throw std::runtime_error(
+          "RerunObserver: 'fields' must be an array of strings for record_id '" +
+          record_id + "'");
+      }
+      static const std::unordered_set<std::string> kJointFieldNames = {
+        "positions", "velocities", "efforts"};
+      std::unordered_set<std::string> filter;
+      for (const auto& f : sub_j.at("fields")) {
+        if (!f.is_string() || f.get<std::string>().empty()) {
+          throw std::runtime_error(
+            "RerunObserver: 'fields' entries must be non-empty strings for "
+            "record_id '" + record_id + "'");
+        }
+        const auto name = f.get<std::string>();
+        if (kJointFieldNames.count(name) == 0) {
+          throw std::runtime_error(
+            "RerunObserver: unknown joint-state field '" + name + "' in 'fields' for "
+            "record_id '" + record_id + "' (allowed: positions, velocities, efforts)");
+        }
+        filter.insert(name);
+      }
+      // Pre-populate the slot so dispatch_ sees the filter on the very first record.
+      subscription_state_[record_id].joint_field_filter = std::move(filter);
+    }
+
     add_subscription(record_id, throttle_hz,
                      [this, record_id](const std::shared_ptr<data::RecordBase>& rec) {
                        dispatch_(record_id, rec);
@@ -130,10 +162,14 @@ RerunObserver::~RerunObserver() {
 bool RerunObserver::on_start() {
   try {
     rec_ = std::make_unique<rerun::RecordingStream>(app_id_);
-    const auto err = rec_->connect_grpc(rerun_url_);
+    // spawn() launches a local viewer if none is listening, otherwise redirects to
+    // the running one - see rerun::RecordingStream::spawn docs. connect_grpc only
+    // attaches to an already-running viewer.
+    const auto err = spawn_viewer_ ? rec_->spawn() : rec_->connect_grpc(rerun_url_);
     if (err.is_err()) {
-      std::cerr << "RerunObserver '" << name()
-                << "' connect_grpc failed: " << err.description << std::endl;
+      std::cerr << "RerunObserver '" << name() << "' "
+                << (spawn_viewer_ ? "spawn" : "connect_grpc")
+                << " failed: " << err.description << std::endl;
       rec_.reset();
       return false;
     }
@@ -153,6 +189,31 @@ bool RerunObserver::on_start() {
 
 void RerunObserver::on_stop() {
   rec_.reset();
+}
+
+void RerunObserver::on_episode_start(uint32_t episode_index) noexcept {
+  (void)episode_index;
+  // No-op if the transport is closed (failed connect, or hook ran before on_start) -
+  // there is nothing to clear in the viewer until we have a recording stream.
+  if (!rec_) {
+    return;
+  }
+  // Iterate every record_id we have dispatched into so far. subscription_state_ is
+  // populated lazily in dispatch_(), so on episode 0 this is typically empty (clears
+  // nothing - correct; nothing to clear). On episode 1+ each previously-seen
+  // record_id gets a recursive Clear, which drops every child entity under it
+  // (e.g. ``slate_base/pose/x``, ``slate_base/twist/linear_x`` etc.) from the viewer's
+  // active time range. The cached path strings inside PerSubscriptionState stay
+  // intact - re-stamping them on the next record is harmless and avoids a per-episode
+  // rebuild on the hot path.
+  try {
+    for (const auto& [record_id, _] : subscription_state_) {
+      rec_->log(record_id, rerun::archetypes::Clear(/*is_recursive=*/true));
+    }
+  } catch (...) {
+    // Swallow: a faulty rerun-cpp call must not raise into SessionManager's fan-out
+    // (the hook is declared noexcept and any throw would terminate the process).
+  }
 }
 
 void RerunObserver::dispatch_(const std::string& record_id,
@@ -176,10 +237,16 @@ void RerunObserver::dispatch_(const std::string& record_id,
     }
   };
 
-  // Use the producer-side monotonic capture time so the timeline does not jump backwards
-  // on system-clock adjustments.
-  const double t_secs = static_cast<double>(rec->ts.monotonic.to_ns()) * 1e-9;
-  rec_->set_time_duration_secs("monotonic", t_secs);
+  // Log the producer-side wall-clock capture time (system_clock, anchored at the Unix
+  // epoch) so the viewer renders human-readable times ("18:25:04.512 local") on plot
+  // axes. We deliberately do NOT use ts.monotonic here - that field comes from
+  // steady_clock (CLOCK_MONOTONIC on Linux) which is anchored at boot, not at the Unix
+  // epoch, so feeding it to set_time_timestamp_secs_since_epoch produces nonsense
+  // wall-clock times offset by however long ago CLOCK_MONOTONIC started. The price of
+  // using realtime is that the timeline can jump backwards on a system-clock adjustment
+  // (NTP / manual set); for live monitoring during recording this is acceptable.
+  const double t_secs = static_cast<double>(rec->ts.realtime.to_ns()) * 1e-9;
+  rec_->set_time_timestamp_secs_since_epoch("wall_clock", t_secs);
 
   if (auto* img = dynamic_cast<data::ImageRecord*>(rec.get())) {
     if (img->image.empty() || img->width == 0 || img->height == 0) {
@@ -277,15 +344,22 @@ void RerunObserver::dispatch_(const std::string& record_id,
         record_id + "/efforts"};
     }
     const auto& jp = *state.joint_paths;
-    if (!js->positions.empty()) {
+    // Honour the per-subscription field filter if one was configured. When unset, all
+    // populated fields are forwarded (legacy default). The filter is validated at
+    // construction time, so we trust its contents here.
+    const auto& filter = state.joint_field_filter;
+    auto wants = [&filter](const char* name) noexcept {
+      return !filter.has_value() || filter->count(name) > 0;
+    };
+    if (!js->positions.empty() && wants("positions")) {
       std::vector<double> pos(js->positions.begin(), js->positions.end());
       rec_->log(jp.positions, rerun::Scalars(std::move(pos)));
     }
-    if (!js->velocities.empty()) {
+    if (!js->velocities.empty() && wants("velocities")) {
       std::vector<double> vel(js->velocities.begin(), js->velocities.end());
       rec_->log(jp.velocities, rerun::Scalars(std::move(vel)));
     }
-    if (!js->efforts.empty()) {
+    if (!js->efforts.empty() && wants("efforts")) {
       std::vector<double> eff(js->efforts.begin(), js->efforts.end());
       rec_->log(jp.efforts, rerun::Scalars(std::move(eff)));
     }

--- a/src/observer/rerun_observer.cpp
+++ b/src/observer/rerun_observer.cpp
@@ -123,6 +123,15 @@ RerunObserver::RerunObserver(const nlohmann::json& cfg)
           "RerunObserver: 'fields' must be an array of strings for record_id '" +
           record_id + "'");
       }
+      // Reject empty array explicitly. An empty filter would drop every joint-state
+      // channel, which is almost never what the operator wants and contradicts the
+      // "omit to forward all" default elsewhere in this config. Force them to omit
+      // the key instead.
+      if (sub_j.at("fields").empty()) {
+        throw std::runtime_error(
+          "RerunObserver: 'fields' must be non-empty for record_id '" + record_id +
+          "' (omit the 'fields' key entirely to forward all joint-state channels)");
+      }
       static const std::unordered_set<std::string> kJointFieldNames = {
         "positions", "velocities", "efforts"};
       std::unordered_set<std::string> filter;
@@ -192,7 +201,7 @@ void RerunObserver::on_stop() {
   rec_.reset();
 }
 
-void RerunObserver::on_episode_start(uint32_t episode_index) noexcept {
+void RerunObserver::on_episode_started(uint32_t episode_index) noexcept {
   (void)episode_index;
   // No-op if the transport is closed (failed connect, or hook ran before on_start) -
   // there is nothing to clear in the viewer until we have a recording stream.
@@ -281,7 +290,7 @@ void RerunObserver::dispatch_(const std::string& record_id,
     // on subsequent frames, and a kUnsupported result sticks so further string churn is
     // impossible for that subscription.
     //
-    // Lock briefly around the lookup-or-insert: on_episode_start may iterate the map
+    // Lock briefly around the lookup-or-insert: on_episode_started may iterate the map
     // concurrently on the caller thread. unordered_map keeps references valid through
     // rehashes, so we can drop the lock and use ``state`` outside the critical section.
     PerSubscriptionState* state_ptr;

--- a/src/observer/rerun_observer.cpp
+++ b/src/observer/rerun_observer.cpp
@@ -203,7 +203,17 @@ void RerunObserver::on_stop() {
 
 void RerunObserver::on_episode_started(uint32_t episode_index) noexcept {
   (void)episode_index;
-  // No-op if the transport is closed (failed connect, or hook ran before on_start) -
+  // Defer the viewer Clear to the worker thread (consumed in dispatch_). This hook
+  // runs on the SessionManager's start_episode() thread; issuing the rec_->log(Clear)
+  // calls here would block that thread under gRPC backpressure when no viewer is
+  // draining the stream, hanging episode start (the buffer fills after ~one episode,
+  // so the stall first appears on the episode-1->2 transition). Setting a flag is
+  // non-blocking; the worker performs the Clear before the new episode's first record.
+  episode_clear_pending_.store(true, std::memory_order_release);
+}
+
+void RerunObserver::clear_subscribed_entities_() {
+  // No-op if the transport is closed (failed connect, or called before on_start) -
   // there is nothing to clear in the viewer until we have a recording stream.
   if (!rec_) {
     return;
@@ -218,9 +228,8 @@ void RerunObserver::on_episode_started(uint32_t episode_index) noexcept {
   // rebuild on the hot path.
   //
   // Snapshot the keys under the mutex before calling rec_->log. dispatch_ runs on the
-  // worker thread and may insert into subscription_state_ concurrently; holding the
-  // mutex through the rerun gRPC calls would needlessly block dispatch_ for the
-  // length of those calls.
+  // same (worker) thread, so there is no insert-vs-iterate race here, but the lock is
+  // cheap and keeps the access discipline uniform with the rest of the class.
   std::vector<std::string> record_ids;
   {
     std::lock_guard<std::mutex> lk(subscription_state_mutex_);
@@ -234,8 +243,7 @@ void RerunObserver::on_episode_started(uint32_t episode_index) noexcept {
       rec_->log(record_id, rerun::archetypes::Clear(/*is_recursive=*/true));
     }
   } catch (...) {
-    // Swallow: a faulty rerun-cpp call must not raise into SessionManager's fan-out
-    // (the hook is declared noexcept and any throw would terminate the process).
+    // Swallow: a faulty rerun-cpp call must not escape the worker loop.
   }
 }
 
@@ -243,6 +251,13 @@ void RerunObserver::dispatch_(const std::string& record_id,
                               const std::shared_ptr<data::RecordBase>& rec) {
   if (!rec_ || !rec) {
     return;
+  }
+
+  // Consume a pending episode-start Clear on this (worker) thread, before logging the
+  // new episode's first record. exchange() ensures the Clear runs exactly once per
+  // episode even though dispatch_ is called per record.
+  if (episode_clear_pending_.exchange(false, std::memory_order_acq_rel)) {
+    clear_subscribed_entities_();
   }
 
   // Count every skip; log once per reason so a config mismatch surfaces a single line

--- a/src/observer/rerun_observer.cpp
+++ b/src/observer/rerun_observer.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -206,8 +207,21 @@ void RerunObserver::on_episode_start(uint32_t episode_index) noexcept {
   // active time range. The cached path strings inside PerSubscriptionState stay
   // intact - re-stamping them on the next record is harmless and avoids a per-episode
   // rebuild on the hot path.
-  try {
+  //
+  // Snapshot the keys under the mutex before calling rec_->log. dispatch_ runs on the
+  // worker thread and may insert into subscription_state_ concurrently; holding the
+  // mutex through the rerun gRPC calls would needlessly block dispatch_ for the
+  // length of those calls.
+  std::vector<std::string> record_ids;
+  {
+    std::lock_guard<std::mutex> lk(subscription_state_mutex_);
+    record_ids.reserve(subscription_state_.size());
     for (const auto& [record_id, _] : subscription_state_) {
+      record_ids.push_back(record_id);
+    }
+  }
+  try {
+    for (const auto& record_id : record_ids) {
       rec_->log(record_id, rerun::archetypes::Clear(/*is_recursive=*/true));
     }
   } catch (...) {
@@ -266,7 +280,16 @@ void RerunObserver::dispatch_(const std::string& record_id,
     // first sight (encoding=kUnresolved). After resolution we never re-parse the string
     // on subsequent frames, and a kUnsupported result sticks so further string churn is
     // impossible for that subscription.
-    auto& state = subscription_state_[record_id];
+    //
+    // Lock briefly around the lookup-or-insert: on_episode_start may iterate the map
+    // concurrently on the caller thread. unordered_map keeps references valid through
+    // rehashes, so we can drop the lock and use ``state`` outside the critical section.
+    PerSubscriptionState* state_ptr;
+    {
+      std::lock_guard<std::mutex> lk(subscription_state_mutex_);
+      state_ptr = &subscription_state_[record_id];
+    }
+    auto& state = *state_ptr;
     if (state.encoding == detail::ColorEncoding::kUnresolved) {
       state.encoding = detail::resolve_encoding(img->encoding);
     }
@@ -336,7 +359,12 @@ void RerunObserver::dispatch_(const std::string& record_id,
   }
 
   if (auto* js = dynamic_cast<data::JointStateRecord*>(rec.get())) {
-    auto& state = subscription_state_[record_id];
+    PerSubscriptionState* state_ptr;
+    {
+      std::lock_guard<std::mutex> lk(subscription_state_mutex_);
+      state_ptr = &subscription_state_[record_id];
+    }
+    auto& state = *state_ptr;
     if (!state.joint_paths.has_value()) {
       state.joint_paths = PerSubscriptionState::JointPaths{
         record_id + "/positions",
@@ -367,7 +395,12 @@ void RerunObserver::dispatch_(const std::string& record_id,
   }
 
   if (auto* odom = dynamic_cast<data::Odometry2DRecord*>(rec.get())) {
-    auto& state = subscription_state_[record_id];
+    PerSubscriptionState* state_ptr;
+    {
+      std::lock_guard<std::mutex> lk(subscription_state_mutex_);
+      state_ptr = &subscription_state_[record_id];
+    }
+    auto& state = *state_ptr;
     if (!state.odom_paths.has_value()) {
       state.odom_paths = PerSubscriptionState::OdomPaths{
         record_id + "/pose/x",

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -355,6 +355,24 @@ bool SessionManager::start_episode() {
   trossen::utils::announce(
     "Episode " + std::to_string(next_episode_index_) + " started", false);
 
+  // Fan out the episode-start hook to every running observer before user callbacks
+  // run, so user code sees observers that have already reset any per-episode state.
+  // start_episode() does not hold episode_mutex_, so this is naturally outside the
+  // lock - same contract as on_episode_end below (see teardown_episode comment).
+  const uint32_t started_episode_index = next_episode_index_;
+  for (const auto& obs : observers_) {
+    if (obs && obs->is_running()) {
+      try {
+        obs->on_episode_start(started_episode_index);
+      } catch (const std::exception& e) {
+        // on_episode_start is declared noexcept, but a misbehaving subclass could
+        // still terminate via throw - guard belt-and-suspenders.
+        std::cerr << "Observer '" << obs->name()
+                  << "' on_episode_start error: " << e.what() << std::endl;
+      }
+    }
+  }
+
   // Invoke episode-started callbacks
   for (const auto& cb : episode_started_cbs_) {
     try {
@@ -389,8 +407,12 @@ void SessionManager::teardown_episode(bool discard) {
     monitor_thread_.join();
   }
 
-  // Now safely acquire lock and do cleanup
-  std::lock_guard<std::mutex> lock(episode_mutex_);
+  // Now safely acquire lock and do cleanup. We use unique_lock (not lock_guard) so we
+  // can release the mutex before dispatching on_episode_ended callbacks below - those
+  // callbacks routinely want to call observer_stats() / stats(), both of which re-acquire
+  // episode_mutex_ via lock_guard. std::mutex is non-recursive, so dispatching callbacks
+  // while still holding the lock would deadlock on the first such accessor call.
+  std::unique_lock<std::mutex> lock(episode_mutex_);
 
   if (!episode_active_) {
     return;  // no-op if not active
@@ -478,8 +500,33 @@ void SessionManager::teardown_episode(bool discard) {
     Stats final_stats = stats_unlocked();
     final_stats.current_episode_index = finished_episode_index;
 
+    // Snapshot the callback list and the observers list under the lock so concurrent
+    // registration (on_episode_ended()) or shutdown cannot race with the dispatch
+    // loops below.
+    auto callbacks_snapshot = episode_ended_cbs_;
+    auto observers_snapshot = observers_;
+
+    // Release episode_mutex_ before dispatching callbacks. Callbacks must be free to
+    // call back into the SessionManager (observer_stats, stats, etc.) without deadlock;
+    // see the unique_lock comment at the top of this function.
+    lock.unlock();
+
+    // Fan out the episode-end hook to every running observer before user callbacks
+    // run, so user code (telemetry sidecar, summary print, etc.) sees observers that
+    // have already finalised their per-episode state.
+    for (const auto& obs : observers_snapshot) {
+      if (obs && obs->is_running()) {
+        try {
+          obs->on_episode_end(finished_episode_index);
+        } catch (const std::exception& e) {
+          std::cerr << "Observer '" << obs->name()
+                    << "' on_episode_end error: " << e.what() << std::endl;
+        }
+      }
+    }
+
     // Invoke episode-ended callbacks
-    for (const auto& cb : episode_ended_cbs_) {
+    for (const auto& cb : callbacks_snapshot) {
       try {
         cb(final_stats);
       } catch (const std::exception& e) {

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -273,6 +273,24 @@ bool SessionManager::start_episode() {
     }
   }
 
+  // Fan out the episode-started hook to every running observer BEFORE any producer
+  // (push or scheduled) is started, so the hook can reset per-episode state (e.g.
+  // RerunObserver clearing entity trees) without racing the first record. Filters on
+  // is_running() rather than reusing observers_snapshot's !is_stopped() filter because
+  // the hook contract is "fired on observers that are currently running".
+  // start_episode() does not hold episode_mutex_, so this is naturally outside the
+  // lock - same contract as on_episode_ended below (see teardown_episode comment).
+  // Note: if push-producer startup below fails and triggers cleanup_and_abort(), this
+  // observer-side "started" hook will have fired without a matching "ended". Treated
+  // as acceptable: producer failures are rare and surface their own diagnostics, and
+  // observers' per-episode reset is idempotent against the next successful start.
+  const uint32_t started_episode_index = next_episode_index_;
+  for (const auto& obs : observers_) {
+    if (obs && obs->is_running()) {
+      obs->on_episode_started(started_episode_index);
+    }
+  }
+
   // Start push producers (own threads, emit into current sink)
   // Capture shared_ptr to ensure Sink lifetime outlives any in-flight emit callbacks
   std::shared_ptr<io::Sink> sink_shared = current_sink_;
@@ -354,24 +372,6 @@ bool SessionManager::start_episode() {
 
   trossen::utils::announce(
     "Episode " + std::to_string(next_episode_index_) + " started", false);
-
-  // Fan out the episode-start hook to every running observer before user callbacks
-  // run, so user code sees observers that have already reset any per-episode state.
-  // start_episode() does not hold episode_mutex_, so this is naturally outside the
-  // lock - same contract as on_episode_end below (see teardown_episode comment).
-  const uint32_t started_episode_index = next_episode_index_;
-  for (const auto& obs : observers_) {
-    if (obs && obs->is_running()) {
-      try {
-        obs->on_episode_start(started_episode_index);
-      } catch (const std::exception& e) {
-        // on_episode_start is declared noexcept, but a misbehaving subclass could
-        // still terminate via throw - guard belt-and-suspenders.
-        std::cerr << "Observer '" << obs->name()
-                  << "' on_episode_start error: " << e.what() << std::endl;
-      }
-    }
-  }
 
   // Invoke episode-started callbacks
   for (const auto& cb : episode_started_cbs_) {
@@ -511,17 +511,12 @@ void SessionManager::teardown_episode(bool discard) {
     // see the unique_lock comment at the top of this function.
     lock.unlock();
 
-    // Fan out the episode-end hook to every running observer before user callbacks
+    // Fan out the episode-ended hook to every running observer before user callbacks
     // run, so user code (telemetry sidecar, summary print, etc.) sees observers that
     // have already finalised their per-episode state.
     for (const auto& obs : observers_snapshot) {
       if (obs && obs->is_running()) {
-        try {
-          obs->on_episode_end(finished_episode_index);
-        } catch (const std::exception& e) {
-          std::cerr << "Observer '" << obs->name()
-                    << "' on_episode_end error: " << e.what() << std::endl;
-        }
+        obs->on_episode_ended(finished_episode_index);
       }
     }
 

--- a/tests/test_observer_registry.cpp
+++ b/tests/test_observer_registry.cpp
@@ -72,6 +72,42 @@ TEST(ObserverSubscriptionConfigTest, Rejects_NonPositiveThrottle) {
                std::runtime_error);
 }
 
+TEST(ObserverSubscriptionConfigTest, Fields_OptionalDefaultsEmpty) {
+  auto j = json::parse(R"({"record_id": "arm", "throttle_hz": 30.0})");
+  auto c = ObserverSubscriptionConfig::from_json(j);
+  EXPECT_TRUE(c.fields.empty());
+}
+
+TEST(ObserverSubscriptionConfigTest, Fields_ParsesStringArray) {
+  auto j = json::parse(R"({
+    "record_id":   "arm",
+    "throttle_hz": 30.0,
+    "fields":      ["positions", "efforts"]
+  })");
+  auto c = ObserverSubscriptionConfig::from_json(j);
+  ASSERT_EQ(c.fields.size(), 2u);
+  EXPECT_EQ(c.fields[0], "positions");
+  EXPECT_EQ(c.fields[1], "efforts");
+}
+
+TEST(ObserverSubscriptionConfigTest, Fields_RejectsNonArrayAndNonStrings) {
+  EXPECT_THROW(ObserverSubscriptionConfig::from_json(json::parse(R"({
+    "record_id":   "arm",
+    "throttle_hz": 30.0,
+    "fields":      "positions"
+  })")), std::runtime_error);
+  EXPECT_THROW(ObserverSubscriptionConfig::from_json(json::parse(R"({
+    "record_id":   "arm",
+    "throttle_hz": 30.0,
+    "fields":      [1, 2]
+  })")), std::runtime_error);
+  EXPECT_THROW(ObserverSubscriptionConfig::from_json(json::parse(R"({
+    "record_id":   "arm",
+    "throttle_hz": 30.0,
+    "fields":      [""]
+  })")), std::runtime_error);
+}
+
 // ----------------------------------------------------------------------------
 // ObserverConfig
 // ----------------------------------------------------------------------------

--- a/tests/test_rerun_observer.cpp
+++ b/tests/test_rerun_observer.cpp
@@ -97,6 +97,21 @@ TEST(RerunObserverTest, Construct_RejectsNonArrayFields) {
   EXPECT_THROW(RerunObserver{cfg}, std::runtime_error);
 }
 
+TEST(RerunObserverTest, Construct_RejectsEmptyFieldsArray) {
+  // Empty 'fields': [] is rejected explicitly so it can't be confused with "omit to
+  // forward all" semantics - an empty filter would otherwise silently drop every
+  // joint-state channel.
+  auto cfg = json::parse(R"({
+    "type": "rerun",
+    "subscriptions": [{
+      "record_id":   "arm",
+      "throttle_hz": 30.0,
+      "fields":      []
+    }]
+  })");
+  EXPECT_THROW(RerunObserver{cfg}, std::runtime_error);
+}
+
 TEST(RerunObserverTest, Construct_SpawnDefaultsOffAndHonoursExplicitTrue) {
   // spawn defaults to false (connect_grpc path).
   auto cfg_default = json::parse(R"({

--- a/tests/test_rerun_observer.cpp
+++ b/tests/test_rerun_observer.cpp
@@ -59,6 +59,65 @@ TEST(RerunObserverTest, Construct_HonoursIdRerunUrlAndAppId) {
   EXPECT_EQ(obs.subscription_count(), 2u);
 }
 
+TEST(RerunObserverTest, Construct_AcceptsKnownJointFields) {
+  auto cfg = json::parse(R"({
+    "type": "rerun",
+    "subscriptions": [{
+      "record_id":   "arm",
+      "throttle_hz": 30.0,
+      "fields":      ["positions"]
+    }]
+  })");
+  EXPECT_NO_THROW(RerunObserver{cfg});
+}
+
+TEST(RerunObserverTest, Construct_RejectsUnknownJointFieldName) {
+  // Typo-style protection: unknown field names throw at construction so an operator
+  // mistake surfaces immediately instead of silently dropping every frame.
+  auto cfg = json::parse(R"({
+    "type": "rerun",
+    "subscriptions": [{
+      "record_id":   "arm",
+      "throttle_hz": 30.0,
+      "fields":      ["psotions"]
+    }]
+  })");
+  EXPECT_THROW(RerunObserver{cfg}, std::runtime_error);
+}
+
+TEST(RerunObserverTest, Construct_RejectsNonArrayFields) {
+  auto cfg = json::parse(R"({
+    "type": "rerun",
+    "subscriptions": [{
+      "record_id":   "arm",
+      "throttle_hz": 30.0,
+      "fields":      "positions"
+    }]
+  })");
+  EXPECT_THROW(RerunObserver{cfg}, std::runtime_error);
+}
+
+TEST(RerunObserverTest, Construct_SpawnDefaultsOffAndHonoursExplicitTrue) {
+  // spawn defaults to false (connect_grpc path).
+  auto cfg_default = json::parse(R"({
+    "type": "rerun",
+    "subscriptions": [{"record_id": "arm", "throttle_hz": 30.0}]
+  })");
+  RerunObserver obs_default(cfg_default);
+  EXPECT_FALSE(obs_default.spawn_enabled());
+
+  // spawn=true is parsed and stored. on_start() will branch to RecordingStream::spawn
+  // (verified by inspection; not invoked here to avoid actually launching a viewer
+  // process during the unit-test run).
+  auto cfg_spawn = json::parse(R"({
+    "type": "rerun",
+    "spawn": true,
+    "subscriptions": [{"record_id": "arm", "throttle_hz": 30.0}]
+  })");
+  RerunObserver obs_spawn(cfg_spawn);
+  EXPECT_TRUE(obs_spawn.spawn_enabled());
+}
+
 TEST(RerunObserverTest, Construct_RejectsMissingSubscriptions) {
   EXPECT_THROW(
     RerunObserver(json::parse(R"({"type": "rerun"})")),

--- a/tests/test_session_manager_observers.cpp
+++ b/tests/test_session_manager_observers.cpp
@@ -78,7 +78,7 @@ protected:
   bool on_start() override { return false; }
 };
 
-/// Observer that records every on_episode_start / on_episode_end invocation
+/// Observer that records every on_episode_started / on_episode_ended invocation
 /// (with the episode index argument) so tests can assert ordering and payload.
 class EpisodeBoundaryObserver : public ObserverBase {
 public:
@@ -91,10 +91,10 @@ public:
   std::vector<uint32_t> ended_indices;
 
 protected:
-  void on_episode_start(uint32_t episode_index) noexcept override {
+  void on_episode_started(uint32_t episode_index) noexcept override {
     started_indices.push_back(episode_index);
   }
-  void on_episode_end(uint32_t episode_index) noexcept override {
+  void on_episode_ended(uint32_t episode_index) noexcept override {
     ended_indices.push_back(episode_index);
   }
 };
@@ -445,9 +445,9 @@ TEST_F(SessionManagerObserversTest, OnEpisodeEndedCallback_CanCallObserverStats)
 }
 
 TEST_F(SessionManagerObserversTest, EpisodeBoundaryHooks_FireOncePerEpisode) {
-  // on_episode_start / on_episode_end fire exactly once per running observer per
-  // episode, and the index reported to on_episode_end matches the index reported to
-  // the matching on_episode_start. The test fixture uses the null backend, which
+  // on_episode_started / on_episode_ended fire exactly once per running observer per
+  // episode, and the index reported to on_episode_ended matches the index reported to
+  // the matching on_episode_started. The test fixture uses the null backend, which
   // resets next_episode_index_ to 0 via scan_existing_episodes() at every
   // start_episode() - so this test does not assume monotonically increasing indices
   // (that contract is enforced only by persistent backends).
@@ -493,7 +493,7 @@ TEST_F(SessionManagerObserversTest, EpisodeBoundaryHooks_SkipFailedStartObserver
 }
 
 TEST_F(SessionManagerObserversTest, EpisodeEndHook_CanCallObserverStats) {
-  // on_episode_end runs outside episode_mutex_ (same contract as on_episode_ended
+  // on_episode_ended runs outside episode_mutex_ (same contract as on_episode_ended
   // user callbacks). Subclasses are free to call back into the SessionManager from
   // inside the hook without deadlocking - pin that contract.
   class CallbackObserver : public ObserverBase {
@@ -504,7 +504,7 @@ TEST_F(SessionManagerObserversTest, EpisodeEndHook_CanCallObserverStats) {
                        [](const std::shared_ptr<RecordBase>&) {});
     }
     std::atomic<size_t> end_observer_count{0};
-    void on_episode_end(uint32_t episode_index) noexcept override {
+    void on_episode_ended(uint32_t episode_index) noexcept override {
       (void)episode_index;
       end_observer_count.store(sm_->observer_stats().size());
     }

--- a/tests/test_session_manager_observers.cpp
+++ b/tests/test_session_manager_observers.cpp
@@ -78,6 +78,27 @@ protected:
   bool on_start() override { return false; }
 };
 
+/// Observer that records every on_episode_start / on_episode_end invocation
+/// (with the episode index argument) so tests can assert ordering and payload.
+class EpisodeBoundaryObserver : public ObserverBase {
+public:
+  EpisodeBoundaryObserver() : ObserverBase("episode_boundary") {
+    add_subscription("mock/joints", 100.0,
+                     [](const std::shared_ptr<RecordBase>&) {});
+  }
+
+  std::vector<uint32_t> started_indices;
+  std::vector<uint32_t> ended_indices;
+
+protected:
+  void on_episode_start(uint32_t episode_index) noexcept override {
+    started_indices.push_back(episode_index);
+  }
+  void on_episode_end(uint32_t episode_index) noexcept override {
+    ended_indices.push_back(episode_index);
+  }
+};
+
 class SessionManagerObserversTest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
@@ -384,4 +405,121 @@ TEST_F(SessionManagerObserversTest, DiscardEpisode_PreservesObservers) {
 
   EXPECT_GE(obs->stats().accepted, accepted_before);
   EXPECT_TRUE(obs->is_running());
+}
+
+TEST_F(SessionManagerObserversTest, OnEpisodeEndedCallback_CanCallObserverStats) {
+  // Regression: on_episode_ended callbacks used to be dispatched while episode_mutex_
+  // was held. observer_stats() / stats() re-acquire that same (non-recursive) mutex,
+  // so any callback that touched stats hung the SessionManager forever. The fix moves
+  // callback dispatch outside the locked region. This test pins that contract by
+  // calling both accessors from inside the callback and asserting we reach the
+  // post-callback assertion (i.e. did not deadlock).
+  SessionManager sm;
+  std::atomic<int> counter{0};
+  sm.add_observer(std::make_shared<CountingObserver>(
+    "obs", "mock/joints", 100.0, &counter));
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  std::atomic<bool> callback_completed{false};
+  std::atomic<size_t> observer_stats_size{0};
+  std::atomic<uint32_t> seen_episode_index{0};
+  sm.on_episode_ended(
+    [&](const SessionManager::Stats& s) {
+      // Both of these used to deadlock. They must return without hanging.
+      const auto obs_stats = sm.observer_stats();
+      const auto sess_stats = sm.stats();
+      observer_stats_size.store(obs_stats.size());
+      seen_episode_index.store(s.current_episode_index);
+      (void)sess_stats;
+      callback_completed.store(true);
+    });
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(60));
+  sm.stop_episode();
+
+  EXPECT_TRUE(callback_completed.load());
+  EXPECT_EQ(observer_stats_size.load(), 1u);
+  EXPECT_EQ(seen_episode_index.load(), 0u);
+}
+
+TEST_F(SessionManagerObserversTest, EpisodeBoundaryHooks_FireOncePerEpisode) {
+  // on_episode_start / on_episode_end fire exactly once per running observer per
+  // episode, and the index reported to on_episode_end matches the index reported to
+  // the matching on_episode_start. The test fixture uses the null backend, which
+  // resets next_episode_index_ to 0 via scan_existing_episodes() at every
+  // start_episode() - so this test does not assume monotonically increasing indices
+  // (that contract is enforced only by persistent backends).
+  SessionManager sm;
+  auto obs = std::make_shared<EpisodeBoundaryObserver>();
+  sm.add_observer(obs);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(40));
+  sm.stop_episode();
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(40));
+  sm.stop_episode();
+
+  ASSERT_EQ(obs->started_indices.size(), 2u);
+  ASSERT_EQ(obs->ended_indices.size(), 2u);
+  EXPECT_EQ(obs->started_indices[0], obs->ended_indices[0]);
+  EXPECT_EQ(obs->started_indices[1], obs->ended_indices[1]);
+}
+
+TEST_F(SessionManagerObserversTest, EpisodeBoundaryHooks_SkipFailedStartObservers) {
+  // Observers whose start() failed (is_running() == false, is_stopped() == true) must
+  // not receive episode-boundary hook calls - they are terminal.
+  SessionManager sm;
+  auto live = std::make_shared<EpisodeBoundaryObserver>();
+  auto dead = std::make_shared<DeadObserver>();
+  sm.add_observer(live);
+  sm.add_observer(dead);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(40));
+  sm.stop_episode();
+
+  EXPECT_EQ(live->started_indices.size(), 1u);
+  EXPECT_EQ(live->ended_indices.size(), 1u);
+  EXPECT_TRUE(dead->is_stopped());
+  EXPECT_FALSE(dead->is_running());
+}
+
+TEST_F(SessionManagerObserversTest, EpisodeEndHook_CanCallObserverStats) {
+  // on_episode_end runs outside episode_mutex_ (same contract as on_episode_ended
+  // user callbacks). Subclasses are free to call back into the SessionManager from
+  // inside the hook without deadlocking - pin that contract.
+  class CallbackObserver : public ObserverBase {
+   public:
+    explicit CallbackObserver(SessionManager* sm)
+      : ObserverBase("callback"), sm_(sm) {
+      add_subscription("mock/joints", 100.0,
+                       [](const std::shared_ptr<RecordBase>&) {});
+    }
+    std::atomic<size_t> end_observer_count{0};
+    void on_episode_end(uint32_t episode_index) noexcept override {
+      (void)episode_index;
+      end_observer_count.store(sm_->observer_stats().size());
+    }
+   private:
+    SessionManager* sm_;
+  };
+  SessionManager sm;
+  auto obs = std::make_shared<CallbackObserver>(&sm);
+  sm.add_observer(obs);
+  sm.add_producer(std::make_shared<MockPolledProducer>(),
+                  std::chrono::milliseconds(5));
+
+  ASSERT_TRUE(sm.start_episode());
+  std::this_thread::sleep_for(std::chrono::milliseconds(40));
+  sm.stop_episode();
+
+  EXPECT_EQ(obs->end_observer_count.load(), 1u);
 }


### PR DESCRIPTION
## Summary

Follow-up fixes for the rerun observer found while running it against live solo, stationary, and mobile hardware. Adds episode lifecycle hooks (`on_episode_start` / `on_episode_end`) on `ObserverBase`, a `spawn` flag and per-subscription `fields` filter on `RerunObserver`, switches the rerun timeline from a `steady_clock` duration to a `system_clock` wall-clock timestamp so multi-episode runs scrub correctly, clears entity trees per episode to defeat the viewer's autoscale collapse, and fixes a `SessionManager` deadlock where `on_episode_ended` callbacks ran with `episode_mutex_` held.

## Changes

- In `include/trossen_sdk/observer/observer_base.hpp`: add `on_episode_start()` and `on_episode_end()` virtual hooks so concrete observers can react to episode boundaries (default no-op, so existing observers are unaffected).
- In `src/runtime/session_manager.cpp`: dispatch `on_episode_ended` callbacks after releasing `episode_mutex_` — callbacks that re-enter the manager (e.g. `observer_stats()`) would otherwise deadlock against the held mutex.
- In `include/trossen_sdk/observer/rerun_observer.hpp` + `src/observer/rerun_observer.cpp`: add a `spawn` config flag that launches a local rerun viewer at construction (so operators can run the example without first starting `rerun --serve` in another terminal).
- In `include/trossen_sdk/configuration/types/observers/observer_config.hpp` + `src/observer/rerun_observer.cpp`: add an optional per-subscription `fields` array on `ObserverSubscriptionConfig` (`positions` / `velocities` / `efforts`) so operators can drop unused joint-state channels from the viewer. Defaults to all fields when omitted.
- In `src/observer/rerun_observer.cpp`: log the rerun timeline as a `system_clock` wall-clock timestamp instead of a `steady_clock` duration since recorder start — the duration-based timeline made the viewer's autoscale collapse the previous episode's data into a sliver on each new episode, and timestamps from different operator sessions are no longer comparable.
- In `src/observer/rerun_observer.cpp`: clear logged entity trees inside `on_episode_start()` so each new episode begins with a clean canvas, which keeps the viewer's autoscale from blending current and prior episodes into one compressed view.
- Extend `tests/test_session_manager_observers.cpp` to cover the new episode hooks and the deadlock-free callback ordering; extend `tests/test_rerun_observer.cpp` for `spawn` + `fields`; extend `tests/test_observer_registry.cpp` for `fields` config parsing.

## Test Plan

- [x] Builds cleanly (`make build`) with the option OFF (default)
- [x] Builds cleanly with `-DTROSSEN_ENABLE_RERUN_OBSERVER=ON`
- [x] Tests pass (`make test`) — `test_observer_registry`, `test_rerun_observer`, `test_session_manager_observers`
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware — verified end-to-end against live solo, stationary, and mobile setups; multi-episode runs scrub correctly on the rerun timeline, entity trees reset between episodes, and `on_episode_ended` no longer deadlocks `SessionManager`

## Breaking Changes

None. The new hooks default to no-op; the new config keys (`spawn`, `fields`) are optional and existing configs continue to load unchanged; the `on_episode_ended` dispatch reordering is internal to `SessionManager`.

## Related Issues

Relates to TDS-116