### PR TITLE
docs: document observers config and rerun live-viewer setup

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,7 +46,7 @@ The rest of the docs assume you are working from one of these.
 Schema Reference
 ================
 
-A config is a JSON object with six top-level keys, used by every example:
+A config is a JSON object with top-level keys, used by every example:
 
 .. code-block:: javascript
 
@@ -56,6 +56,7 @@ A config is a JSON object with six top-level keys, used by every example:
       "producers":   [ ... ],       // Data streams (one per device channel)
       "teleop":      { ... },       // Leader/follower pairing
       "backend":     { ... },       // TrossenMCAP output settings
+      "observers":   [ ... ],       // Optional live-stream consumers (e.g. ReRun viewer)
       "session":     { ... }        // Episode durations and limits
     }
 
@@ -199,6 +200,103 @@ Backend
 
 Episodes land at ``<root>/<dataset_id>/episode_NNNNNN.mcap``.
 Episode numbers are assigned automatically and resume from the highest existing index in the directory.
+
+Observers
+---------
+
+``observers`` is an **optional JSON array** of live, non-durable consumers that receive records as they are produced.
+Each observer runs alongside the backend and is independent of the on-disk ``.mcap`` capture — leave the key out entirely if you do not need live streaming.
+
+The only observer that ships with the SDK today is the ReRun viewer (``"type": "rerun"``).
+For background on what ReRun is and how to launch the viewer, see :doc:`/visualize`.
+
+.. code-block:: javascript
+
+    "observers": [
+      {
+        "type":      "rerun",                                // Observer type (table below)
+        "id":        "live_viewer",                          // Logging label; defaults to type
+        "enabled":   true,                                   // Set false to disable this observer
+        "rerun_url": "rerun+http://127.0.0.1:9876/proxy",    // gRPC endpoint of a running ReRun viewer
+        "app_id":    "trossen_solo_ai",                      // ReRun application id
+        "spawn":     false,                                  // true = SDK launches the viewer itself (ignores rerun_url)
+        "subscriptions": [
+          { "record_id": "leader",      "throttle_hz": 30.0 },
+          { "record_id": "follower",    "throttle_hz": 30.0 },
+          { "record_id": "camera_main", "throttle_hz": 15.0 }
+        ]
+      }
+    ]
+
+Fields common to every observer:
+
+.. list-table::
+    :align: center
+    :header-rows: 1
+    :class: centered-table
+
+    * - Field
+      - Type
+      - Description
+    * - ``type``
+      - string
+      - Observer type. Required. Only ``"rerun"`` ships today.
+    * - ``id``
+      - string
+      - Logging label for this instance. Defaults to ``type`` when omitted.
+    * - ``enabled``
+      - bool
+      - When ``false``, the observer is parsed and validated but not started. Defaults to ``true``.
+    * - ``subscriptions``
+      - array
+      - Per-stream subscriptions. At least one entry is required and ``record_id`` values must be unique within one observer.
+
+Each subscription entry accepts:
+
+.. list-table::
+    :align: center
+    :header-rows: 1
+    :class: centered-table
+
+    * - Field
+      - Type
+      - Description
+    * - ``record_id``
+      - string
+      - Exact match against a producer's ``stream_id`` (joint-state / odometry) or camera channel (e.g. ``camera_main``). Required.
+    * - ``throttle_hz``
+      - number
+      - Maximum dispatch rate to this observer for this stream. Range ``[1e-3, 1e4]``. Required.
+    * - ``fields``
+      - array of strings
+      - Optional per-subscription field filter. Observer-specific semantics — for ``rerun`` on a ``JointStateRecord`` subscription, accepted values are ``"positions"``, ``"velocities"``, ``"efforts"`` (drop the channels you don't want plotted). Omit the key entirely to forward all fields; ``"fields": []`` is rejected.
+
+ReRun-specific fields (used only when ``type`` is ``"rerun"``):
+
+.. list-table::
+    :align: center
+    :header-rows: 1
+    :class: centered-table
+
+    * - Field
+      - Type
+      - Description
+    * - ``rerun_url``
+      - string
+      - gRPC URL of an already-running ReRun viewer. Defaults to ``"rerun+http://127.0.0.1:9876/proxy"``.
+    * - ``app_id``
+      - string
+      - ReRun application id passed to the recording stream. Defaults to ``"trossen_sdk"``.
+    * - ``spawn``
+      - bool
+      - When ``true``, the SDK launches a local ReRun viewer at session start instead of connecting to an already-running one, and ``rerun_url`` is ignored. Requires the ``rerun`` binary on ``PATH`` (see :doc:`/visualize`); if its version differs from the SDK's, ReRun prints a one-time compatibility warning but still connects and renders. Defaults to ``false``.
+
+.. note::
+
+    ReRun support is a build-time option.
+    Configure with ``-DTROSSEN_ENABLE_RERUN_OBSERVER=ON`` to compile the observer in.
+    With the option off (default), any ``"type": "rerun"`` entry in your config fails to load with an "unknown observer type" error.
+    See :doc:`/visualize` for the full setup walkthrough.
 
 Session
 -------

--- a/docs/record.rst
+++ b/docs/record.rst
@@ -75,6 +75,7 @@ A recording session proceeds through the following phases:
 #.  **Recording.**
     The ``SessionManager`` opens a new ``.mcap`` file, starts all producers, and begins logging.
     The process runs for at most ``session.max_duration`` seconds.
+    If your config defines an ``observers`` block, each observer receives the same records in parallel — see :doc:`/visualize` for the ReRun live-viewer setup.
 #.  **Reset.**
     After each episode, the demo pauses for ``session.reset_duration`` seconds before starting the next episode.
 #.  **Shutdown.**
@@ -113,7 +114,7 @@ What's Next
 
 With ``.mcap`` episodes on disk:
 
--   Open them in Foxglove Studio.
+-   Open them in Foxglove Studio, or stream the next session live to a ReRun viewer.
     See :doc:`/visualize`.
 -   Replay an episode back on hardware.
     See :doc:`/replay`.

--- a/docs/visualize.rst
+++ b/docs/visualize.rst
@@ -2,6 +2,18 @@
 Visualize
 =========
 
+The SDK supports two visualization workflows:
+
+-   **Post-hoc inspection in Foxglove Studio.**
+    Open any recorded ``.mcap`` file after the session finishes.
+    No build-time configuration is required.
+-   **Live streaming to a ReRun viewer during recording.**
+    Plots and camera feeds update in real time as the operator teleoperates.
+    Requires a build-time flag and a small ``observers`` section in your config.
+
+Pick the one that matches what you need.
+Most operators use Foxglove for episode review and add ReRun when they want to watch joint trajectories or camera feeds in real time during teleoperation.
+
 TrossenMCAP episodes are written in the `MCAP <https://mcap.dev>`_ container format with protobuf-encoded messages, so they open directly in `Foxglove Studio <https://foxglove.dev>`_.
 No conversion is required.
 
@@ -126,6 +138,123 @@ Names include the ``stream_id`` from your ``producers`` config.
     * - ``{stream_id}/odom/state``
       - ``trossen_sdk.msg.Odometry2D``
       - Plot (``twist.linear_x``, ``twist.linear_y``, ``twist.angular_z``)
+
+Streaming with ReRun
+====================
+
+The SDK ships an optional ``RerunObserver`` that forwards records to a `ReRun <https://rerun.io>`_ viewer as they are produced.
+Unlike Foxglove, which reads completed ``.mcap`` files after a session, ReRun renders plots and camera feeds in real time while teleoperation is running.
+
+The observer is independent of on-disk capture — every record continues to land in the ``.mcap`` exactly as before.
+
+Prerequisites
+-------------
+
+ReRun support is gated behind a build flag and a runtime viewer.
+
+#.  **Compile with ReRun enabled.**
+    Configure the build with ``-DTROSSEN_ENABLE_RERUN_OBSERVER=ON`` so the observer is registered:
+
+    .. code-block:: bash
+
+        cmake -B build -DTROSSEN_ENABLE_RERUN_OBSERVER=ON
+        cmake --build build -j$(nproc)
+
+    With the flag off (default), any ``"type": "rerun"`` entry in your config fails to load.
+
+#.  **Install the ReRun viewer.**
+    The quickest option is the snap, which bundles the viewer with no Python
+    environment to manage:
+
+    .. code-block:: bash
+
+        sudo snap install rerun
+
+    The viewer is also published as a Python package. Installing it as an
+    isolated tool with `uv <https://docs.astral.sh/uv/>`_ puts ``rerun`` on your
+    ``PATH`` without any virtualenv to manage (append ``==<version>`` to either
+    command to pin a specific release):
+
+    .. code-block:: bash
+
+        uv tool install rerun-sdk      # isolated, no virtualenv needed
+        # or, inside an activated virtualenv:
+        pip install rerun-sdk
+
+    See `the ReRun install guide <https://rerun.io/docs/getting-started/installing-viewer>`_ for other options.
+
+    .. note::
+
+       Keep the viewer reasonably current — **ReRun 0.32 or newer** is
+       recommended so it matches the ``rerun-cpp`` SDK version the observer is
+       built against (``RERUN_SDK_VERSION``). Slightly older viewers usually
+       still render but may log harmless schema-version warnings; very old
+       viewers fail to render and report errors such as ``transport error`` or
+       ``dropping LogMsg ... Missing row_id column``. If the viewer stays blank,
+       update it first.
+
+Launch the Viewer
+-----------------
+
+Start the viewer in a separate terminal before launching the SDK demo:
+
+.. code-block:: bash
+
+    rerun
+
+The viewer window opens and listens for gRPC connections on ``127.0.0.1:9876`` by default.
+Leave the default ``rerun_url`` in your config; the SDK connects to it over gRPC at session start.
+The viewer survives across SDK restarts and you can reconnect to it at any time.
+
+Letting the SDK Launch the Viewer
+---------------------------------
+
+Instead of starting ``rerun`` yourself, set ``"spawn": true`` on the observer and the SDK launches a local viewer for you at session start:
+
+.. code-block:: javascript
+
+    "observers": [
+      { "type": "rerun", "id": "live_viewer", "spawn": true, "subscriptions": [ ... ] }
+    ]
+
+This requires the ``rerun`` binary on your ``PATH`` (any of the installs under `Prerequisites`_).
+When ``spawn`` is true the ``rerun_url`` key is ignored.
+If the installed viewer's version differs from the SDK's, ReRun prints a one-time compatibility warning at startup but still connects and renders — see the version note above.
+
+Observer Config
+---------------
+
+A minimal observer block subscribes to one or more record streams:
+
+.. code-block:: javascript
+
+    "observers": [
+      {
+        "type": "rerun",
+        "id":   "live_viewer",
+        "subscriptions": [
+          { "record_id": "leader",       "throttle_hz": 30.0 },
+          { "record_id": "follower",     "throttle_hz": 30.0 },
+          { "record_id": "camera_main",  "throttle_hz": 15.0 }
+        ]
+      }
+    ]
+
+``record_id`` matches the producer ``stream_id`` (for arm and odometry streams) or the camera id (for camera streams).
+``throttle_hz`` caps the dispatch rate per subscription — set it well below the producer ``poll_rate_hz`` to keep the viewer responsive on dense camera streams.
+
+The example configs that ship with the SDK already include an ``observers`` block wired up to the cameras and arms for each robot.
+Open ``examples/trossen_solo_ai/config.json`` (or the stationary / mobile variant) for a complete reference.
+
+For the full set of subscription options — including the per-subscription ``fields`` filter for trimming joint-state channels — see :doc:`/configuration`.
+
+Across Episodes
+---------------
+
+Each subscribed entity tree is cleared at the start of every new episode, so the viewer does not blend the previous episode's plots into the current one.
+Per-record on-disk capture (MCAP, LeRobot) is unaffected — this only resets what the live viewer renders.
+
+The ReRun timeline uses wall-clock timestamps, so a multi-episode session scrubs correctly across boundaries and timestamps from different operator sessions are directly comparable.
 
 What's Next
 ===========


### PR DESCRIPTION
## Summary

- Add an `Observers` section to `docs/configuration.rst` covering the config schema, subscription fields (including the `fields` filter), the ReRun-specific `rerun_url` / `app_id` keys, and the `-DTROSSEN_ENABLE_RERUN_OBSERVER=ON` build gate.
- Add a `Streaming with ReRun` section to `docs/visualize.rst` covering prerequisites, viewer launch, observer config, and across-episodes behavior (entity-tree reset + wall-clock timeline).
- Cross-reference observers from `docs/record.rst` (Recording phase + What's Next).

Built on top of #244 (`05-22-rerun-hw-hardening`); merge after the rerun observer code lands.

## Test plan

- [x] `make docs-strict` builds without warnings (requires `make docs-deps` first if Sphinx isn't installed locally).
- [x] `make docs-serve` and visually verify the new Observers and Streaming with ReRun sections render correctly with intact cross-refs.
- [x] Confirm no mention of the `spawn` config key anywhere (the option exists in code but is currently non-functional).