### PR TITLE
control: per-episode hardware lifecycle driven by SessionManager

### DIFF
--- a/examples/trossen_mobile_ai/README.md
+++ b/examples/trossen_mobile_ai/README.md
@@ -89,7 +89,7 @@ Override:
 ```
 
 The script will:
-1. Connect to all four arms and the SLATE base, then move arms to the staged starting position
+1. Connect to all four arms and the SLATE base
 2. Enable teleop — each follower mirrors its paired leader
 3. Start recording an episode (default: 20 seconds)
    - Arms and cameras are polled at 30 Hz
@@ -99,6 +99,15 @@ The script will:
 6. Return arms to the sleep position
 
 Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
+
+### Optional: home staging
+
+Set `"episode_lifecycle_enabled": true` on an arm and give it a `staged_position`
+(a joint-space home pose); the SessionManager moves that arm to its home pose at
+the start of **every** episode. Staging is opt-in and off by default — an arm
+without the flag (or without a `staged_position`) is left untouched. When teleop
+is enabled, the SessionManager pauses each mirror loop while the arms move to home,
+then re-arms it before recording resumes.
 
 ---
 

--- a/examples/trossen_mobile_ai/README.md
+++ b/examples/trossen_mobile_ai/README.md
@@ -102,12 +102,50 @@ Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
 
 ### Optional: home staging
 
-Set `"episode_lifecycle_enabled": true` on an arm and give it a `staged_position`
-(a joint-space home pose); the SessionManager moves that arm to its home pose at
-the start of **every** episode. Staging is opt-in and off by default — an arm
-without the flag (or without a `staged_position`) is left untouched. When teleop
-is enabled, the SessionManager pauses each mirror loop while the arms move to home,
-then re-arms it before recording resumes.
+Staging moves an arm to a fixed joint-space "home" pose at the start of **every**
+episode, so each recording begins from a known configuration. It is opt-in and off
+by default — an arm without the flag (or without a `staged_position`) is left
+untouched.
+
+**Where:** in `config.json`, inside the arm's own block under
+`hardware` → `arms` → `<arm_name>` (this example has `leader_left`, `leader_right`,
+`follower_left`, `follower_right`).
+
+**What to add:** append these three keys to that arm's block (add a comma to its
+current last line — `end_effector` — first):
+
+```json
+"staged_position": [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
+"staging_time_s": 2.0,
+"episode_lifecycle_enabled": true
+```
+
+In context, the `follower_left` arm block then looks like:
+
+```json
+"follower_left": {
+  "ip_address":   "192.168.1.5",
+  "model":        "wxai_v0",
+  "end_effector": "wxai_v0_follower",
+  "staged_position": [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
+  "staging_time_s": 2.0,
+  "episode_lifecycle_enabled": true
+}
+```
+
+Field reference:
+
+- `staged_position` — joint-space home pose in radians, one value per joint (must
+  match the arm's joint count). The values above are a safe upright home for the
+  `wxai_v0`.
+- `staging_time_s` — duration of the move to home, in seconds (also used for the
+  return-to-rest move on teleop stop). Optional; defaults to `2.0`. Longer =
+  slower, gentler.
+- `episode_lifecycle_enabled` — must be `true` for staging to run on this arm.
+
+Repeat the three keys on each arm you want staged. When teleop is enabled, the
+SessionManager pauses each mirror loop while the arms move to home, then re-arms it
+before recording resumes.
 
 ---
 

--- a/examples/trossen_mobile_ai/config.json
+++ b/examples/trossen_mobile_ai/config.json
@@ -1,6 +1,7 @@
 {
   "robot_name": "trossen_mobile_ai",
 
+
   "hardware": {
     "arms": {
       "leader_left": {

--- a/examples/trossen_mobile_ai/config.json
+++ b/examples/trossen_mobile_ai/config.json
@@ -1,7 +1,6 @@
 {
   "robot_name": "trossen_mobile_ai",
 
-
   "hardware": {
     "arms": {
       "leader_left": {

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -71,6 +71,11 @@ static void print_usage(const char* program) {
 }
 
 int main(int argc, char** argv) {
+  // Flush every line immediately so progress (and the last line before any
+  // stall) is always visible — important for a long-running, hardware-driven
+  // recording loop.
+  std::cout << std::unitbuf;
+
   trossen::configuration::CliParser cli(argc, argv);
 
   if (cli.has_flag("help")) {
@@ -311,28 +316,22 @@ int main(int argc, char** argv) {
   }
 
   // ──────────────────────────────────────────────────────────
-  // Teleop controllers (constructor stages arms)
+  // Teleop controllers
   // ──────────────────────────────────────────────────────────
 
   auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
 
+  // Hand the controllers to the SessionManager, which owns their per-episode
+  // lifecycle: before each episode it pauses the mirror, re-homes any arm that
+  // opted into the episode lifecycle (episode_lifecycle_enabled in its config),
+  // and re-arms teleop; it starts mirroring when recording goes live, resets
+  // between episodes, and stops teleop at shutdown.
+  const bool has_teleop = !controllers.empty();
+  for (auto& ctrl : controllers) mgr.add_teleop(std::move(ctrl));
+
   // ──────────────────────────────────────────────────────────
   // Register lifecycle callbacks
   // ──────────────────────────────────────────────────────────
-
-  // Before each episode: let controllers run their pre-episode lifecycle
-  mgr.on_pre_episode([&]() -> bool {
-    for (auto& ctrl : controllers) ctrl->prepare_teleop();
-    return true;
-  });
-
-  // Episode started: begin mirroring (alongside recording)
-  mgr.on_episode_started([&]() {
-    for (auto& ctrl : controllers) ctrl->teleop();
-    std::cout << "Episode started - recording"
-              << (controllers.empty() ? "" : " and mirroring")
-              << " active.\n";
-  });
 
   // Count depth-capable cameras once for sanity checks
   int depth_cameras = 0;
@@ -340,10 +339,9 @@ int main(int argc, char** argv) {
     if (cam.use_depth) ++depth_cameras;
   }
 
-  // After each episode: reset mode (mirroring continues, no recording)
+  // After each episode: print a summary and run sanity checks. (Teleop reset and
+  // arm re-homing are owned by the SessionManager.)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
-    for (auto& ctrl : controllers) ctrl->reset_teleop();
-
     const std::string file_path =
       trossen::utils::generate_episode_path(root, stats.current_episode_index);
     trossen::utils::print_episode_summary(file_path, stats);
@@ -360,10 +358,11 @@ int main(int argc, char** argv) {
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });
 
-  // Shutdown: stop mirror + return arms to rest
+  // Shutdown: the SessionManager stops teleop and returns those arms to rest.
+  // If teleop is disabled (no controllers), return each arm to rest directly so
+  // they don't stay in their last commanded pose.
   mgr.on_pre_shutdown([&]() {
-    for (auto& ctrl : controllers) ctrl->stop_teleop();
-    if (controllers.empty()) {
+    if (!has_teleop) {
       for (auto& [id, arm] : arm_components) arm->end_teleop();
     }
   });

--- a/examples/trossen_solo_ai/README.md
+++ b/examples/trossen_solo_ai/README.md
@@ -77,10 +77,47 @@ Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
 
 ### Optional: home staging
 
-Set `"episode_lifecycle_enabled": true` on an arm and give it a `staged_position`
-(a joint-space home pose); the SessionManager moves that arm to its home pose at
-the start of **every** episode. Staging is opt-in and off by default — an arm
-without the flag (or without a `staged_position`) is left untouched. When teleop
+Staging moves an arm to a fixed joint-space "home" pose at the start of **every**
+episode, so each recording begins from a known configuration. It is opt-in and off
+by default — an arm without the flag (or without a `staged_position`) is left
+untouched.
+
+**Where:** in `config.json`, inside the arm's own block under
+`hardware` → `arms` → `<arm_name>`.
+
+**What to add:** append these three keys to that arm's block (add a comma to its
+current last line — `end_effector` — first):
+
+```json
+"staged_position": [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
+"staging_time_s": 2.0,
+"episode_lifecycle_enabled": true
+```
+
+In context, the `follower` arm block then looks like:
+
+```json
+"follower": {
+  "ip_address":   "192.168.1.4",
+  "model":        "wxai_v0",
+  "end_effector": "wxai_v0_follower",
+  "staged_position": [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
+  "staging_time_s": 2.0,
+  "episode_lifecycle_enabled": true
+}
+```
+
+Field reference:
+
+- `staged_position` — joint-space home pose in radians, one value per joint (must
+  match the arm's joint count). The values above are a safe upright home for the
+  `wxai_v0`.
+- `staging_time_s` — duration of the move to home, in seconds (also used for the
+  return-to-rest move on teleop stop). Optional; defaults to `2.0`. Longer =
+  slower, gentler.
+- `episode_lifecycle_enabled` — must be `true` for staging to run on this arm.
+
+Repeat the three keys on any other arm you want staged (e.g. `leader`). When teleop
 is enabled, the SessionManager pauses the mirror loop while the arms move to home,
 then re-arms it before recording resumes.
 

--- a/examples/trossen_solo_ai/README.md
+++ b/examples/trossen_solo_ai/README.md
@@ -66,7 +66,7 @@ Update `config.json` or override on the command line:
 ```
 
 The script will:
-1. Connect to both arms and move them to the staged starting position
+1. Connect to both arms
 2. Enable teleop — the follower mirrors the leader
 3. Start recording an episode (default: 10 seconds)
 4. Stop, flush, and save the `.mcap` file
@@ -74,6 +74,15 @@ The script will:
 6. Return arms to the sleep position
 
 Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
+
+### Optional: home staging
+
+Set `"episode_lifecycle_enabled": true` on an arm and give it a `staged_position`
+(a joint-space home pose); the SessionManager moves that arm to its home pose at
+the start of **every** episode. Staging is opt-in and off by default — an arm
+without the flag (or without a `staged_position`) is left untouched. When teleop
+is enabled, the SessionManager pauses the mirror loop while the arms move to home,
+then re-arms it before recording resumes.
 
 ---
 

--- a/examples/trossen_solo_ai/config.json
+++ b/examples/trossen_solo_ai/config.json
@@ -1,6 +1,7 @@
 {
   "robot_name": "trossen_solo_ai",
 
+
   "hardware": {
     "arms": {
       "leader": {
@@ -8,14 +9,16 @@
         "model":               "wxai_v0",
         "end_effector":        "wxai_v0_leader",
         "staged_position":     [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
-        "teleop_moving_time_s": 2.0
+        "slew_time_s": 2.0,
+        "episode_lifecycle_enabled": true
       },
       "follower": {
         "ip_address":          "192.168.1.4",
         "model":               "wxai_v0",
         "end_effector":        "wxai_v0_follower",
         "staged_position":     [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
-        "teleop_moving_time_s": 2.0
+        "slew_time_s": 2.0,
+        "episode_lifecycle_enabled": true
       }
     },
     "cameras": [

--- a/examples/trossen_solo_ai/config.json
+++ b/examples/trossen_solo_ai/config.json
@@ -1,24 +1,17 @@
 {
   "robot_name": "trossen_solo_ai",
 
-
   "hardware": {
     "arms": {
       "leader": {
         "ip_address":          "192.168.1.2",
         "model":               "wxai_v0",
-        "end_effector":        "wxai_v0_leader",
-        "staged_position":     [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
-        "slew_time_s": 2.0,
-        "episode_lifecycle_enabled": true
+        "end_effector":        "wxai_v0_leader"
       },
       "follower": {
         "ip_address":          "192.168.1.4",
         "model":               "wxai_v0",
-        "end_effector":        "wxai_v0_follower",
-        "staged_position":     [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
-        "slew_time_s": 2.0,
-        "episode_lifecycle_enabled": true
+        "end_effector":        "wxai_v0_follower"
       }
     },
     "cameras": [

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -68,6 +68,11 @@ static void print_usage(const char* program) {
 }
 
 int main(int argc, char** argv) {
+  // Flush every line immediately so progress (and the last line before any
+  // stall) is always visible — important for a long-running, hardware-driven
+  // recording loop.
+  std::cout << std::unitbuf;
+
   trossen::configuration::CliParser cli(argc, argv);
 
   if (cli.has_flag("help")) {
@@ -277,28 +282,22 @@ int main(int argc, char** argv) {
   }
 
   // ──────────────────────────────────────────────────────────
-  // Teleop controllers (constructor stages arms)
+  // Teleop controllers
   // ──────────────────────────────────────────────────────────
 
   auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
 
+  // Hand the controllers to the SessionManager, which owns their per-episode
+  // lifecycle: before each episode it pauses the mirror, re-homes any arm that
+  // opted into the episode lifecycle (episode_lifecycle_enabled in its config),
+  // and re-arms teleop; it starts mirroring when recording goes live, resets
+  // between episodes, and stops teleop at shutdown.
+  const bool has_teleop = !controllers.empty();
+  for (auto& ctrl : controllers) mgr.add_teleop(std::move(ctrl));
+
   // ──────────────────────────────────────────────────────────
   // Register lifecycle callbacks
   // ──────────────────────────────────────────────────────────
-
-  // Before each episode: let controllers run their pre-episode lifecycle
-  mgr.on_pre_episode([&]() -> bool {
-    for (auto& ctrl : controllers) ctrl->prepare_teleop();
-    return true;
-  });
-
-  // Episode started: begin mirroring (alongside recording)
-  mgr.on_episode_started([&]() {
-    for (auto& ctrl : controllers) ctrl->teleop();
-    std::cout << "Episode started - recording"
-              << (controllers.empty() ? "" : " and mirroring")
-              << " active.\n";
-  });
 
   // Count depth-capable cameras once for sanity checks
   int depth_cameras = 0;
@@ -306,10 +305,9 @@ int main(int argc, char** argv) {
     if (cam.use_depth) ++depth_cameras;
   }
 
-  // After each episode: reset mode (mirroring continues, no recording)
+  // After each episode: print a summary and run sanity checks. (Teleop reset and
+  // arm re-homing are owned by the SessionManager.)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
-    for (auto& ctrl : controllers) ctrl->reset_teleop();
-
     const std::string file_path =
       trossen::utils::generate_episode_path(root, stats.current_episode_index);
     trossen::utils::print_episode_summary(file_path, stats);
@@ -326,12 +324,11 @@ int main(int argc, char** argv) {
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });
 
-  // Shutdown: stop mirror + return arms to rest. If teleop was disabled (no
-  // controllers), return each arm to rest directly so they don't stay in
-  // their last commanded pose.
+  // Shutdown: the SessionManager stops teleop and returns those arms to rest.
+  // If teleop is disabled (no controllers), return each arm to rest directly so
+  // they don't stay in their last commanded pose.
   mgr.on_pre_shutdown([&]() {
-    for (auto& ctrl : controllers) ctrl->stop_teleop();
-    if (controllers.empty()) {
+    if (!has_teleop) {
       for (auto& [id, arm] : arm_components) arm->end_teleop();
     }
   });

--- a/examples/trossen_stationary_ai/README.md
+++ b/examples/trossen_stationary_ai/README.md
@@ -83,12 +83,50 @@ Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
 
 ### Optional: home staging
 
-Set `"episode_lifecycle_enabled": true` on an arm and give it a `staged_position`
-(a joint-space home pose); the SessionManager moves that arm to its home pose at
-the start of **every** episode. Staging is opt-in and off by default — an arm
-without the flag (or without a `staged_position`) is left untouched. When teleop
-is enabled, the SessionManager pauses each mirror loop while the arms move to home,
-then re-arms it before recording resumes.
+Staging moves an arm to a fixed joint-space "home" pose at the start of **every**
+episode, so each recording begins from a known configuration. It is opt-in and off
+by default — an arm without the flag (or without a `staged_position`) is left
+untouched.
+
+**Where:** in `config.json`, inside the arm's own block under
+`hardware` → `arms` → `<arm_name>` (this example has `leader_left`, `leader_right`,
+`follower_left`, `follower_right`).
+
+**What to add:** append these three keys to that arm's block (add a comma to its
+current last line — `end_effector` — first):
+
+```json
+"staged_position": [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
+"staging_time_s": 2.0,
+"episode_lifecycle_enabled": true
+```
+
+In context, the `follower_left` arm block then looks like:
+
+```json
+"follower_left": {
+  "ip_address":   "192.168.1.5",
+  "model":        "wxai_v0",
+  "end_effector": "wxai_v0_follower",
+  "staged_position": [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
+  "staging_time_s": 2.0,
+  "episode_lifecycle_enabled": true
+}
+```
+
+Field reference:
+
+- `staged_position` — joint-space home pose in radians, one value per joint (must
+  match the arm's joint count). The values above are a safe upright home for the
+  `wxai_v0`.
+- `staging_time_s` — duration of the move to home, in seconds (also used for the
+  return-to-rest move on teleop stop). Optional; defaults to `2.0`. Longer =
+  slower, gentler.
+- `episode_lifecycle_enabled` — must be `true` for staging to run on this arm.
+
+Repeat the three keys on each arm you want staged. When teleop is enabled, the
+SessionManager pauses each mirror loop while the arms move to home, then re-arms it
+before recording resumes.
 
 ---
 

--- a/examples/trossen_stationary_ai/README.md
+++ b/examples/trossen_stationary_ai/README.md
@@ -72,7 +72,7 @@ Update `config.json` or override on the command line:
 ```
 
 The script will:
-1. Connect to all four arms and move them to the staged starting position
+1. Connect to all four arms
 2. Enable teleop — each follower mirrors its paired leader
 3. Start recording an episode (default: 20 seconds)
 4. Stop, flush, and save the `.mcap` file
@@ -80,6 +80,15 @@ The script will:
 6. Return arms to the sleep position
 
 Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
+
+### Optional: home staging
+
+Set `"episode_lifecycle_enabled": true` on an arm and give it a `staged_position`
+(a joint-space home pose); the SessionManager moves that arm to its home pose at
+the start of **every** episode. Staging is opt-in and off by default — an arm
+without the flag (or without a `staged_position`) is left untouched. When teleop
+is enabled, the SessionManager pauses each mirror loop while the arms move to home,
+then re-arms it before recording resumes.
 
 ---
 

--- a/examples/trossen_stationary_ai/config.json
+++ b/examples/trossen_stationary_ai/config.json
@@ -1,7 +1,6 @@
 {
   "robot_name": "trossen_stationary_ai",
 
-
   "hardware": {
     "arms": {
       "leader_left": {

--- a/examples/trossen_stationary_ai/config.json
+++ b/examples/trossen_stationary_ai/config.json
@@ -1,6 +1,7 @@
 {
   "robot_name": "trossen_stationary_ai",
 
+
   "hardware": {
     "arms": {
       "leader_left": {

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -68,6 +68,11 @@ static void print_usage(const char* program) {
 }
 
 int main(int argc, char** argv) {
+  // Flush every line immediately so progress (and the last line before any
+  // stall) is always visible — important for a long-running, hardware-driven
+  // recording loop.
+  std::cout << std::unitbuf;
+
   trossen::configuration::CliParser cli(argc, argv);
 
   if (cli.has_flag("help")) {
@@ -278,28 +283,22 @@ int main(int argc, char** argv) {
   }
 
   // ──────────────────────────────────────────────────────────
-  // Teleop controllers (constructor stages arms)
+  // Teleop controllers
   // ──────────────────────────────────────────────────────────
 
   auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
 
+  // Hand the controllers to the SessionManager, which owns their per-episode
+  // lifecycle: before each episode it pauses the mirror, re-homes any arm that
+  // opted into the episode lifecycle (episode_lifecycle_enabled in its config),
+  // and re-arms teleop; it starts mirroring when recording goes live, resets
+  // between episodes, and stops teleop at shutdown.
+  const bool has_teleop = !controllers.empty();
+  for (auto& ctrl : controllers) mgr.add_teleop(std::move(ctrl));
+
   // ──────────────────────────────────────────────────────────
   // Register lifecycle callbacks
   // ──────────────────────────────────────────────────────────
-
-  // Before each episode: let controllers run their pre-episode lifecycle
-  mgr.on_pre_episode([&]() -> bool {
-    for (auto& ctrl : controllers) ctrl->prepare_teleop();
-    return true;
-  });
-
-  // Episode started: begin mirroring (alongside recording)
-  mgr.on_episode_started([&]() {
-    for (auto& ctrl : controllers) ctrl->teleop();
-    std::cout << "Episode started - recording"
-              << (controllers.empty() ? "" : " and mirroring")
-              << " active.\n";
-  });
 
   // Count depth-capable cameras once for sanity checks
   int depth_cameras = 0;
@@ -307,10 +306,9 @@ int main(int argc, char** argv) {
     if (cam.use_depth) ++depth_cameras;
   }
 
-  // After each episode: reset mode (mirroring continues, no recording)
+  // After each episode: print a summary and run sanity checks. (Teleop reset and
+  // arm re-homing are owned by the SessionManager.)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
-    for (auto& ctrl : controllers) ctrl->reset_teleop();
-
     const std::string file_path =
       trossen::utils::generate_episode_path(root, stats.current_episode_index);
     trossen::utils::print_episode_summary(file_path, stats);
@@ -327,10 +325,11 @@ int main(int argc, char** argv) {
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });
 
-  // Shutdown: stop mirror + return arms to rest
+  // Shutdown: the SessionManager stops teleop and returns those arms to rest.
+  // If teleop is disabled (no controllers), return each arm to rest directly so
+  // they don't stay in their last commanded pose.
   mgr.on_pre_shutdown([&]() {
-    for (auto& ctrl : controllers) ctrl->stop_teleop();
-    if (controllers.empty()) {
+    if (!has_teleop) {
       for (auto& [id, arm] : arm_components) arm->end_teleop();
     }
   });

--- a/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
@@ -22,7 +22,7 @@ namespace trossen::configuration {
  *   "model": "wxai_v0",
  *   "end_effector": "wxai_v0_leader",
  *   "staged_position": [0.0, 1.04, 0.52, 0.63, 0.0, 0.0, 0.0],  // optional
- *   "slew_time_s": 2.0,                                   // optional
+ *   "staging_time_s": 2.0,                                // optional
  *   "episode_lifecycle_enabled": true                     // optional, default false
  * }
  */
@@ -41,12 +41,12 @@ struct ArmConfig {
   /// TrossenArmComponent::configure()).
   std::vector<float> staged_position;
 
-  /// @brief Slew time (seconds): the duration over which an SDK-commanded
+  /// @brief Staging time (seconds): the duration over which an SDK-commanded
   /// point-to-point move runs (staging to home and the return-to-rest move).
   /// Longer = slower, gentler motion. Sized so that a large start-to-goal
   /// difference does not exceed joint velocity limits or produce violent
   /// motion. Optional; 2.0s is a safe default for the supported arms.
-  float slew_time_s{2.0f};
+  float staging_time_s{2.0f};
 
   /// @brief Whether this arm participates in the SessionManager's per-episode
   /// lifecycle (staging to its home pose before each episode). Opt-in; defaults to
@@ -61,8 +61,8 @@ struct ArmConfig {
     if (j.contains("staged_position")) {
       j.at("staged_position").get_to(c.staged_position);
     }
-    if (j.contains("slew_time_s")) {
-      j.at("slew_time_s").get_to(c.slew_time_s);
+    if (j.contains("staging_time_s")) {
+      j.at("staging_time_s").get_to(c.staging_time_s);
     }
     if (j.contains("episode_lifecycle_enabled")) {
       j.at("episode_lifecycle_enabled").get_to(c.episode_lifecycle_enabled);
@@ -75,7 +75,7 @@ struct ArmConfig {
       {"ip_address", ip_address},
       {"model", model},
       {"end_effector", end_effector},
-      {"slew_time_s", slew_time_s},
+      {"staging_time_s", staging_time_s},
       {"episode_lifecycle_enabled", episode_lifecycle_enabled}
     };
     // Emit staging only when configured. TrossenArmComponent::configure()

--- a/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
@@ -7,6 +7,7 @@
 #define TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__ARM_CONFIG_HPP_
 
 #include <string>
+#include <vector>
 
 #include "nlohmann/json.hpp"
 
@@ -19,7 +20,10 @@ namespace trossen::configuration {
  * {
  *   "ip_address": "192.168.1.3",
  *   "model": "wxai_v0",
- *   "end_effector": "wxai_v0_leader"
+ *   "end_effector": "wxai_v0_leader",
+ *   "staged_position": [0.0, 1.04, 0.52, 0.63, 0.0, 0.0, 0.0],  // optional
+ *   "slew_time_s": 2.0,                                   // optional
+ *   "episode_lifecycle_enabled": true                     // optional, default false
  * }
  */
 struct ArmConfig {
@@ -32,20 +36,55 @@ struct ArmConfig {
   /// @brief End effector type (e.g. "wxai_v0_follower", "wxai_v0_leader")
   std::string end_effector{"wxai_v0_follower"};
 
+  /// @brief Joint-space home pose the arm moves to when staged. Empty disables
+  /// staging. Length must match the arm's joint count (validated downstream by
+  /// TrossenArmComponent::configure()).
+  std::vector<float> staged_position;
+
+  /// @brief Slew time (seconds): the duration over which an SDK-commanded
+  /// point-to-point move runs (staging to home and the return-to-rest move).
+  /// Longer = slower, gentler motion. Sized so that a large start-to-goal
+  /// difference does not exceed joint velocity limits or produce violent
+  /// motion. Optional; 2.0s is a safe default for the supported arms.
+  float slew_time_s{2.0f};
+
+  /// @brief Whether this arm participates in the SessionManager's per-episode
+  /// lifecycle (staging to its home pose before each episode). Opt-in; defaults to
+  /// false so an arm is only re-homed between episodes when explicitly enabled.
+  bool episode_lifecycle_enabled{false};
+
   static ArmConfig from_json(const nlohmann::json& j) {
     ArmConfig c;
     if (j.contains("ip_address")) j.at("ip_address").get_to(c.ip_address);
     if (j.contains("model")) j.at("model").get_to(c.model);
     if (j.contains("end_effector")) j.at("end_effector").get_to(c.end_effector);
+    if (j.contains("staged_position")) {
+      j.at("staged_position").get_to(c.staged_position);
+    }
+    if (j.contains("slew_time_s")) {
+      j.at("slew_time_s").get_to(c.slew_time_s);
+    }
+    if (j.contains("episode_lifecycle_enabled")) {
+      j.at("episode_lifecycle_enabled").get_to(c.episode_lifecycle_enabled);
+    }
     return c;
   }
 
   nlohmann::json to_json() const {
-    return nlohmann::json{
+    nlohmann::json j{
       {"ip_address", ip_address},
       {"model", model},
-      {"end_effector", end_effector}
+      {"end_effector", end_effector},
+      {"slew_time_s", slew_time_s},
+      {"episode_lifecycle_enabled", episode_lifecycle_enabled}
     };
+    // Emit staging only when configured. TrossenArmComponent::configure()
+    // rejects a present-but-wrong-length staged_position, so an empty array
+    // would break the no-staging case.
+    if (!staged_position.empty()) {
+      j["staged_position"] = staged_position;
+    }
+    return j;
   }
 };
 

--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -53,7 +53,7 @@ public:
    *   "model": "wxai_v0",
    *   "end_effector": "wxai_v0_follower",
    *   "staged_position": [0, 1.0, 0.5, 0.6, 0, 0, 0],  // optional, joint-space
-   *   "teleop_moving_time_s": 2.0         // optional, default 2.0
+   *   "slew_time_s": 2.0           // optional, default 2.0
    * }
    *
    * @param config JSON configuration object
@@ -74,6 +74,13 @@ public:
    * @return JSON object with component details
    */
   nlohmann::json get_info() const override;
+
+  // ── HardwareComponent: per-episode lifecycle ─────────────────────────────
+  // Opt-in via "episode_lifecycle_enabled" in config. When enabled, the
+  // SessionManager calls on_pre_episode() to re-home this arm before each
+  // episode (it pauses any teleop mirror around the call, so stage() is safe).
+  bool is_episode_lifecycle_enabled() const override { return episode_lifecycle_enabled_; }
+  void on_pre_episode() override;
 
   /**
    * @brief Get the underlying hardware driver instance
@@ -150,8 +157,14 @@ private:
   /// Empty = no staging.
   std::vector<float> staged_position_;
 
-  /// Trajectory time used by stage() and the end_teleop() rest move.
-  float teleop_moving_time_s_{2.0f};
+  /// Slew time: duration of the point-to-point moves in stage() and the
+  /// end_teleop() rest move. Sized to keep motion within joint velocity limits
+  /// (no violent moves when start and goal are far apart).
+  float slew_time_s_{2.0f};
+
+  /// Whether this arm participates in the per-episode lifecycle (staging before
+  /// each episode). Opt-in; parsed from "episode_lifecycle_enabled" in configure().
+  bool episode_lifecycle_enabled_{false};
 };
 
 }  // namespace trossen::hw::arm

--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -53,7 +53,7 @@ public:
    *   "model": "wxai_v0",
    *   "end_effector": "wxai_v0_follower",
    *   "staged_position": [0, 1.0, 0.5, 0.6, 0, 0, 0],  // optional, joint-space
-   *   "slew_time_s": 2.0           // optional, default 2.0
+   *   "staging_time_s": 2.0           // optional, default 2.0
    * }
    *
    * @param config JSON configuration object
@@ -157,10 +157,10 @@ private:
   /// Empty = no staging.
   std::vector<float> staged_position_;
 
-  /// Slew time: duration of the point-to-point moves in stage() and the
+  /// Staging time: duration of the point-to-point moves in stage() and the
   /// end_teleop() rest move. Sized to keep motion within joint velocity limits
   /// (no violent moves when start and goal are far apart).
-  float slew_time_s_{2.0f};
+  float staging_time_s_{2.0f};
 
   /// Whether this arm participates in the per-episode lifecycle (staging before
   /// each episode). Opt-in; parsed from "episode_lifecycle_enabled" in configure().

--- a/include/trossen_sdk/hw/hardware_component.hpp
+++ b/include/trossen_sdk/hw/hardware_component.hpp
@@ -62,6 +62,57 @@ public:
    */
   virtual nlohmann::json get_info() const { return nlohmann::json::object(); }
 
+  /**
+   * @brief Per-episode lifecycle hook: prepare the hardware before recording starts.
+   *
+   * Invoked by the SessionManager during the pre-episode phase (the same point as
+   * on_pre_episode callbacks), before the recording scheduler runs. Override to do
+   * per-episode setup that should happen from a known state — e.g. an arm moves to its
+   * staged home pose, a mobile base resets its odometry, a camera recalibrates. Default
+   * is a no-op: a component that needs no per-episode preparation simply does not
+   * override it.
+   *
+   * Unlike the on_pre_episode callback (which returns bool to abort), this is the
+   * component's action and returns void.
+   *
+   * @note For arms driven by teleop, the SessionManager pauses the mirror loop around
+   *       the whole preparation pass, so this hook may move the hardware freely.
+   */
+  virtual void on_pre_episode() {}
+
+  /**
+   * @brief Per-episode lifecycle hook: the episode is now live and recording.
+   *
+   * Invoked by the SessionManager once the recording scheduler is running (the same
+   * point as on_episode_started callbacks). Override for work that must begin exactly
+   * when recording starts. Default is a no-op.
+   */
+  virtual void on_episode_started() {}
+
+  /**
+   * @brief Per-episode lifecycle hook: the episode has finished recording.
+   *
+   * Invoked by the SessionManager after the episode stops (the same point as
+   * on_episode_ended callbacks). Override for per-episode teardown or cleanup. Default
+   * is a no-op.
+   */
+  virtual void on_episode_ended() {}
+
+  /**
+   * @brief Whether the SessionManager should invoke this component's per-episode
+   * lifecycle hooks (on_pre_episode / on_episode_started / on_episode_ended).
+   *
+   * Defaults to false (opt-in), so hardware is never moved or reset between episodes
+   * unless a component reports otherwise. Components that support episode work override
+   * this to return their own configured state — parsed from their own config block,
+   * alongside their other fields (e.g. an arm reads "episode_lifecycle_enabled" next to
+   * its ip_address / staged_position). The SessionManager checks this before calling
+   * the hooks.
+   *
+   * @return true if this component participates in the per-episode lifecycle
+   */
+  virtual bool is_episode_lifecycle_enabled() const { return false; }
+
 protected:
   /// @brief Component identifier
   std::string identifier_;

--- a/include/trossen_sdk/hw/hardware_component.hpp
+++ b/include/trossen_sdk/hw/hardware_component.hpp
@@ -92,9 +92,14 @@ public:
   /**
    * @brief Per-episode lifecycle hook: the episode has finished recording.
    *
-   * Invoked by the SessionManager after the episode stops (the same point as
+   * Invoked by the SessionManager after the episode stops cleanly (the same point as
    * on_episode_ended callbacks). Override for per-episode teardown or cleanup. Default
    * is a no-op.
+   *
+   * @note Invoked on both a clean stop and a discard / re-record, so the component is
+   *       left in a consistent between-episode state either way. (User on_episode_ended
+   *       *callbacks* registered on the SessionManager, by contrast, fire only on a
+   *       clean stop — a discarded episode produced no data to report.)
    */
   virtual void on_episode_ended() {}
 
@@ -108,6 +113,11 @@ public:
    * alongside their other fields (e.g. an arm reads "episode_lifecycle_enabled" next to
    * its ip_address / staged_position). The SessionManager checks this before calling
    * the hooks.
+   *
+   * @note The SessionManager discovers lifecycle components through the producers
+   *       registered with it, so a component participates only if it also backs at
+   *       least one producer added via add_producer()/add_push_producer(). Enabling the
+   *       flag on a component that is never recorded has no effect.
    *
    * @return true if this component participates in the per-episode lifecycle
    */

--- a/include/trossen_sdk/hw/producer_base.hpp
+++ b/include/trossen_sdk/hw/producer_base.hpp
@@ -19,6 +19,10 @@
 
 namespace trossen::hw {
 
+// Forward declaration: producers store and expose their backing component as a
+// shared_ptr but never dereference it here, so an incomplete type suffices.
+class HardwareComponent;
+
 /**
  * @brief Statistics for a producer
  */
@@ -111,6 +115,24 @@ public:
    */
   virtual std::shared_ptr<ProducerMetadata> metadata() const = 0;
 
+  /**
+   * @brief The hardware component this producer was built from.
+   *
+   * nullptr for producers with no backing component (e.g. mocks). Set by the
+   * ProducerRegistry at creation; the SessionManager uses it to reach the
+   * component's per-episode lifecycle hooks.
+   *
+   * @return Shared pointer to the backing component, or nullptr
+   */
+  std::shared_ptr<HardwareComponent> hardware() const { return component_; }
+
+  /**
+   * @brief Set the backing hardware component. Called by ProducerRegistry::create().
+   *
+   * @param hw Hardware component this producer was built from
+   */
+  void set_hardware(std::shared_ptr<HardwareComponent> hw) { component_ = std::move(hw); }
+
 protected:
   /// @brief Whether we've opened the device
   bool opened_{false};
@@ -138,6 +160,9 @@ protected:
 
   /// @brief Producer metadata
   PolledProducer::ProducerMetadata metadata_{};
+
+  /// @brief Backing hardware component (see hardware()).
+  std::shared_ptr<HardwareComponent> component_;
 };
 
 /**
@@ -177,6 +202,24 @@ public:
    */
   const ProducerStats& stats() const {return stats_; }
 
+  /**
+   * @brief The hardware component this producer was built from.
+   *
+   * nullptr for producers with no backing component. Set by the
+   * PushProducerRegistry at creation; the SessionManager uses it to reach the
+   * component's per-episode lifecycle hooks.
+   *
+   * @return Shared pointer to the backing component, or nullptr
+   */
+  std::shared_ptr<HardwareComponent> hardware() const { return component_; }
+
+  /**
+   * @brief Set the backing hardware component. Called by PushProducerRegistry::create().
+   *
+   * @param hw Hardware component this producer was built from
+   */
+  void set_hardware(std::shared_ptr<HardwareComponent> hw) { component_ = std::move(hw); }
+
 protected:
   /// @brief Whether we've opened the device
   bool opened_{false};
@@ -201,6 +244,9 @@ protected:
 
   /// @brief Monotonic sequence number for emitted records
   uint64_t seq_{0};
+
+  /// @brief Backing hardware component (see hardware()).
+  std::shared_ptr<HardwareComponent> component_;
 };
 
 }  // namespace trossen::hw

--- a/include/trossen_sdk/hw/teleop/teleop_controller.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_controller.hpp
@@ -90,6 +90,20 @@ public:
   void reset_teleop();
 
   /**
+   * @brief Pause the mirror loop without releasing the hardware.
+   *
+   * Joins the control thread but, unlike stop_teleop(), does NOT call
+   * end_teleop() — the drivers stay configured and the robots hold their last
+   * commanded pose. After this, the robots can be re-staged, and a subsequent
+   * prepare_teleop() re-arms teleop modes (running_ is false again) followed
+   * by teleop() to restart the loop. Idempotent; no-op if not running.
+   *
+   * Used to re-stage robots to their home pose between episodes without tearing
+   * down teleop.
+   */
+  void pause_teleop();
+
+  /**
    * @brief Stop the mirror loop and return hardware to rest.
    *
    * Joins the control thread, then calls end_teleop() on both components

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -32,6 +32,11 @@
 #include "trossen_sdk/configuration/types/runtime/session_manager_config.hpp"
 
 
+// Forward declaration: the SessionManager holds teleop controllers as shared_ptrs
+// and drives their lifecycle primitives. The full definition is only needed in the
+// .cpp, so forward-declaring keeps the teleop header out of this one.
+namespace trossen::hw::teleop { class TeleopController; }
+
 namespace trossen::runtime {
 
 /// @brief User action returned by monitor_episode() and wait_for_reset()
@@ -101,6 +106,21 @@ public:
    * Must be called before start_episode().
    */
   void add_push_producer(std::shared_ptr<hw::PushProducer> producer);
+
+  /**
+   * @brief Register a teleop controller whose lifecycle the SessionManager drives.
+   *
+   * Once registered, the manager owns the controller's per-episode choreography: it
+   * pauses the mirror and re-arms around staging in the pre-episode phase, starts
+   * mirroring when recording goes live, resets between episodes, and stops teleop at
+   * shutdown. Applications no longer wire these steps by hand.
+   *
+   * Must be called before start_episode().
+   *
+   * @param controller Shared pointer to a teleop controller
+   * @throws std::runtime_error if called while an episode is active
+   */
+  void add_teleop(std::shared_ptr<hw::teleop::TeleopController> controller);
 
   /**
    * @brief Register a non-durable Observer.
@@ -545,6 +565,10 @@ private:
   /// @brief Registered push producers (persists across episodes)
   std::vector<PushProducerEntry> push_producer_entries_;
 
+  /// @brief Registered teleop controllers; the manager drives their per-episode
+  /// lifecycle (pause/stage bracket, mirror start, reset, shutdown stop).
+  std::vector<std::shared_ptr<hw::teleop::TeleopController>> teleop_controllers_;
+
   /// @brief Registered observers; persist across episodes
   std::vector<std::shared_ptr<observer::ObserverBase>> observers_;
 
@@ -584,6 +608,20 @@ private:
    * Checks elapsed time and calls stop_episode() when max_duration reached
    */
   void monitor_duration();
+
+  /**
+   * @brief Collect the unique hardware components that opt into the per-episode
+   * lifecycle.
+   *
+   * Walks the registered polled and push producers, takes each producer's backing
+   * component (producer->hardware()), drops nulls (e.g. mock producers) and
+   * duplicates, and keeps only those reporting is_episode_lifecycle_enabled(). The
+   * result is the set on which on_pre_episode()/on_episode_started()/on_episode_ended()
+   * are invoked.
+   *
+   * @return Deduplicated, lifecycle-enabled components backing the producers
+   */
+  std::vector<std::shared_ptr<hw::HardwareComponent>> collect_lifecycle_components_() const;
 };
 
 }  // namespace trossen::runtime

--- a/src/hw/arm/trossen_arm_component.cpp
+++ b/src/hw/arm/trossen_arm_component.cpp
@@ -7,6 +7,7 @@
 #include "trossen_sdk/hw/hardware_registry.hpp"
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -68,12 +69,15 @@ void TrossenArmComponent::configure(const nlohmann::json& config) {
     }
     staged_position_ = std::move(pos);
   }
-  if (config.contains("teleop_moving_time_s")) {
-    teleop_moving_time_s_ = config.at("teleop_moving_time_s").get<float>();
-    if (teleop_moving_time_s_ < 0.0f || !std::isfinite(teleop_moving_time_s_)) {
+  if (config.contains("slew_time_s")) {
+    slew_time_s_ = config.at("slew_time_s").get<float>();
+    if (slew_time_s_ < 0.0f || !std::isfinite(slew_time_s_)) {
       throw std::runtime_error(
-        "TrossenArmComponent: 'teleop_moving_time_s' must be non-negative and finite");
+        "TrossenArmComponent: 'slew_time_s' must be non-negative and finite");
     }
+  }
+  if (config.contains("episode_lifecycle_enabled")) {
+    episode_lifecycle_enabled_ = config.at("episode_lifecycle_enabled").get<bool>();
   }
 
   // TODO(lukeschmitt-tr): Can do other configuration like joint characteristics here if needed
@@ -153,24 +157,51 @@ void TrossenArmComponent::prepare_for_teleop() {
 
 void TrossenArmComponent::end_teleop() {
   if (!driver_) return;
-  // Neutralize first (safe regardless of current mode), then gracefully
-  // return to rest over the configured trajectory time, then release the
-  // driver.
-  driver_->set_all_modes(trossen_arm::Mode::idle);
+  std::cout << "  [end_teleop] " << get_identifier()
+            << ": holding pose, then returning to rest over "
+            << slew_time_s_ << "s..." << std::endl;
+  // Hold the current pose before resting, so the arm doesn't drop under
+  // gravity on Ctrl+C before position control engages. Switch into position
+  // mode and immediately command the measured pose (goal_time 0 = zero
+  // displacement, since the arm is already there) to seed the position
+  // setpoint to where the arm actually is, so it holds. Then drive it to rest
+  // over the configured trajectory time.
+  const std::vector<float> current = read_joint();
   driver_->set_all_modes(trossen_arm::Mode::position);
+  if (!current.empty()) {
+    driver_->set_all_positions(
+      std::vector<double>(current.begin(), current.end()), 0.0, true);
+  }
   driver_->set_all_positions(
     std::vector<double>(driver_->get_num_joints(), 0.0),
-    teleop_moving_time_s_, true);
+    slew_time_s_, true);
   driver_->cleanup();
   driver_.reset();
+  std::cout << "  [end_teleop] " << get_identifier() << ": done" << std::endl;
+}
+
+void TrossenArmComponent::on_pre_episode() {
+  // HardwareComponent per-episode hook: re-home this arm before each episode.
+  // The SessionManager calls this only when is_episode_lifecycle_enabled() is
+  // true, and pauses any teleop mirror around the call, so stage() can drive
+  // the arm safely. stage() itself is a no-op when no staged_position is set.
+  stage();
 }
 
 void TrossenArmComponent::stage() {
-  if (!driver_ || staged_position_.empty()) return;
+  if (!driver_) return;
+  if (staged_position_.empty()) {
+    std::cout << "  [stage] " << get_identifier()
+              << ": no staged_position configured, skipping" << std::endl;
+    return;
+  }
+  std::cout << "  [stage] " << get_identifier() << ": moving to home over "
+            << slew_time_s_ << "s" << std::endl;
   driver_->set_all_modes(trossen_arm::Mode::position);
   std::vector<double> pos_d(staged_position_.begin(), staged_position_.end());
-  // Non-blocking so multiple arms can stage in parallel.
-  driver_->set_all_positions(pos_d, teleop_moving_time_s_, false);
+  // Blocking so the arm reaches home before the caller hands it to teleop
+  // (gravity-comp) or starts recording; this mirrors end_teleop()'s rest move.
+  driver_->set_all_positions(pos_d, slew_time_s_, true);
 }
 
 REGISTER_HARDWARE(TrossenArmComponent, "trossen_arm")

--- a/src/hw/arm/trossen_arm_component.cpp
+++ b/src/hw/arm/trossen_arm_component.cpp
@@ -69,11 +69,11 @@ void TrossenArmComponent::configure(const nlohmann::json& config) {
     }
     staged_position_ = std::move(pos);
   }
-  if (config.contains("slew_time_s")) {
-    slew_time_s_ = config.at("slew_time_s").get<float>();
-    if (slew_time_s_ < 0.0f || !std::isfinite(slew_time_s_)) {
+  if (config.contains("staging_time_s")) {
+    staging_time_s_ = config.at("staging_time_s").get<float>();
+    if (staging_time_s_ < 0.0f || !std::isfinite(staging_time_s_)) {
       throw std::runtime_error(
-        "TrossenArmComponent: 'slew_time_s' must be non-negative and finite");
+        "TrossenArmComponent: 'staging_time_s' must be non-negative and finite");
     }
   }
   if (config.contains("episode_lifecycle_enabled")) {
@@ -159,7 +159,7 @@ void TrossenArmComponent::end_teleop() {
   if (!driver_) return;
   std::cout << "  [end_teleop] " << get_identifier()
             << ": holding pose, then returning to rest over "
-            << slew_time_s_ << "s..." << std::endl;
+            << staging_time_s_ << "s..." << std::endl;
   // Hold the current pose before resting, so the arm doesn't drop under
   // gravity on Ctrl+C before position control engages. Switch into position
   // mode and immediately command the measured pose (goal_time 0 = zero
@@ -174,7 +174,7 @@ void TrossenArmComponent::end_teleop() {
   }
   driver_->set_all_positions(
     std::vector<double>(driver_->get_num_joints(), 0.0),
-    slew_time_s_, true);
+    staging_time_s_, true);
   driver_->cleanup();
   driver_.reset();
   std::cout << "  [end_teleop] " << get_identifier() << ": done" << std::endl;
@@ -196,12 +196,12 @@ void TrossenArmComponent::stage() {
     return;
   }
   std::cout << "  [stage] " << get_identifier() << ": moving to home over "
-            << slew_time_s_ << "s" << std::endl;
+            << staging_time_s_ << "s" << std::endl;
   driver_->set_all_modes(trossen_arm::Mode::position);
   std::vector<double> pos_d(staged_position_.begin(), staged_position_.end());
   // Blocking so the arm reaches home before the caller hands it to teleop
   // (gravity-comp) or starts recording; this mirrors end_teleop()'s rest move.
-  driver_->set_all_positions(pos_d, slew_time_s_, true);
+  driver_->set_all_positions(pos_d, staging_time_s_, true);
 }
 
 REGISTER_HARDWARE(TrossenArmComponent, "trossen_arm")

--- a/src/hw/teleop/teleop_controller.cpp
+++ b/src/hw/teleop/teleop_controller.cpp
@@ -34,10 +34,10 @@ TeleopController::TeleopController(
   // not implement the required space child class.
   resolve_space_views();
 
-  // Staging to a home pose is driven by the application (see the examples'
-  // on_pre_episode hook), not the controller, so that it happens before the
-  // mirror loop becomes active and can be re-run per episode when teleop is
-  // disabled.
+  // Staging to a home pose is not the controller's concern. The SessionManager
+  // drives it per episode by calling HardwareComponent::on_pre_episode() on each
+  // opted-in component (e.g. an arm moving to its staged pose) while the mirror
+  // loop is paused, so it happens from a known state before teleop restarts.
 }
 
 TeleopController::~TeleopController() {

--- a/src/hw/teleop/teleop_controller.cpp
+++ b/src/hw/teleop/teleop_controller.cpp
@@ -34,15 +34,10 @@ TeleopController::TeleopController(
   // not implement the required space child class.
   resolve_space_views();
 
-  // Each arm stages itself using its own configured staging pose and
-  // trajectory time. Arms that don't need staging override stage() with
-  // a no-op. Calls here are expected to be non-blocking so multi-arm
-  // setups stage in parallel.
-  leader_->stage();
-  if (follower_) {
-    follower_->stage();
-  }
-  std::cout << "  [teleop] Staging initiated\n";
+  // Staging to a home pose is driven by the application (see the examples'
+  // on_pre_episode hook), not the controller, so that it happens before the
+  // mirror loop becomes active and can be re-run per episode when teleop is
+  // disabled.
 }
 
 TeleopController::~TeleopController() {
@@ -114,6 +109,13 @@ void TeleopController::teleop() {
   if (running_.exchange(true)) {
     return;
   }
+  // Reap a previous loop that exited on its own: control_loop() catches and
+  // sets running_=false on exception but does not join, so the finished thread
+  // stays joinable. Assigning to a joinable std::thread calls std::terminate,
+  // so join any stale thread before starting a new one.
+  if (thread_.joinable()) {
+    thread_.join();
+  }
   thread_ = std::thread([this]() { control_loop(); });
 }
 
@@ -121,6 +123,16 @@ void TeleopController::reset_teleop() {
   leader_->post_episode();
   if (follower_) {
     follower_->post_episode();
+  }
+}
+
+void TeleopController::pause_teleop() {
+  // Stop the mirror thread but keep the drivers alive. running_ is left false
+  // so the next prepare_teleop() re-arms teleop modes and teleop() can restart
+  // the loop. Unlike stop_teleop(), end_teleop() is not called.
+  running_.store(false);
+  if (thread_.joinable()) {
+    thread_.join();
   }
 }
 

--- a/src/runtime/producer_registry.cpp
+++ b/src/runtime/producer_registry.cpp
@@ -45,6 +45,11 @@ std::shared_ptr<hw::PolledProducer> ProducerRegistry::create(
     throw std::runtime_error("Failed to create producer of type: " + type);
   }
 
+  // Retain the backing component so the SessionManager can reach its per-episode
+  // lifecycle hooks. nullptr for hardware-less producers (e.g. mocks), which the
+  // manager then simply skips.
+  producer->set_hardware(hardware);
+
   return producer;
 }
 

--- a/src/runtime/push_producer_registry.cpp
+++ b/src/runtime/push_producer_registry.cpp
@@ -45,6 +45,11 @@ std::shared_ptr<hw::PushProducer> PushProducerRegistry::create(
     throw std::runtime_error("Failed to create push producer of type: " + type);
   }
 
+  // Retain the backing component so the SessionManager can reach its per-episode
+  // lifecycle hooks. nullptr for hardware-less producers (e.g. mocks), which the
+  // manager then simply skips.
+  producer->set_hardware(hardware);
+
   return producer;
 }
 

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <future>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -371,7 +372,18 @@ bool SessionManager::start_episode() {
   // (e.g. arms re-home to their staged pose), then re-arm teleop modes before the
   // mirror restarts at episode start.
   for (auto& ctrl : teleop_controllers_) ctrl->pause_teleop();
-  for (auto& comp : collect_lifecycle_components_()) comp->on_pre_episode();
+  // Run the components' pre-episode hooks in parallel. Each drives independent
+  // hardware (its own arm/driver), and staging is a blocking point-to-point move, so
+  // running them concurrently bounds the episode-boundary wait by the slowest component
+  // instead of the sum. Futures rethrow on get() and join on destruction, so a hook
+  // exception still propagates and no staging thread is left orphaned.
+  {
+    std::vector<std::future<void>> staging;
+    for (auto& comp : collect_lifecycle_components_()) {
+      staging.push_back(std::async(std::launch::async, [comp]() { comp->on_pre_episode(); }));
+    }
+    for (auto& f : staging) f.get();
+  }
   for (auto& ctrl : teleop_controllers_) ctrl->prepare_teleop();
 
   // Create and configure scheduler

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -10,9 +10,12 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_controller.hpp"
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/runtime/session_manager.hpp"
 #include "trossen_sdk/utils/app_utils.hpp"
@@ -106,6 +109,11 @@ void SessionManager::shutdown() {
   // Useful for returning hardware to safe positions while post-processing runs.
   if (!shutdown_callbacks_fired_) {
     shutdown_callbacks_fired_ = true;
+
+    // SDK-driven shutdown safing: stop each teleop mirror and return its hardware to
+    // rest before user pre-shutdown callbacks run.
+    for (auto& ctrl : teleop_controllers_) ctrl->stop_teleop();
+
     for (const auto& cb : pre_shutdown_cbs_) {
       try {
         cb();
@@ -149,6 +157,44 @@ void SessionManager::add_push_producer(std::shared_ptr<hw::PushProducer> produce
   }
 
   push_producer_entries_.push_back(PushProducerEntry{.producer = std::move(producer)});
+}
+
+void SessionManager::add_teleop(std::shared_ptr<hw::teleop::TeleopController> controller) {
+  if (!controller) {
+    throw std::invalid_argument("Cannot add null teleop controller");
+  }
+
+  if (episode_active_) {
+    throw std::runtime_error(
+      "Cannot add teleop controllers while episode is active. Add before start_episode().");
+  }
+
+  teleop_controllers_.push_back(std::move(controller));
+}
+
+std::vector<std::shared_ptr<hw::HardwareComponent>>
+SessionManager::collect_lifecycle_components_() const {
+  // A component may back multiple producers, so deduplicate by identity to invoke
+  // each component's hooks exactly once. Skip nulls (hardware-less producers such as
+  // mocks) and components that did not opt in (is_episode_lifecycle_enabled()
+  // defaults to false).
+  std::vector<std::shared_ptr<hw::HardwareComponent>> components;
+  std::unordered_set<hw::HardwareComponent*> seen;
+
+  auto consider = [&](const std::shared_ptr<hw::HardwareComponent>& c) {
+    if (!c) return;                                    // hardware-less producer (e.g. mock)
+    if (!c->is_episode_lifecycle_enabled()) return;    // opted out (the default)
+    if (!seen.insert(c.get()).second) return;          // already collected (dedup by identity)
+    components.push_back(c);
+  };
+
+  for (const auto& pt : producer_tasks_) {
+    consider(pt.producer ? pt.producer->hardware() : nullptr);
+  }
+  for (const auto& ppe : push_producer_entries_) {
+    consider(ppe.producer ? ppe.producer->hardware() : nullptr);
+  }
+  return components;
 }
 
 void SessionManager::add_observer(std::shared_ptr<observer::ObserverBase> observer) {
@@ -319,6 +365,15 @@ bool SessionManager::start_episode() {
     }
   }
 
+  // SDK-driven per-episode preparation (runs after user pre-episode callbacks, so it
+  // is skipped if the episode was aborted above). Pause teleop mirrors so staging
+  // cannot fight the control loop, run each opted-in component's pre-episode hook
+  // (e.g. arms re-home to their staged pose), then re-arm teleop modes before the
+  // mirror restarts at episode start.
+  for (auto& ctrl : teleop_controllers_) ctrl->pause_teleop();
+  for (auto& comp : collect_lifecycle_components_()) comp->on_pre_episode();
+  for (auto& ctrl : teleop_controllers_) ctrl->prepare_teleop();
+
   // Create and configure scheduler
   scheduler_ = std::make_unique<Scheduler>();
   // TODO(lukeschmitt-tr): Expose Scheduler::Config in SessionConfig if needed
@@ -372,6 +427,11 @@ bool SessionManager::start_episode() {
 
   trossen::utils::announce(
     "Episode " + std::to_string(next_episode_index_) + " started", false);
+
+  // SDK-driven episode start: bring teleop mirrors up now that recording is live, and
+  // notify components that the episode has started.
+  for (auto& ctrl : teleop_controllers_) ctrl->teleop();
+  for (auto& comp : collect_lifecycle_components_()) comp->on_episode_started();
 
   // Invoke episode-started callbacks
   for (const auto& cb : episode_started_cbs_) {
@@ -519,6 +579,11 @@ void SessionManager::teardown_episode(bool discard) {
         obs->on_episode_ended(finished_episode_index);
       }
     }
+
+    // SDK-driven episode end: put teleop mirrors into their between-episode reset
+    // state and notify components that the episode has ended.
+    for (auto& ctrl : teleop_controllers_) ctrl->reset_teleop();
+    for (auto& comp : collect_lifecycle_components_()) comp->on_episode_ended();
 
     // Invoke episode-ended callbacks
     for (const auto& cb : callbacks_snapshot) {

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -519,6 +519,12 @@ void SessionManager::teardown_episode(bool discard) {
 
   episode_active_ = false;
 
+  // Snapshot the per-episode lifecycle participants under the lock; their hooks run
+  // after the lock is released (below) on both the discard and clean-stop paths, so we
+  // never call into hardware while holding episode_mutex_.
+  auto lifecycle_controllers = teleop_controllers_;
+  auto lifecycle_components = collect_lifecycle_components_();
+
   if (discard) {
     // Signal stats emitted so monitor_episode() can exit
     stats_emitted_.store(true);
@@ -529,6 +535,13 @@ void SessionManager::teardown_episode(bool discard) {
 
     std::cout << "Episode " << next_episode_index_
               << " discarded. Will re-record at same index." << std::endl;
+
+    // Run the episode-end lifecycle on discard too, so teleop and components are left
+    // in the same between-episode state as a clean stop. No user episode-ended
+    // callbacks fire here -- a discarded episode produced no data to report.
+    lock.unlock();
+    for (auto& ctrl : lifecycle_controllers) ctrl->reset_teleop();
+    for (auto& comp : lifecycle_components) comp->on_episode_ended();
   } else {
     ++total_episodes_completed_;
 
@@ -582,8 +595,8 @@ void SessionManager::teardown_episode(bool discard) {
 
     // SDK-driven episode end: put teleop mirrors into their between-episode reset
     // state and notify components that the episode has ended.
-    for (auto& ctrl : teleop_controllers_) ctrl->reset_teleop();
-    for (auto& comp : collect_lifecycle_components_()) comp->on_episode_ended();
+    for (auto& ctrl : lifecycle_controllers) ctrl->reset_teleop();
+    for (auto& comp : lifecycle_components) comp->on_episode_ended();
 
     // Invoke episode-ended callbacks
     for (const auto& cb : callbacks_snapshot) {

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -375,14 +375,20 @@ bool SessionManager::start_episode() {
   // Run the components' pre-episode hooks in parallel. Each drives independent
   // hardware (its own arm/driver), and staging is a blocking point-to-point move, so
   // running them concurrently bounds the episode-boundary wait by the slowest component
-  // instead of the sum. Futures rethrow on get() and join on destruction, so a hook
-  // exception still propagates and no staging thread is left orphaned.
-  {
+  // instead of the sum. A hook can throw (e.g. an arm's stage() on a comms/limit fault);
+  // get() rethrows the first such failure, and the remaining async futures still join in
+  // the vector's destructor as the stack unwinds, so no staging thread is orphaned. Treat
+  // a staging failure like any other start_episode() failure: log and cleanly abort.
+  try {
     std::vector<std::future<void>> staging;
     for (auto& comp : collect_lifecycle_components_()) {
       staging.push_back(std::async(std::launch::async, [comp]() { comp->on_pre_episode(); }));
     }
     for (auto& f : staging) f.get();
+  } catch (const std::exception& e) {
+    std::cerr << "Per-episode staging hook threw: " << e.what()
+              << "; aborting episode." << std::endl;
+    return cleanup_and_abort();
   }
   for (auto& ctrl : teleop_controllers_) ctrl->prepare_teleop();
 

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -195,7 +195,7 @@ TEST(ArmConfigTest, FromJson_ParsesStagingFields) {
     {"model", "wxai_v0"},
     {"end_effector", "wxai_v0_leader"},
     {"staged_position", {0.0f, 1.0f, 0.5f, 0.6f, 0.0f, 0.0f, 0.0f}},
-    {"slew_time_s", 3.5f}
+    {"staging_time_s", 3.5f}
   };
 
   ArmConfig cfg = ArmConfig::from_json(j);
@@ -204,7 +204,7 @@ TEST(ArmConfigTest, FromJson_ParsesStagingFields) {
   EXPECT_EQ(cfg.end_effector, "wxai_v0_leader");
   ASSERT_EQ(cfg.staged_position.size(), 7u);
   EXPECT_FLOAT_EQ(cfg.staged_position[1], 1.0f);
-  EXPECT_FLOAT_EQ(cfg.slew_time_s, 3.5f);
+  EXPECT_FLOAT_EQ(cfg.staging_time_s, 3.5f);
 }
 
 // ============================================================================
@@ -215,14 +215,14 @@ TEST(ArmConfigTest, RoundTrip_PreservesStagingFields) {
   ArmConfig original;
   original.ip_address = "192.168.1.7";
   original.staged_position = {0.1f, 0.2f, 0.3f};
-  original.slew_time_s = 1.25f;
+  original.staging_time_s = 1.25f;
 
   ArmConfig restored = ArmConfig::from_json(original.to_json());
 
   EXPECT_EQ(restored.ip_address, "192.168.1.7");
   ASSERT_EQ(restored.staged_position.size(), 3u);
   EXPECT_FLOAT_EQ(restored.staged_position[2], 0.3f);
-  EXPECT_FLOAT_EQ(restored.slew_time_s, 1.25f);
+  EXPECT_FLOAT_EQ(restored.staging_time_s, 1.25f);
 }
 
 // ============================================================================
@@ -235,9 +235,9 @@ TEST(ArmConfigTest, ToJson_OmitsEmptyStagedPosition) {
   nlohmann::json j = cfg.to_json();
 
   // staged_position must be absent (a present-but-empty array would be
-  // rejected by TrossenArmComponent::configure()), while slew_time_s
+  // rejected by TrossenArmComponent::configure()), while staging_time_s
   // is always emitted.
   EXPECT_FALSE(j.contains("staged_position"));
-  EXPECT_TRUE(j.contains("slew_time_s"));
-  EXPECT_FLOAT_EQ(j.at("slew_time_s").get<float>(), 2.0f);
+  EXPECT_TRUE(j.contains("staging_time_s"));
+  EXPECT_FLOAT_EQ(j.at("staging_time_s").get<float>(), 2.0f);
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -15,11 +15,15 @@
 #include "trossen_sdk/configuration/base_config.hpp"
 #include "trossen_sdk/configuration/config_registry.hpp"
 #include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/sdk_config.hpp"
+#include "trossen_sdk/configuration/types/hardware/arm_config.hpp"
 #include "trossen_sdk/configuration/types/runtime/session_manager_config.hpp"
 
+using trossen::configuration::ArmConfig;
 using trossen::configuration::BaseConfig;
 using trossen::configuration::ConfigRegistry;
 using trossen::configuration::GlobalConfig;
+using trossen::configuration::SdkConfig;
 using trossen::configuration::SessionManagerConfig;
 
 // ============================================================================
@@ -179,4 +183,61 @@ TEST(ConfigRegistryTest, SessionManagerType_Registered) {
   auto sm_cfg = std::dynamic_pointer_cast<SessionManagerConfig>(cfg);
   ASSERT_NE(sm_cfg, nullptr);
   EXPECT_DOUBLE_EQ(sm_cfg->max_duration->count(), 5.0);
+}
+
+// ============================================================================
+// CFG-08: ArmConfig parses optional staging fields from JSON
+// ============================================================================
+
+TEST(ArmConfigTest, FromJson_ParsesStagingFields) {
+  nlohmann::json j = {
+    {"ip_address", "192.168.1.5"},
+    {"model", "wxai_v0"},
+    {"end_effector", "wxai_v0_leader"},
+    {"staged_position", {0.0f, 1.0f, 0.5f, 0.6f, 0.0f, 0.0f, 0.0f}},
+    {"slew_time_s", 3.5f}
+  };
+
+  ArmConfig cfg = ArmConfig::from_json(j);
+
+  EXPECT_EQ(cfg.ip_address, "192.168.1.5");
+  EXPECT_EQ(cfg.end_effector, "wxai_v0_leader");
+  ASSERT_EQ(cfg.staged_position.size(), 7u);
+  EXPECT_FLOAT_EQ(cfg.staged_position[1], 1.0f);
+  EXPECT_FLOAT_EQ(cfg.slew_time_s, 3.5f);
+}
+
+// ============================================================================
+// CFG-09: ArmConfig round-trips staging fields through to_json/from_json
+// ============================================================================
+
+TEST(ArmConfigTest, RoundTrip_PreservesStagingFields) {
+  ArmConfig original;
+  original.ip_address = "192.168.1.7";
+  original.staged_position = {0.1f, 0.2f, 0.3f};
+  original.slew_time_s = 1.25f;
+
+  ArmConfig restored = ArmConfig::from_json(original.to_json());
+
+  EXPECT_EQ(restored.ip_address, "192.168.1.7");
+  ASSERT_EQ(restored.staged_position.size(), 3u);
+  EXPECT_FLOAT_EQ(restored.staged_position[2], 0.3f);
+  EXPECT_FLOAT_EQ(restored.slew_time_s, 1.25f);
+}
+
+// ============================================================================
+// CFG-10: ArmConfig with no staging omits staged_position in JSON
+// ============================================================================
+
+TEST(ArmConfigTest, ToJson_OmitsEmptyStagedPosition) {
+  ArmConfig cfg;  // default: empty staged_position
+
+  nlohmann::json j = cfg.to_json();
+
+  // staged_position must be absent (a present-but-empty array would be
+  // rejected by TrossenArmComponent::configure()), while slew_time_s
+  // is always emitted.
+  EXPECT_FALSE(j.contains("staged_position"));
+  EXPECT_TRUE(j.contains("slew_time_s"));
+  EXPECT_FLOAT_EQ(j.at("slew_time_s").get<float>(), 2.0f);
 }

--- a/tests/test_teleop_controller.cpp
+++ b/tests/test_teleop_controller.cpp
@@ -43,6 +43,20 @@ public:
   TeleopTypeIO* as_space_io(Space) override { return &io_; }
 };
 
+// Wait (bounded) for the control loop to observe its own exit. A ThrowingLeader
+// makes control_loop() throw on the first read(), which clears running_; poll for
+// that transition rather than assuming a fixed delay, so the test is deterministic
+// on slow/loaded CI but still fails (instead of hanging) if the loop never stops.
+bool wait_until_stopped(const TeleopController& ctrl,
+                        std::chrono::milliseconds timeout = std::chrono::seconds(2)) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (ctrl.is_running()) {
+    if (std::chrono::steady_clock::now() >= deadline) return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return true;
+}
+
 // If the control loop throws, the controller must not std::terminate on
 // destruction. The exception handler in control_loop() catches the error
 // and clears running_; the destructor then joins the (already-exited)
@@ -52,8 +66,7 @@ TEST(TeleopControllerTest, ControlLoopExceptionDoesNotTerminate) {
   TeleopController::Config cfg{};
   TeleopController ctrl(leader, nullptr, cfg);
   ctrl.teleop();
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  EXPECT_FALSE(ctrl.is_running());
+  EXPECT_TRUE(wait_until_stopped(ctrl));
   // Destruction here must complete without std::terminate.
 }
 
@@ -71,14 +84,12 @@ TEST(TeleopControllerTest, RestartAfterControlLoopExceptionDoesNotTerminate) {
   // First start: read() throws, control_loop() catches and clears running_,
   // but nothing joins the finished thread.
   ctrl.teleop();
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  EXPECT_FALSE(ctrl.is_running());
+  EXPECT_TRUE(wait_until_stopped(ctrl));
 
   // Restart with no intervening pause_teleop()/stop_teleop(): must reap the
   // stale joinable thread instead of terminating.
   ctrl.teleop();
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  EXPECT_FALSE(ctrl.is_running());
+  EXPECT_TRUE(wait_until_stopped(ctrl));
 }
 
 // A controller with a zero control_rate_hz must throw at construction.

--- a/tests/test_teleop_controller.cpp
+++ b/tests/test_teleop_controller.cpp
@@ -57,6 +57,30 @@ TEST(TeleopControllerTest, ControlLoopExceptionDoesNotTerminate) {
   // Destruction here must complete without std::terminate.
 }
 
+// Regression: when the control loop exits via exception it clears running_ but
+// leaves the thread joinable, and the per-episode reaper (pause_teleop()) only
+// runs when staging is enabled. So with staging off, a subsequent teleop()
+// must itself join the stale thread before assigning a new one — otherwise the
+// assignment to a joinable std::thread calls std::terminate.
+TEST(TeleopControllerTest, RestartAfterControlLoopExceptionDoesNotTerminate) {
+  auto leader = std::make_shared<ThrowingLeader>();
+  TeleopController::Config cfg{};
+  cfg.control_rate_hz = 100.0f;
+  TeleopController ctrl(leader, nullptr, cfg);
+
+  // First start: read() throws, control_loop() catches and clears running_,
+  // but nothing joins the finished thread.
+  ctrl.teleop();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_FALSE(ctrl.is_running());
+
+  // Restart with no intervening pause_teleop()/stop_teleop(): must reap the
+  // stale joinable thread instead of terminating.
+  ctrl.teleop();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_FALSE(ctrl.is_running());
+}
+
 // A controller with a zero control_rate_hz must throw at construction.
 TEST(TeleopControllerTest, ZeroRateThrows) {
   auto leader = std::make_shared<StubLeader>();
@@ -86,6 +110,41 @@ TEST(TeleopControllerTest, StartStopCycle) {
 
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   ctrl.stop_teleop();
+  EXPECT_FALSE(ctrl.is_running());
+}
+
+// pause_teleop() stops the loop without tearing down teleop, and the mirror
+// can be restarted afterwards (the per-episode re-staging path).
+TEST(TeleopControllerTest, PauseTeleopStopsAndRestarts) {
+  auto leader = std::make_shared<StubLeader>();
+  TeleopController::Config cfg{};
+  cfg.control_rate_hz = 100.0f;
+  TeleopController ctrl(leader, nullptr, cfg);
+
+  ctrl.prepare_teleop();
+  ctrl.teleop();
+  EXPECT_TRUE(ctrl.is_running());
+
+  ctrl.pause_teleop();
+  EXPECT_FALSE(ctrl.is_running());
+
+  // Restartable after a pause.
+  ctrl.prepare_teleop();
+  ctrl.teleop();
+  EXPECT_TRUE(ctrl.is_running());
+
+  ctrl.stop_teleop();
+  EXPECT_FALSE(ctrl.is_running());
+}
+
+// pause_teleop() on an idle controller is a harmless no-op.
+TEST(TeleopControllerTest, PauseTeleopWhenIdleIsSafe) {
+  auto leader = std::make_shared<StubLeader>();
+  TeleopController::Config cfg{};
+  cfg.control_rate_hz = 100.0f;
+  TeleopController ctrl(leader, nullptr, cfg);
+
+  ctrl.pause_teleop();  // never started
   EXPECT_FALSE(ctrl.is_running());
 }
 


### PR DESCRIPTION
## Summary

Moves the per-episode teleop + staging choreography out of the example apps and into the SDK: the `SessionManager` now owns a per-episode hardware lifecycle, components opt in and implement their own per-episode work, and the three AI examples collapse to a single `add_teleop()` registration. Supersedes #246.

## Changes

- In `include/trossen_sdk/hw/hardware_component.hpp`: add opt-in, no-op per-episode lifecycle hooks `on_pre_episode()` / `on_episode_started()` / `on_episode_ended()` plus a virtual `is_episode_lifecycle_enabled()` (default `false`). The base parses no config — each component answers the getter from its own config. The per-episode lifecycle runs on both a clean stop and a discard/re-record (user episode-ended *callbacks* stay clean-stop only); a component only participates if it backs a registered producer.
- In `include/trossen_sdk/hw/producer_base.hpp` + `src/runtime/producer_registry.cpp` + `src/runtime/push_producer_registry.cpp`: producers retain their backing `HardwareComponent` and expose it via `hardware()`; the registries set it once after construction, so the `SessionManager` can reach every component's hooks with no per-producer code.
- In `include/trossen_sdk/runtime/session_manager.hpp` + `src/runtime/session_manager.cpp`: add `add_teleop()` + a `teleop_controllers_` list and `collect_lifecycle_components_()` (the unique, opted-in, producer-backed components). Drive the per-episode bracket — pause mirrors → `on_pre_episode()` (arms re-home) → re-arm in the pre-episode phase; `teleop()` + `on_episode_started()` once recording is live; `reset_teleop()` + `on_episode_ended()` on episode end; `stop_teleop()` at shutdown. Opted-in components stage **in parallel** (independent hardware via `std::async`), so the episode-boundary wait is bounded by the slowest arm rather than the sum. A staging hook that throws is caught and routed through the same `cleanup_and_abort()` path as every other `start_episode()` failure.
- In `include/trossen_sdk/hw/arm/trossen_arm_component.hpp` + `src/hw/arm/trossen_arm_component.cpp`: override `on_pre_episode()` → `stage()`, parse `episode_lifecycle_enabled`, and override `is_episode_lifecycle_enabled()`. Rename `teleop_moving_time_s` → `staging_time_s` (it governs any SDK-commanded point-to-point move — staging to home and the return-to-rest move — not just teleop). On teleop stop, hold the measured pose before returning to rest so the arm doesn't drop under gravity.
- In `include/trossen_sdk/hw/teleop/teleop_controller.hpp` + `src/hw/teleop/teleop_controller.cpp`: rename `pause_mirror()` → `pause_teleop()` for naming consistency, and join a stale control thread on restart so repeated `teleop()` across episodes cannot `std::terminate`.
- In `include/trossen_sdk/configuration/types/hardware/arm_config.hpp`: carry `staged_position`, `staging_time_s`, and `episode_lifecycle_enabled` through `from_json`/`to_json`.
- In `examples/trossen_{solo,stationary,mobile}_ai/{trossen_*_ai.cpp,config.json,README.md}`: hand controllers to the manager via `add_teleop()` and remove the per-episode pause/stage/re-arm, mirror-start, reset, and stop choreography the manager now owns. Example configs stay opt-out (no `episode_lifecycle_enabled`); each README's "Optional: home staging" section documents how to enable staging per arm.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass — `test_config`, `test_teleop_controller`, and the session-manager suite
- [x] Lint passes (`pre-commit` on changed files — cpplint, codespell, json, whitespace)
- [x] Tested on hardware — with staging enabled, opted-in arms re-home at the start of every episode; on Ctrl+C the arm holds its pose (no gravity drop) before returning to rest

## Breaking Changes

The new lifecycle fields — `episode_lifecycle_enabled`, `staged_position`, and `staging_time_s` — are optional and default off/empty, so configs that don't set them load unchanged. One existing key is **renamed, not aliased**: `teleop_moving_time_s` → `staging_time_s`. A config still using the old `teleop_moving_time_s` key will have it silently ignored and fall back to the `2.0s` default; update such configs to `staging_time_s`. This is a deliberate clean break (pre-1.0, no config-compat promise), not a dual-key alias.

ABI is not preserved — `HardwareComponent` gains virtuals and the producer bases gain a member; downstream consumers rebuild on upgrade (pre-1.0, no ABI promise). The teleop-stop sequence is a deliberate runtime behavior change — the arm holds position on stop instead of going briefly limp.

## Related Issues

Relates to TDS-188
