### PR TITLE
policy_client: config schema + SdkConfig wiring

### DIFF
--- a/include/trossen_sdk/configuration/sdk_config.hpp
+++ b/include/trossen_sdk/configuration/sdk_config.hpp
@@ -75,6 +75,7 @@
 #include "trossen_sdk/configuration/types/hardware/arm_config.hpp"
 #include "trossen_sdk/configuration/types/hardware/camera_config.hpp"
 #include "trossen_sdk/configuration/types/hardware/mobile_base_config.hpp"
+#include "trossen_sdk/configuration/types/hardware/policy_client_config.hpp"
 #include "trossen_sdk/configuration/types/observers/observer_config.hpp"
 #include "trossen_sdk/configuration/types/producers/producer_config.hpp"
 #include "trossen_sdk/configuration/types/teleop_config.hpp"
@@ -95,6 +96,9 @@ struct HardwareConfig {
 
   /// @brief Mobile base config (present only for mobile robots)
   std::optional<MobileBaseConfig> mobile_base;
+
+  /// @brief Policy-client hardware configs (zero or more)
+  std::vector<PolicyClientConfig> policy_clients;
 
   static HardwareConfig from_json(const nlohmann::json& j);
 };

--- a/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
@@ -11,7 +11,7 @@
  *   "api_key":      "optional-string",
  *   "transport":        "openpi_ws",       // optional; TransportRegistry name
  *   "transport_config": {},                // optional; opaque per-transport options
- *   "drain_threshold":  0.0,               // optional; firing rule θ in [0, 1)
+ *   "drain_threshold":  0.0,               // optional; firing rule theta in [0, 1)
  *   "inference_hz": 10.0,
  *   "prompt":       "Pick up the red block",
  *   "subscriptions": [
@@ -25,6 +25,9 @@
  *   ]
  * }
  * @endcode
+ *
+ * The ``type`` field selects this schema at the hardware-registry level and is
+ * not parsed by ``from_json()``; every field below (``id`` onward) is.
  */
 
 #ifndef TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__POLICY_CLIENT_CONFIG_HPP_
@@ -260,7 +263,7 @@ struct PolicyClientConfig {
   /// Defaults to an empty object.
   nlohmann::json transport_config = nlohmann::json::object();
 
-  /// Firing rule θ: send the next observation when the remaining playable
+  /// Firing rule theta: send the next observation when the remaining playable
   /// fraction of the current chunk drops to this value. 0 reproduces the
   /// synchronous openpi cadence (observe at end-of-chunk pose); higher values
   /// overlap inference with playback. Parsed and validated here; consumed by
@@ -286,7 +289,7 @@ struct PolicyClientConfig {
   /// this many seconds after a new chunk takes over from the previous one,
   /// sample() blends the outgoing chunk's last commanded row into the new
   /// chunk's rows (linear ramp from 0 to 1). Zero disables blending (hard
-  /// step). Typical values 0.05–0.15 s.
+  /// step). Typical values 0.05-0.15 s.
   double chunk_boundary_blend_s{0.0};
 
   /// Maximum time (ms) the inference loop will wait for a fresh delivery from
@@ -393,7 +396,7 @@ struct PolicyClientConfig {
       }
       j.at("drain_threshold").get_to(c.drain_threshold);
     }
-    // Strict [0, 1): θ=1 ("fire with the whole chunk unplayed") degenerates
+    // Strict [0, 1): theta=1 ("fire with the whole chunk unplayed") degenerates
     // to firing always; the negated bounded comparison also rejects NaN.
     if (!(c.drain_threshold >= 0.0 && c.drain_threshold < 1.0)) {
       throw std::runtime_error(

--- a/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
@@ -243,8 +243,8 @@ struct PolicyClientConfig {
   std::string id;
 
   /// Endpoint of the remote policy server. The scheme/format is validated by
-  /// the selected transport's factory, not here (``ws[s]://...`` for
-  /// ``openpi_ws``; ``host:port`` for the planned ``lerobot_grpc``).
+  /// the selected transport's factory, not here — e.g. ``ws[s]://host:port``
+  /// for ``openpi_ws``, ``host:port`` for ``lerobot_grpc``.
   std::string server_url;
 
   /// Optional bearer key sent as ``Authorization: Api-Key <value>``
@@ -264,7 +264,7 @@ struct PolicyClientConfig {
   /// fraction of the current chunk drops to this value. 0 reproduces the
   /// synchronous openpi cadence (observe at end-of-chunk pose); higher values
   /// overlap inference with playback. Parsed and validated here; consumed by
-  /// the drain-threshold firing logic (slice L5).
+  /// the drain-threshold firing logic.
   double drain_threshold{0.0};
 
   /// Inference cadence in Hz; must lie in (0, 1e4].

--- a/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
@@ -5,7 +5,6 @@
  * JSON format:
  * @code
  * {
- *   "type": "policy_client",
  *   "id":   "policy_main",
  *   "server_url":   "ws://10.0.0.5:8000",
  *   "api_key":      "optional-string",
@@ -156,7 +155,7 @@ struct PolicyClientJointLayoutEntry {
   /// Optional per-joint motor names for this slice. When present, length must
   /// equal ``joint_count``. Consumed by transports that key state by motor
   /// name (LeRobot's ``"<name>.pos"``); ignored by transports that concatenate
-  /// positionally (openpi). Empty means "unnamed" — downstream falls back to a
+  /// positionally (openpi). Empty means "unnamed" - downstream falls back to a
   /// positional key.
   std::vector<std::string> joint_names;
 
@@ -246,7 +245,7 @@ struct PolicyClientConfig {
   std::string id;
 
   /// Endpoint of the remote policy server. The scheme/format is validated by
-  /// the selected transport's factory, not here — e.g. ``ws[s]://host:port``
+  /// the selected transport's factory, not here - e.g. ``ws[s]://host:port``
   /// for ``openpi_ws``, ``host:port`` for ``lerobot_grpc``.
   std::string server_url;
 
@@ -304,18 +303,18 @@ struct PolicyClientConfig {
   double freshness_timeout_ms{200.0};
 
   /// First-order EMA coefficient applied to each Face's per-tick output:
-  /// ``out_t = α · chunk_row_t + (1-α) · out_{t-1}``. Acts as a low-pass
-  /// filter on the action stream sent to the followers — masks per-row
+  /// ``out_t = alpha * chunk_row_t + (1-alpha) * out_{t-1}``. Acts as a low-pass
+  /// filter on the action stream sent to the followers - masks per-row
   /// chunk noise without depending on the arm-side ``write_moving_time_s``
   /// trajectory smoother. 1.0 disables smoothing (pass-through). Lower
   /// values smooth more but add lag; rough time constant at 30 Hz is
-  /// ``(1-α)/α · 33 ms`` → α=0.5 ≈ 33 ms, α=0.4 ≈ 50 ms, α=0.3 ≈ 80 ms.
+  /// ``(1-alpha)/alpha * 33 ms`` -> alpha=0.5 ~ 33 ms, alpha=0.4 ~ 50 ms, alpha=0.3 ~ 80 ms.
   /// Reset to pass-through state on pause / slot clear. Applies to all
   /// joints in a Face's slice *except* the last one (the gripper); the
   /// gripper has its own coefficient below.
   double output_ema_alpha{1.0};
 
-  /// EMA coefficient applied to the *last joint* of each Face slice — by
+  /// EMA coefficient applied to the *last joint* of each Face slice - by
   /// convention the gripper. Defaults to 1.0 (pass-through) because
   /// gripper open/close is a fast transient (often 2-3 chunk rows from
   /// closed to fully open); smoothing it like the arm joints causes the
@@ -602,7 +601,7 @@ struct PolicyClientConfig {
     // The joint_layout entries are slices of one flat action row: each entry
     // owns columns [joint_offset, joint_offset + joint_count) and the row width
     // is the sum of the counts. For the slices to address distinct, complete
-    // joints they must tile [0, sum) exactly — no gaps, no overlap. Validate
+    // joints they must tile [0, sum) exactly - no gaps, no overlap. Validate
     // that here so a transposed or mis-typed offset fails at load instead of
     // silently commanding the wrong joints. Entries are sorted by offset and
     // each offset must equal the running total of the preceding counts.

--- a/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
@@ -538,6 +538,19 @@ struct PolicyClientConfig {
         }
       }
     }
+    {
+      // obs_key is the observation-dict slot for this record; two records sharing
+      // a key would overwrite each other at pack time, dropping one arm's state
+      // silently. Reject duplicates here so the collision surfaces at config load.
+      std::unordered_set<std::string> seen_obs_keys;
+      for (const auto& sub : c.subscriptions) {
+        if (!seen_obs_keys.insert(sub.obs_key).second) {
+          throw std::runtime_error(
+            "PolicyClientConfig: duplicate subscription obs_key '" + sub.obs_key +
+            "' for policy_client '" + c.id + "'");
+        }
+      }
+    }
     // The inference loop must never sample a record that hasn't been delivered to the
     // cache yet; throttle_hz must therefore be at least inference_hz for each entry.
     for (const auto& sub : c.subscriptions) {

--- a/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
@@ -1,0 +1,622 @@
+/**
+ * @file policy_client_config.hpp
+ * @brief Configuration for a PolicyClient hardware entry.
+ *
+ * JSON format:
+ * @code
+ * {
+ *   "type": "policy_client",
+ *   "id":   "policy_main",
+ *   "server_url":   "ws://10.0.0.5:8000",
+ *   "api_key":      "optional-string",
+ *   "transport":        "openpi_ws",       // optional; TransportRegistry name
+ *   "transport_config": {},                // optional; opaque per-transport options
+ *   "drain_threshold":  0.0,               // optional; firing rule θ in [0, 1)
+ *   "inference_hz": 10.0,
+ *   "prompt":       "Pick up the red block",
+ *   "subscriptions": [
+ *     { "record_id": "follower_left",  "throttle_hz": 30.0, "obs_key": "state.left"  },
+ *     { "record_id": "cam_high/color", "throttle_hz": 15.0, "obs_key": "images.cam_high",
+ *       "resize": [224, 224] }
+ *   ],
+ *   "joint_layout": [
+ *     { "leader_id": "policy_left",  "joint_offset": 0, "joint_count": 7 },
+ *     { "leader_id": "policy_right", "joint_offset": 7, "joint_count": 7 }
+ *   ]
+ * }
+ * @endcode
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__POLICY_CLIENT_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__POLICY_CLIENT_CONFIG_HPP_
+
+#include <algorithm>
+#include <cstddef>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Per-stream subscription that feeds the PolicyClient's observation cache.
+ */
+struct PolicyClientSubscriptionConfig {
+  /// Exact match against ``RecordBase::id``.
+  std::string record_id;
+
+  /// Maximum handler dispatch rate (Hz); must lie within [1e-3, 1e4].
+  double throttle_hz{0.0};
+
+  /// Key used when packing this record into the observation dict (e.g. "state.left",
+  /// "images.cam_high").
+  std::string obs_key;
+
+  /// {width, height} target for image streams; absent means "no resize".
+  std::optional<std::pair<int, int>> resize;
+
+  static PolicyClientSubscriptionConfig from_json(const nlohmann::json& j) {
+    PolicyClientSubscriptionConfig c;
+    if (!j.is_object()) {
+      throw std::runtime_error(
+        "PolicyClientSubscriptionConfig: entry must be a JSON object");
+    }
+
+    if (j.contains("record_id")) {
+      if (!j.at("record_id").is_string()) {
+        throw std::runtime_error(
+          "PolicyClientSubscriptionConfig: 'record_id' must be a string");
+      }
+      j.at("record_id").get_to(c.record_id);
+    }
+    if (c.record_id.empty()) {
+      throw std::runtime_error(
+        "PolicyClientSubscriptionConfig: 'record_id' is required and must be non-empty");
+    }
+
+    if (j.contains("throttle_hz")) {
+      if (!j.at("throttle_hz").is_number()) {
+        throw std::runtime_error(
+          "PolicyClientSubscriptionConfig: 'throttle_hz' must be a number for "
+          "record_id '" + c.record_id + "'");
+      }
+      j.at("throttle_hz").get_to(c.throttle_hz);
+    }
+    // Bounded-range check rejects NaN: any comparison with NaN is false, so the
+    // negation throws.
+    constexpr double kMinThrottleHz = 1e-3;
+    constexpr double kMaxThrottleHz = 1e4;
+    if (!(c.throttle_hz >= kMinThrottleHz && c.throttle_hz <= kMaxThrottleHz)) {
+      throw std::runtime_error(
+        "PolicyClientSubscriptionConfig: 'throttle_hz' must be within [1e-3, 1e4] "
+        "for record_id '" + c.record_id + "'");
+    }
+
+    if (j.contains("obs_key")) {
+      if (!j.at("obs_key").is_string()) {
+        throw std::runtime_error(
+          "PolicyClientSubscriptionConfig: 'obs_key' must be a string for "
+          "record_id '" + c.record_id + "'");
+      }
+      j.at("obs_key").get_to(c.obs_key);
+    }
+    if (c.obs_key.empty()) {
+      throw std::runtime_error(
+        "PolicyClientSubscriptionConfig: 'obs_key' is required and must be "
+        "non-empty for record_id '" + c.record_id + "'");
+    }
+
+    if (j.contains("resize")) {
+      const auto& rj = j.at("resize");
+      if (!rj.is_array() || rj.size() != 2) {
+        throw std::runtime_error(
+          "PolicyClientSubscriptionConfig: 'resize' must be a [width, height] "
+          "array for record_id '" + c.record_id + "'");
+      }
+      if (!rj[0].is_number_integer() || !rj[1].is_number_integer()) {
+        throw std::runtime_error(
+          "PolicyClientSubscriptionConfig: 'resize' entries must be integers for "
+          "record_id '" + c.record_id + "'");
+      }
+      const int w = rj[0].get<int>();
+      const int h = rj[1].get<int>();
+      if (w <= 0 || h <= 0) {
+        throw std::runtime_error(
+          "PolicyClientSubscriptionConfig: 'resize' width and height must be > 0 "
+          "for record_id '" + c.record_id + "'");
+      }
+      c.resize = std::make_pair(w, h);
+    }
+
+    return c;
+  }
+};
+
+/**
+ * @brief One row of the joint layout: which Face id, which slice of the chunk.
+ */
+struct PolicyClientJointLayoutEntry {
+  /// Id used to register the per-arm Face in ActiveHardwareRegistry.
+  std::string leader_id;
+
+  /// First column of the action chunk that belongs to this Face.
+  int joint_offset{0};
+
+  /// Number of columns this Face consumes.
+  int joint_count{0};
+
+  /// Optional per-joint motor names for this slice. When present, length must
+  /// equal ``joint_count``. Consumed by transports that key state by motor
+  /// name (LeRobot's ``"<name>.pos"``); ignored by transports that concatenate
+  /// positionally (openpi). Empty means "unnamed" — downstream falls back to a
+  /// positional key.
+  std::vector<std::string> joint_names;
+
+  static PolicyClientJointLayoutEntry from_json(const nlohmann::json& j) {
+    PolicyClientJointLayoutEntry c;
+    if (!j.is_object()) {
+      throw std::runtime_error(
+        "PolicyClientJointLayoutEntry: entry must be a JSON object");
+    }
+
+    if (j.contains("leader_id")) {
+      if (!j.at("leader_id").is_string()) {
+        throw std::runtime_error(
+          "PolicyClientJointLayoutEntry: 'leader_id' must be a string");
+      }
+      j.at("leader_id").get_to(c.leader_id);
+    }
+    if (c.leader_id.empty()) {
+      throw std::runtime_error(
+        "PolicyClientJointLayoutEntry: 'leader_id' is required and must be non-empty");
+    }
+
+    if (j.contains("joint_offset")) {
+      if (!j.at("joint_offset").is_number_integer()) {
+        throw std::runtime_error(
+          "PolicyClientJointLayoutEntry: 'joint_offset' must be an integer for "
+          "leader_id '" + c.leader_id + "'");
+      }
+      j.at("joint_offset").get_to(c.joint_offset);
+    }
+    if (c.joint_offset < 0) {
+      throw std::runtime_error(
+        "PolicyClientJointLayoutEntry: 'joint_offset' must be >= 0 for leader_id '" +
+        c.leader_id + "'");
+    }
+
+    if (j.contains("joint_count")) {
+      if (!j.at("joint_count").is_number_integer()) {
+        throw std::runtime_error(
+          "PolicyClientJointLayoutEntry: 'joint_count' must be an integer for "
+          "leader_id '" + c.leader_id + "'");
+      }
+      j.at("joint_count").get_to(c.joint_count);
+    }
+    if (c.joint_count <= 0) {
+      throw std::runtime_error(
+        "PolicyClientJointLayoutEntry: 'joint_count' must be > 0 for leader_id '" +
+        c.leader_id + "'");
+    }
+
+    if (j.contains("joint_names")) {
+      const auto& jn = j.at("joint_names");
+      if (!jn.is_array()) {
+        throw std::runtime_error(
+          "PolicyClientJointLayoutEntry: 'joint_names' must be an array for "
+          "leader_id '" + c.leader_id + "'");
+      }
+      for (const auto& nm : jn) {
+        if (!nm.is_string()) {
+          throw std::runtime_error(
+            "PolicyClientJointLayoutEntry: 'joint_names' entries must be "
+            "strings for leader_id '" + c.leader_id + "'");
+        }
+        c.joint_names.push_back(nm.get<std::string>());
+      }
+      if (!c.joint_names.empty() &&
+          c.joint_names.size() != static_cast<std::size_t>(c.joint_count)) {
+        throw std::runtime_error(
+          "PolicyClientJointLayoutEntry: 'joint_names' length (" +
+          std::to_string(c.joint_names.size()) + ") must equal 'joint_count' (" +
+          std::to_string(c.joint_count) + ") for leader_id '" + c.leader_id + "'");
+      }
+    }
+
+    return c;
+  }
+};
+
+/**
+ * @brief Configuration for a single PolicyClient hardware instance.
+ *
+ * Faces declared in ``joint_layout`` are not configured under ``hardware:`` directly;
+ * the PolicyClient instantiates them and registers each one in ActiveHardwareRegistry.
+ */
+struct PolicyClientConfig {
+  /// Logical hardware id (matches ``hardware_id`` of the paired producer entry).
+  std::string id;
+
+  /// Endpoint of the remote policy server. The scheme/format is validated by
+  /// the selected transport's factory, not here (``ws[s]://...`` for
+  /// ``openpi_ws``; ``host:port`` for the planned ``lerobot_grpc``).
+  std::string server_url;
+
+  /// Optional bearer key sent as ``Authorization: Api-Key <value>``
+  /// (openpi_ws). Injected into ``transport_config`` when the transport is
+  /// built, so factories read it from there.
+  std::optional<std::string> api_key;
+
+  /// TransportRegistry name selecting the PolicyTransport implementation.
+  /// Defaults to ``openpi_ws`` so existing configs are untouched.
+  std::string transport{"openpi_ws"};
+
+  /// Opaque per-transport options, passed verbatim to the transport factory.
+  /// Defaults to an empty object.
+  nlohmann::json transport_config = nlohmann::json::object();
+
+  /// Firing rule θ: send the next observation when the remaining playable
+  /// fraction of the current chunk drops to this value. 0 reproduces the
+  /// synchronous openpi cadence (observe at end-of-chunk pose); higher values
+  /// overlap inference with playback. Parsed and validated here; consumed by
+  /// the drain-threshold firing logic (slice L5).
+  double drain_threshold{0.0};
+
+  /// Inference cadence in Hz; must lie in (0, 1e4].
+  double inference_hz{10.0};
+
+  /// Prompt forwarded with every observation. May be empty.
+  std::string prompt;
+
+  std::vector<PolicyClientSubscriptionConfig> subscriptions;
+  std::vector<PolicyClientJointLayoutEntry> joint_layout;
+
+  /// Optional JSONL log file path. Empty disables logging. A non-empty value
+  /// (tilde expansion supported) makes ``PolicyClient`` open the file in
+  /// append mode and write one ``request``/``response`` line per inference
+  /// cycle for comparison against external clients.
+  std::string log_path;
+
+  /// Cross-fade window (seconds) applied at chunk-boundary promotions. For
+  /// this many seconds after a new chunk takes over from the previous one,
+  /// sample() blends the outgoing chunk's last commanded row into the new
+  /// chunk's rows (linear ramp from 0 to 1). Zero disables blending (hard
+  /// step). Typical values 0.05–0.15 s.
+  double chunk_boundary_blend_s{0.0};
+
+  /// Maximum time (ms) the inference loop will wait for a fresh delivery from
+  /// every subscribed record_id before packing an observation. Each cycle
+  /// snapshots a per-subscription delivery counter, then waits until every
+  /// counter advances at least once. Guarantees that all records in an
+  /// observation snapshot were produced after the cycle began (and therefore
+  /// within one producer period of each other), matching openpi's
+  /// async_read / new_frame_event semantics. On timeout the loop proceeds
+  /// with the stalest available records and logs the offending record_ids
+  /// (one-shot). Default 200 ms is ~6 camera periods at 30 Hz throttling.
+  double freshness_timeout_ms{200.0};
+
+  /// First-order EMA coefficient applied to each Face's per-tick output:
+  /// ``out_t = α · chunk_row_t + (1-α) · out_{t-1}``. Acts as a low-pass
+  /// filter on the action stream sent to the followers — masks per-row
+  /// chunk noise without depending on the arm-side ``write_moving_time_s``
+  /// trajectory smoother. 1.0 disables smoothing (pass-through). Lower
+  /// values smooth more but add lag; rough time constant at 30 Hz is
+  /// ``(1-α)/α · 33 ms`` → α=0.5 ≈ 33 ms, α=0.4 ≈ 50 ms, α=0.3 ≈ 80 ms.
+  /// Reset to pass-through state on pause / slot clear. Applies to all
+  /// joints in a Face's slice *except* the last one (the gripper); the
+  /// gripper has its own coefficient below.
+  double output_ema_alpha{1.0};
+
+  /// EMA coefficient applied to the *last joint* of each Face slice — by
+  /// convention the gripper. Defaults to 1.0 (pass-through) because
+  /// gripper open/close is a fast transient (often 2-3 chunk rows from
+  /// closed to fully open); smoothing it like the arm joints causes the
+  /// gripper to reach only ~70% of commanded extent before the chunk's
+  /// next phase begins. Override only if you specifically want gentler
+  /// gripper motion.
+  double output_ema_alpha_gripper{1.0};
+
+  /// Original JSON object; preserved so the hardware-registry factory path can
+  /// hand the same payload back to ``PolicyClient::configure()`` without
+  /// re-serializing the parsed struct.
+  nlohmann::json raw_json;
+
+  static PolicyClientConfig from_json(const nlohmann::json& j) {
+    PolicyClientConfig c;
+    if (!j.is_object()) {
+      throw std::runtime_error(
+        "PolicyClientConfig: entry must be a JSON object");
+    }
+    c.raw_json = j;
+
+    if (j.contains("id")) {
+      if (!j.at("id").is_string()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'id' must be a string");
+      }
+      j.at("id").get_to(c.id);
+    }
+    if (c.id.empty()) {
+      throw std::runtime_error(
+        "PolicyClientConfig: 'id' is required and must be non-empty");
+    }
+
+    if (j.contains("server_url")) {
+      if (!j.at("server_url").is_string()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'server_url' must be a string for policy_client '" +
+          c.id + "'");
+      }
+      j.at("server_url").get_to(c.server_url);
+    }
+    if (c.server_url.empty()) {
+      throw std::runtime_error(
+        "PolicyClientConfig: 'server_url' is required and must be non-empty for "
+        "policy_client '" + c.id + "'");
+    }
+    // No scheme validation here: the URL format is transport-specific, so the
+    // selected transport's factory owns it (ws[s]:// for openpi_ws).
+
+    if (j.contains("transport")) {
+      if (!j.at("transport").is_string()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'transport' must be a string for policy_client '" +
+          c.id + "'");
+      }
+      j.at("transport").get_to(c.transport);
+      if (c.transport.empty()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'transport' must be non-empty for policy_client '" +
+          c.id + "'");
+      }
+    }
+
+    if (j.contains("transport_config")) {
+      if (!j.at("transport_config").is_object()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'transport_config' must be an object for "
+          "policy_client '" + c.id + "'");
+      }
+      c.transport_config = j.at("transport_config");
+    }
+
+    if (j.contains("drain_threshold")) {
+      if (!j.at("drain_threshold").is_number()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'drain_threshold' must be a number for "
+          "policy_client '" + c.id + "'");
+      }
+      j.at("drain_threshold").get_to(c.drain_threshold);
+    }
+    // Strict [0, 1): θ=1 ("fire with the whole chunk unplayed") degenerates
+    // to firing always; the negated bounded comparison also rejects NaN.
+    if (!(c.drain_threshold >= 0.0 && c.drain_threshold < 1.0)) {
+      throw std::runtime_error(
+        "PolicyClientConfig: 'drain_threshold' must be within [0, 1) for "
+        "policy_client '" + c.id + "'");
+    }
+
+    if (j.contains("api_key")) {
+      if (!j.at("api_key").is_string()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'api_key' must be a string for policy_client '" +
+          c.id + "'");
+      }
+      c.api_key = j.at("api_key").get<std::string>();
+    }
+
+    if (j.contains("inference_hz")) {
+      if (!j.at("inference_hz").is_number()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'inference_hz' must be a number for policy_client '" +
+          c.id + "'");
+      }
+      j.at("inference_hz").get_to(c.inference_hz);
+    }
+    // Strict (0, 1e4]: also rejects NaN via the negated bounded comparison.
+    constexpr double kMaxInferenceHz = 1e4;
+    if (!(c.inference_hz > 0.0 && c.inference_hz <= kMaxInferenceHz)) {
+      throw std::runtime_error(
+        "PolicyClientConfig: 'inference_hz' must be within (0, 1e4] for "
+        "policy_client '" + c.id + "'");
+    }
+
+    if (j.contains("prompt")) {
+      if (!j.at("prompt").is_string()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'prompt' must be a string for policy_client '" +
+          c.id + "'");
+      }
+      j.at("prompt").get_to(c.prompt);
+    }
+
+    if (j.contains("log_path")) {
+      if (!j.at("log_path").is_string()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'log_path' must be a string for policy_client '" +
+          c.id + "'");
+      }
+      j.at("log_path").get_to(c.log_path);
+    }
+
+    if (j.contains("chunk_boundary_blend_s")) {
+      if (!j.at("chunk_boundary_blend_s").is_number()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'chunk_boundary_blend_s' must be a number for "
+          "policy_client '" + c.id + "'");
+      }
+      j.at("chunk_boundary_blend_s").get_to(c.chunk_boundary_blend_s);
+      if (!(c.chunk_boundary_blend_s >= 0.0 && c.chunk_boundary_blend_s <= 1.0)) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'chunk_boundary_blend_s' must be within [0, 1] "
+          "for policy_client '" + c.id + "'");
+      }
+    }
+
+    if (j.contains("freshness_timeout_ms")) {
+      if (!j.at("freshness_timeout_ms").is_number()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'freshness_timeout_ms' must be a number for "
+          "policy_client '" + c.id + "'");
+      }
+      j.at("freshness_timeout_ms").get_to(c.freshness_timeout_ms);
+      // Upper bound matches the existing 10 s observation prime ceiling; lower
+      // bound rejects negative and NaN via the negated bounded comparison.
+      if (!(c.freshness_timeout_ms >= 0.0 && c.freshness_timeout_ms <= 10000.0)) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'freshness_timeout_ms' must be within [0, 10000] "
+          "for policy_client '" + c.id + "'");
+      }
+    }
+
+    if (j.contains("output_ema_alpha")) {
+      if (!j.at("output_ema_alpha").is_number()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'output_ema_alpha' must be a number for "
+          "policy_client '" + c.id + "'");
+      }
+      j.at("output_ema_alpha").get_to(c.output_ema_alpha);
+      // (0, 1]: zero would freeze the output indefinitely, > 1 amplifies.
+      // Negated comparison rejects NaN.
+      if (!(c.output_ema_alpha > 0.0 && c.output_ema_alpha <= 1.0)) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'output_ema_alpha' must be within (0, 1] for "
+          "policy_client '" + c.id + "'");
+      }
+    }
+
+    if (j.contains("output_ema_alpha_gripper")) {
+      if (!j.at("output_ema_alpha_gripper").is_number()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'output_ema_alpha_gripper' must be a number "
+          "for policy_client '" + c.id + "'");
+      }
+      j.at("output_ema_alpha_gripper").get_to(c.output_ema_alpha_gripper);
+      if (!(c.output_ema_alpha_gripper > 0.0 &&
+            c.output_ema_alpha_gripper <= 1.0)) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'output_ema_alpha_gripper' must be within "
+          "(0, 1] for policy_client '" + c.id + "'");
+      }
+    }
+
+    if (!j.contains("subscriptions") || !j.at("subscriptions").is_array()) {
+      throw std::runtime_error(
+        "PolicyClientConfig: 'subscriptions' (array) is required for policy_client '" +
+        c.id + "'");
+    }
+    {
+      size_t i = 0;
+      for (const auto& sub_j : j.at("subscriptions")) {
+        try {
+          c.subscriptions.push_back(PolicyClientSubscriptionConfig::from_json(sub_j));
+        } catch (const std::exception& e) {
+          throw std::runtime_error(
+            "PolicyClientConfig: failed to parse subscriptions[" + std::to_string(i) +
+            "] for policy_client '" + c.id + "': " + e.what());
+        }
+        ++i;
+      }
+    }
+    if (c.subscriptions.empty()) {
+      throw std::runtime_error(
+        "PolicyClientConfig: 'subscriptions' must be non-empty for policy_client '" +
+        c.id + "'");
+    }
+    {
+      std::unordered_set<std::string> seen_record_ids;
+      for (const auto& sub : c.subscriptions) {
+        if (!seen_record_ids.insert(sub.record_id).second) {
+          throw std::runtime_error(
+            "PolicyClientConfig: duplicate subscription record_id '" + sub.record_id +
+            "' for policy_client '" + c.id + "'");
+        }
+      }
+    }
+    // The inference loop must never sample a record that hasn't been delivered to the
+    // cache yet; throttle_hz must therefore be at least inference_hz for each entry.
+    for (const auto& sub : c.subscriptions) {
+      if (sub.throttle_hz < c.inference_hz) {
+        throw std::runtime_error(
+          "PolicyClientConfig: subscription '" + sub.record_id + "' has throttle_hz=" +
+          std::to_string(sub.throttle_hz) + " < inference_hz=" +
+          std::to_string(c.inference_hz) + " for policy_client '" + c.id + "'");
+      }
+    }
+
+    if (!j.contains("joint_layout") || !j.at("joint_layout").is_array()) {
+      throw std::runtime_error(
+        "PolicyClientConfig: 'joint_layout' (array) is required for policy_client '" +
+        c.id + "'");
+    }
+    {
+      size_t i = 0;
+      for (const auto& row_j : j.at("joint_layout")) {
+        try {
+          c.joint_layout.push_back(PolicyClientJointLayoutEntry::from_json(row_j));
+        } catch (const std::exception& e) {
+          throw std::runtime_error(
+            "PolicyClientConfig: failed to parse joint_layout[" + std::to_string(i) +
+            "] for policy_client '" + c.id + "': " + e.what());
+        }
+        ++i;
+      }
+    }
+    if (c.joint_layout.empty()) {
+      throw std::runtime_error(
+        "PolicyClientConfig: 'joint_layout' must be non-empty for policy_client '" +
+        c.id + "'");
+    }
+    {
+      std::unordered_set<std::string> seen_leader_ids;
+      for (const auto& row : c.joint_layout) {
+        if (!seen_leader_ids.insert(row.leader_id).second) {
+          throw std::runtime_error(
+            "PolicyClientConfig: duplicate joint_layout leader_id '" + row.leader_id +
+            "' for policy_client '" + c.id + "'");
+        }
+      }
+    }
+
+    // The joint_layout entries are slices of one flat action row: each entry
+    // owns columns [joint_offset, joint_offset + joint_count) and the row width
+    // is the sum of the counts. For the slices to address distinct, complete
+    // joints they must tile [0, sum) exactly — no gaps, no overlap. Validate
+    // that here so a transposed or mis-typed offset fails at load instead of
+    // silently commanding the wrong joints. Entries are sorted by offset and
+    // each offset must equal the running total of the preceding counts.
+    {
+      std::vector<const PolicyClientJointLayoutEntry*> ordered;
+      ordered.reserve(c.joint_layout.size());
+      for (const auto& row : c.joint_layout) ordered.push_back(&row);
+      std::sort(ordered.begin(), ordered.end(),
+                [](const PolicyClientJointLayoutEntry* a,
+                   const PolicyClientJointLayoutEntry* b) {
+                  return a->joint_offset < b->joint_offset;
+                });
+      int expected_offset = 0;
+      for (const auto* row : ordered) {
+        if (row->joint_offset != expected_offset) {
+          throw std::runtime_error(
+            "PolicyClientConfig: joint_layout slices must tile the action row "
+            "with no gaps or overlap; entry '" + row->leader_id +
+            "' has joint_offset " + std::to_string(row->joint_offset) +
+            " but the contiguous layout requires " +
+            std::to_string(expected_offset) + " for policy_client '" + c.id + "'");
+        }
+        expected_offset += row->joint_count;
+      }
+    }
+
+    return c;
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__POLICY_CLIENT_CONFIG_HPP_

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -113,7 +113,7 @@ public:
    * Once registered, the manager owns the controller's per-episode choreography: it
    * pauses the mirror and re-arms around staging in the pre-episode phase, starts
    * mirroring when recording goes live, resets between episodes, and stops teleop at
-   * shutdown. Applications no longer wire these steps by hand.
+   * shutdown, so applications do not wire these steps by hand.
    *
    * Must be called before start_episode().
    *

--- a/src/configuration/sdk_config.cpp
+++ b/src/configuration/sdk_config.cpp
@@ -35,6 +35,31 @@ HardwareConfig HardwareConfig::from_json(const nlohmann::json& j) {
     c.mobile_base = MobileBaseConfig::from_json(j.at("mobile_base"));
   }
 
+  if (j.contains("policy_clients")) {
+    if (!j.at("policy_clients").is_array()) {
+      throw std::runtime_error(
+        "HardwareConfig: 'policy_clients' must be an array");
+    }
+    size_t i = 0;
+    for (const auto& pc_j : j.at("policy_clients")) {
+      try {
+        c.policy_clients.push_back(PolicyClientConfig::from_json(pc_j));
+      } catch (const std::exception& e) {
+        throw std::runtime_error(
+          "HardwareConfig: failed to parse policy_clients[" + std::to_string(i) +
+          "]: " + e.what());
+      }
+      ++i;
+    }
+    std::unordered_set<std::string> seen_ids;
+    for (const auto& pc : c.policy_clients) {
+      if (!seen_ids.insert(pc.id).second) {
+        throw std::runtime_error(
+          "HardwareConfig: duplicate policy_client id '" + pc.id + "'");
+      }
+    }
+  }
+
   return c;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,11 @@ if(TROSSEN_ENABLE_RERUN_OBSERVER)
   target_link_libraries(test_rerun_observer PRIVATE trossen_sdk rerun_sdk GTest::gtest_main)
 endif()
 
+# PolicyClient config parsing — header-only schema, no transport deps, so it
+# builds regardless of TROSSEN_SDK_ENABLE_POLICY_CLIENT.
+add_executable(test_policy_client_config test_policy_client_config.cpp)
+target_link_libraries(test_policy_client_config PRIVATE trossen_sdk GTest::gtest_main)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -130,3 +135,4 @@ gtest_discover_tests(test_session_manager_observers)
 if(TROSSEN_ENABLE_RERUN_OBSERVER)
   gtest_discover_tests(test_rerun_observer)
 endif()
+gtest_discover_tests(test_policy_client_config)

--- a/tests/test_policy_client_config.cpp
+++ b/tests/test_policy_client_config.cpp
@@ -360,6 +360,13 @@ TEST(PolicyClientConfigTest, RejectsDuplicateSubscriptionRecordIds) {
   EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
 }
 
+TEST(PolicyClientConfigTest, RejectsDuplicateSubscriptionObsKeys) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  // Distinct record_id (follower_right stays), but collide obs_key with subscription[0].
+  j["subscriptions"][1]["obs_key"] = "state.left";
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
 TEST(PolicyClientConfigTest, RejectsThrottleBelowInferenceHz) {
   auto j = nlohmann::json::parse(kCanonicalConfig);
   // inference_hz = 10, set one throttle to 5 (still within absolute bounds).

--- a/tests/test_policy_client_config.cpp
+++ b/tests/test_policy_client_config.cpp
@@ -252,7 +252,7 @@ TEST(PolicyClientConfigTest, AcceptsWssScheme) {
 
 TEST(PolicyClientConfigTest, AcceptsNonWebsocketUrl) {
   // URL format is transport-specific (a gRPC transport takes host:port), so
-  // the shared config no longer enforces a scheme - the selected transport's
+  // the shared config does not enforce a scheme - the selected transport's
   // factory does (openpi_ws rejection is pinned in the transport tests).
   auto j = nlohmann::json::parse(kCanonicalConfig);
   j["server_url"] = "10.0.0.5:50051";
@@ -445,8 +445,8 @@ TEST(HardwareConfigPolicyClientsTest, ReportsIndexOnParseFailure) {
   nlohmann::json hw_j = nlohmann::json::object();
   hw_j["policy_clients"] = nlohmann::json::array();
   hw_j["policy_clients"].push_back(nlohmann::json::parse(kCanonicalConfig));
-  // Empty server_url is a parse-level error (scheme checks moved into the
-  // transport factories, so a bad scheme no longer throws here).
+  // Empty server_url is a parse-level error (scheme validation lives in the
+  // transport factories, not here).
   auto bad = nlohmann::json::parse(kCanonicalConfig);
   bad["server_url"] = "";
   hw_j["policy_clients"].push_back(bad);

--- a/tests/test_policy_client_config.cpp
+++ b/tests/test_policy_client_config.cpp
@@ -1,0 +1,454 @@
+/**
+ * @file test_policy_client_config.cpp
+ * @brief Unit tests for PolicyClientConfig and HardwareConfig::policy_clients parsing.
+ */
+
+#include "gtest/gtest.h"
+
+#include "nlohmann/json.hpp"
+#include "trossen_sdk/configuration/sdk_config.hpp"
+#include "trossen_sdk/configuration/types/hardware/policy_client_config.hpp"
+
+namespace {
+
+using trossen::configuration::HardwareConfig;
+using trossen::configuration::PolicyClientConfig;
+using trossen::configuration::PolicyClientJointLayoutEntry;
+using trossen::configuration::PolicyClientSubscriptionConfig;
+
+constexpr const char* kCanonicalConfig = R"({
+  "id": "policy_main",
+  "server_url": "ws://10.0.0.5:8000",
+  "inference_hz": 10.0,
+  "prompt": "Pick up the red block",
+  "subscriptions": [
+    { "record_id": "follower_left",  "throttle_hz": 30.0, "obs_key": "state.left"  },
+    { "record_id": "follower_right", "throttle_hz": 30.0, "obs_key": "state.right" },
+    { "record_id": "cam_high/color", "throttle_hz": 15.0, "obs_key": "images.cam_high",
+      "resize": [224, 224] }
+  ],
+  "joint_layout": [
+    { "leader_id": "policy_left",  "joint_offset": 0, "joint_count": 7 },
+    { "leader_id": "policy_right", "joint_offset": 7, "joint_count": 7 }
+  ]
+})";
+
+PolicyClientConfig parse_canonical() {
+  return PolicyClientConfig::from_json(nlohmann::json::parse(kCanonicalConfig));
+}
+
+// --- PolicyClientSubscriptionConfig ----------------------------------------
+
+TEST(PolicyClientSubscriptionConfigTest, RoundTripCanonical) {
+  auto j = nlohmann::json::parse(
+    R"({ "record_id": "cam", "throttle_hz": 30.0, "obs_key": "images.x",
+        "resize": [224, 224] })");
+  auto s = PolicyClientSubscriptionConfig::from_json(j);
+  EXPECT_EQ(s.record_id, "cam");
+  EXPECT_DOUBLE_EQ(s.throttle_hz, 30.0);
+  EXPECT_EQ(s.obs_key, "images.x");
+  ASSERT_TRUE(s.resize.has_value());
+  EXPECT_EQ(s.resize->first, 224);
+  EXPECT_EQ(s.resize->second, 224);
+}
+
+TEST(PolicyClientSubscriptionConfigTest, ResizeOptional) {
+  auto j = nlohmann::json::parse(
+    R"({ "record_id": "joints", "throttle_hz": 30.0, "obs_key": "state.x" })");
+  auto s = PolicyClientSubscriptionConfig::from_json(j);
+  EXPECT_FALSE(s.resize.has_value());
+}
+
+TEST(PolicyClientSubscriptionConfigTest, RejectsEmptyRecordId) {
+  auto j = nlohmann::json::parse(
+    R"({ "record_id": "", "throttle_hz": 30.0, "obs_key": "state.x" })");
+  EXPECT_THROW(PolicyClientSubscriptionConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientSubscriptionConfigTest, RejectsThrottleOutOfRange) {
+  auto low = nlohmann::json::parse(
+    R"({ "record_id": "r", "throttle_hz": 0.0, "obs_key": "k" })");
+  EXPECT_THROW(PolicyClientSubscriptionConfig::from_json(low), std::runtime_error);
+  auto high = nlohmann::json::parse(
+    R"({ "record_id": "r", "throttle_hz": 1e5, "obs_key": "k" })");
+  EXPECT_THROW(PolicyClientSubscriptionConfig::from_json(high), std::runtime_error);
+}
+
+TEST(PolicyClientSubscriptionConfigTest, RejectsEmptyObsKey) {
+  auto j = nlohmann::json::parse(
+    R"({ "record_id": "r", "throttle_hz": 30.0, "obs_key": "" })");
+  EXPECT_THROW(PolicyClientSubscriptionConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientSubscriptionConfigTest, RejectsResizeWithWrongShape) {
+  auto bad_size = nlohmann::json::parse(
+    R"({ "record_id": "r", "throttle_hz": 30.0, "obs_key": "k", "resize": [224] })");
+  EXPECT_THROW(
+    PolicyClientSubscriptionConfig::from_json(bad_size), std::runtime_error);
+}
+
+TEST(PolicyClientSubscriptionConfigTest, RejectsNonPositiveResize) {
+  auto zero = nlohmann::json::parse(
+    R"({ "record_id": "r", "throttle_hz": 30.0, "obs_key": "k", "resize": [0, 224] })");
+  EXPECT_THROW(PolicyClientSubscriptionConfig::from_json(zero), std::runtime_error);
+  auto neg = nlohmann::json::parse(
+    R"({ "record_id": "r", "throttle_hz": 30.0, "obs_key": "k", "resize": [224, -1] })");
+  EXPECT_THROW(PolicyClientSubscriptionConfig::from_json(neg), std::runtime_error);
+}
+
+TEST(PolicyClientSubscriptionConfigTest, RejectsNonIntegerResize) {
+  auto j = nlohmann::json::parse(
+    R"({ "record_id": "r", "throttle_hz": 30.0, "obs_key": "k",
+        "resize": [224.5, 224] })");
+  EXPECT_THROW(PolicyClientSubscriptionConfig::from_json(j), std::runtime_error);
+}
+
+// --- PolicyClientJointLayoutEntry ------------------------------------------
+
+TEST(PolicyClientJointLayoutEntryTest, RoundTripCanonical) {
+  auto j = nlohmann::json::parse(
+    R"({ "leader_id": "policy_left", "joint_offset": 0, "joint_count": 7 })");
+  auto e = PolicyClientJointLayoutEntry::from_json(j);
+  EXPECT_EQ(e.leader_id, "policy_left");
+  EXPECT_EQ(e.joint_offset, 0);
+  EXPECT_EQ(e.joint_count, 7);
+}
+
+TEST(PolicyClientJointLayoutEntryTest, RejectsEmptyLeaderId) {
+  auto j = nlohmann::json::parse(
+    R"({ "leader_id": "", "joint_offset": 0, "joint_count": 7 })");
+  EXPECT_THROW(PolicyClientJointLayoutEntry::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientJointLayoutEntryTest, RejectsNegativeOffset) {
+  auto j = nlohmann::json::parse(
+    R"({ "leader_id": "x", "joint_offset": -1, "joint_count": 7 })");
+  EXPECT_THROW(PolicyClientJointLayoutEntry::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientJointLayoutEntryTest, RejectsNonPositiveCount) {
+  auto zero = nlohmann::json::parse(
+    R"({ "leader_id": "x", "joint_offset": 0, "joint_count": 0 })");
+  EXPECT_THROW(PolicyClientJointLayoutEntry::from_json(zero), std::runtime_error);
+  auto neg = nlohmann::json::parse(
+    R"({ "leader_id": "x", "joint_offset": 0, "joint_count": -1 })");
+  EXPECT_THROW(PolicyClientJointLayoutEntry::from_json(neg), std::runtime_error);
+}
+
+TEST(PolicyClientJointLayoutEntryTest, JointNamesOptionalAndParsed) {
+  // Absent: empty (positional fallback downstream).
+  auto without = nlohmann::json::parse(
+    R"({ "leader_id": "x", "joint_offset": 0, "joint_count": 2 })");
+  EXPECT_TRUE(PolicyClientJointLayoutEntry::from_json(without).joint_names.empty());
+
+  // Present with length == joint_count: parsed in order.
+  auto with = nlohmann::json::parse(
+    R"({ "leader_id": "x", "joint_offset": 0, "joint_count": 2,
+         "joint_names": ["waist", "gripper"] })");
+  auto e = PolicyClientJointLayoutEntry::from_json(with);
+  ASSERT_EQ(e.joint_names.size(), 2u);
+  EXPECT_EQ(e.joint_names[0], "waist");
+  EXPECT_EQ(e.joint_names[1], "gripper");
+}
+
+TEST(PolicyClientJointLayoutEntryTest, RejectsJointNamesLengthMismatch) {
+  auto j = nlohmann::json::parse(
+    R"({ "leader_id": "x", "joint_offset": 0, "joint_count": 3,
+         "joint_names": ["a", "b"] })");
+  EXPECT_THROW(PolicyClientJointLayoutEntry::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientJointLayoutEntryTest, RejectsNonStringJointNames) {
+  auto not_array = nlohmann::json::parse(
+    R"({ "leader_id": "x", "joint_offset": 0, "joint_count": 2,
+         "joint_names": "waist" })");
+  EXPECT_THROW(PolicyClientJointLayoutEntry::from_json(not_array), std::runtime_error);
+
+  auto non_string = nlohmann::json::parse(
+    R"({ "leader_id": "x", "joint_offset": 0, "joint_count": 2,
+         "joint_names": ["waist", 5] })");
+  EXPECT_THROW(PolicyClientJointLayoutEntry::from_json(non_string), std::runtime_error);
+}
+
+// --- PolicyClientConfig: top-level positive ---------------------------------
+
+TEST(PolicyClientConfigTest, RoundTripCanonical) {
+  auto c = parse_canonical();
+  EXPECT_EQ(c.id, "policy_main");
+  EXPECT_EQ(c.server_url, "ws://10.0.0.5:8000");
+  EXPECT_FALSE(c.api_key.has_value());
+  EXPECT_DOUBLE_EQ(c.inference_hz, 10.0);
+  EXPECT_EQ(c.prompt, "Pick up the red block");
+  ASSERT_EQ(c.subscriptions.size(), 3u);
+  EXPECT_EQ(c.subscriptions[0].record_id, "follower_left");
+  EXPECT_EQ(c.subscriptions[0].obs_key, "state.left");
+  EXPECT_TRUE(c.subscriptions[2].resize.has_value());
+  ASSERT_EQ(c.joint_layout.size(), 2u);
+  EXPECT_EQ(c.joint_layout[0].leader_id, "policy_left");
+  EXPECT_EQ(c.joint_layout[1].joint_offset, 7);
+  EXPECT_EQ(c.joint_layout[1].joint_count, 7);
+  // Transport-selection defaults: existing configs resolve openpi_ws with an
+  // empty options object and the synchronous θ=0 firing cadence.
+  EXPECT_EQ(c.transport, "openpi_ws");
+  EXPECT_TRUE(c.transport_config.is_object());
+  EXPECT_TRUE(c.transport_config.empty());
+  EXPECT_DOUBLE_EQ(c.drain_threshold, 0.0);
+}
+
+TEST(PolicyClientConfigTest, RejectsOverlappingJointLayout) {
+  // Two entries whose slices overlap (both cover column 3) sum to a width that
+  // can still match the chunk, yet they address the same joints — reject it.
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["joint_layout"] = nlohmann::json::parse(R"([
+    { "leader_id": "a", "joint_offset": 0, "joint_count": 7 },
+    { "leader_id": "b", "joint_offset": 3, "joint_count": 7 }
+  ])");
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsGappedJointLayout) {
+  // A gap between slices (columns 7..9 unowned) leaves part of the action row
+  // unaddressed; reject it.
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["joint_layout"] = nlohmann::json::parse(R"([
+    { "leader_id": "a", "joint_offset": 0,  "joint_count": 7 },
+    { "leader_id": "b", "joint_offset": 10, "joint_count": 7 }
+  ])");
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, AcceptsContiguousJointLayoutOutOfOrder) {
+  // Order in the array does not matter as long as the slices tile [0, sum).
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["joint_layout"] = nlohmann::json::parse(R"([
+    { "leader_id": "b", "joint_offset": 7, "joint_count": 7 },
+    { "leader_id": "a", "joint_offset": 0, "joint_count": 7 }
+  ])");
+  auto c = PolicyClientConfig::from_json(j);
+  EXPECT_EQ(c.joint_layout.size(), 2u);
+}
+
+TEST(PolicyClientConfigTest, EmptyPromptAllowed) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["prompt"] = "";
+  auto c = PolicyClientConfig::from_json(j);
+  EXPECT_EQ(c.prompt, "");
+}
+
+TEST(PolicyClientConfigTest, OptionalApiKey) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["api_key"] = "secret-token";
+  auto c = PolicyClientConfig::from_json(j);
+  ASSERT_TRUE(c.api_key.has_value());
+  EXPECT_EQ(*c.api_key, "secret-token");
+}
+
+TEST(PolicyClientConfigTest, AcceptsWssScheme) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["server_url"] = "wss://example.com:443";
+  auto c = PolicyClientConfig::from_json(j);
+  EXPECT_EQ(c.server_url, "wss://example.com:443");
+}
+
+TEST(PolicyClientConfigTest, AcceptsNonWebsocketUrl) {
+  // URL format is transport-specific (a gRPC transport takes host:port), so
+  // the shared config no longer enforces a scheme — the selected transport's
+  // factory does (openpi_ws rejection is pinned in the transport tests).
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["server_url"] = "10.0.0.5:50051";
+  auto c = PolicyClientConfig::from_json(j);
+  EXPECT_EQ(c.server_url, "10.0.0.5:50051");
+}
+
+TEST(PolicyClientConfigTest, TransportNameParsed) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["transport"] = "lerobot_grpc";
+  auto c = PolicyClientConfig::from_json(j);
+  EXPECT_EQ(c.transport, "lerobot_grpc");
+}
+
+TEST(PolicyClientConfigTest, RejectsEmptyTransportName) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["transport"] = "";
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, TransportConfigPassedVerbatim) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["transport_config"] = {{"api_key", "k"}, {"custom_knob", 3}};
+  auto c = PolicyClientConfig::from_json(j);
+  ASSERT_TRUE(c.transport_config.is_object());
+  EXPECT_EQ(c.transport_config.at("api_key"), "k");
+  EXPECT_EQ(c.transport_config.at("custom_knob"), 3);
+}
+
+TEST(PolicyClientConfigTest, RejectsNonObjectTransportConfig) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["transport_config"] = "not-an-object";
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, DrainThresholdParsed) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["drain_threshold"] = 0.5;
+  auto c = PolicyClientConfig::from_json(j);
+  EXPECT_DOUBLE_EQ(c.drain_threshold, 0.5);
+}
+
+TEST(PolicyClientConfigTest, RejectsDrainThresholdAtOne) {
+  // θ=1 ("fire with the whole chunk unplayed") degenerates to firing always.
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["drain_threshold"] = 1.0;
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsNegativeDrainThreshold) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["drain_threshold"] = -0.1;
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+// --- PolicyClientConfig: validation rule negatives --------------------------
+
+TEST(PolicyClientConfigTest, RejectsEmptyId) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["id"] = "";
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsMissingServerUrl) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j.erase("server_url");
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsInferenceHzAtBoundary) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["inference_hz"] = 0.0;
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+  j["inference_hz"] = -1.0;
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+  j["inference_hz"] = 1e4 + 1.0;
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, AcceptsInferenceHzAtUpperBoundary) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["inference_hz"] = 1e4;
+  // Each subscription must satisfy throttle_hz >= inference_hz at the new ceiling.
+  for (auto& s : j["subscriptions"]) {
+    s["throttle_hz"] = 1e4;
+  }
+  EXPECT_NO_THROW(PolicyClientConfig::from_json(j));
+}
+
+TEST(PolicyClientConfigTest, RejectsEmptySubscriptions) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["subscriptions"] = nlohmann::json::array();
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsMissingSubscriptions) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j.erase("subscriptions");
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsDuplicateSubscriptionRecordIds) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["subscriptions"][1]["record_id"] = "follower_left";
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsThrottleBelowInferenceHz) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  // inference_hz = 10, set one throttle to 5 (still within absolute bounds).
+  j["subscriptions"][0]["throttle_hz"] = 5.0;
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsEmptyJointLayout) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["joint_layout"] = nlohmann::json::array();
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsMissingJointLayout) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j.erase("joint_layout");
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsDuplicateLeaderIds) {
+  auto j = nlohmann::json::parse(kCanonicalConfig);
+  j["joint_layout"][1]["leader_id"] = "policy_left";
+  EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RejectsNonObjectInput) {
+  EXPECT_THROW(
+    PolicyClientConfig::from_json(nlohmann::json::array()), std::runtime_error);
+}
+
+TEST(PolicyClientConfigTest, RawJsonRoundTripsParsedInput) {
+  const auto j = nlohmann::json::parse(kCanonicalConfig);
+  const auto c = PolicyClientConfig::from_json(j);
+  EXPECT_EQ(c.raw_json, j);
+}
+
+// --- HardwareConfig::policy_clients integration -----------------------------
+
+TEST(HardwareConfigPolicyClientsTest, ParsesArrayWithMultipleClients) {
+  nlohmann::json hw_j = nlohmann::json::object();
+  hw_j["policy_clients"] = nlohmann::json::array();
+  auto a = nlohmann::json::parse(kCanonicalConfig);
+  auto b = nlohmann::json::parse(kCanonicalConfig);
+  b["id"] = "policy_secondary";
+  hw_j["policy_clients"].push_back(a);
+  hw_j["policy_clients"].push_back(b);
+
+  auto hw = HardwareConfig::from_json(hw_j);
+  ASSERT_EQ(hw.policy_clients.size(), 2u);
+  EXPECT_EQ(hw.policy_clients[0].id, "policy_main");
+  EXPECT_EQ(hw.policy_clients[1].id, "policy_secondary");
+}
+
+TEST(HardwareConfigPolicyClientsTest, AbsentSectionDefaultsToEmpty) {
+  auto hw = HardwareConfig::from_json(nlohmann::json::object());
+  EXPECT_TRUE(hw.policy_clients.empty());
+}
+
+TEST(HardwareConfigPolicyClientsTest, RejectsNonArray) {
+  nlohmann::json hw_j = nlohmann::json::object();
+  hw_j["policy_clients"] = "not-an-array";
+  EXPECT_THROW(HardwareConfig::from_json(hw_j), std::runtime_error);
+}
+
+TEST(HardwareConfigPolicyClientsTest, RejectsDuplicateIds) {
+  nlohmann::json hw_j = nlohmann::json::object();
+  hw_j["policy_clients"] = nlohmann::json::array();
+  auto a = nlohmann::json::parse(kCanonicalConfig);
+  auto b = nlohmann::json::parse(kCanonicalConfig);
+  hw_j["policy_clients"].push_back(a);
+  hw_j["policy_clients"].push_back(b);
+  EXPECT_THROW(HardwareConfig::from_json(hw_j), std::runtime_error);
+}
+
+TEST(HardwareConfigPolicyClientsTest, ReportsIndexOnParseFailure) {
+  nlohmann::json hw_j = nlohmann::json::object();
+  hw_j["policy_clients"] = nlohmann::json::array();
+  hw_j["policy_clients"].push_back(nlohmann::json::parse(kCanonicalConfig));
+  // Empty server_url is a parse-level error (scheme checks moved into the
+  // transport factories, so a bad scheme no longer throws here).
+  auto bad = nlohmann::json::parse(kCanonicalConfig);
+  bad["server_url"] = "";
+  hw_j["policy_clients"].push_back(bad);
+  try {
+    HardwareConfig::from_json(hw_j);
+    FAIL() << "expected throw";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find("policy_clients[1]"), std::string::npos);
+  }
+}
+
+}  // namespace

--- a/tests/test_policy_client_config.cpp
+++ b/tests/test_policy_client_config.cpp
@@ -188,7 +188,7 @@ TEST(PolicyClientConfigTest, RoundTripCanonical) {
   EXPECT_EQ(c.joint_layout[1].joint_offset, 7);
   EXPECT_EQ(c.joint_layout[1].joint_count, 7);
   // Transport-selection defaults: existing configs resolve openpi_ws with an
-  // empty options object and the synchronous θ=0 firing cadence.
+  // empty options object and the synchronous theta=0 firing cadence.
   EXPECT_EQ(c.transport, "openpi_ws");
   EXPECT_TRUE(c.transport_config.is_object());
   EXPECT_TRUE(c.transport_config.empty());
@@ -296,7 +296,7 @@ TEST(PolicyClientConfigTest, DrainThresholdParsed) {
 }
 
 TEST(PolicyClientConfigTest, RejectsDrainThresholdAtOne) {
-  // θ=1 ("fire with the whole chunk unplayed") degenerates to firing always.
+  // theta=1 ("fire with the whole chunk unplayed") degenerates to firing always.
   auto j = nlohmann::json::parse(kCanonicalConfig);
   j["drain_threshold"] = 1.0;
   EXPECT_THROW(PolicyClientConfig::from_json(j), std::runtime_error);

--- a/tests/test_policy_client_config.cpp
+++ b/tests/test_policy_client_config.cpp
@@ -197,7 +197,7 @@ TEST(PolicyClientConfigTest, RoundTripCanonical) {
 
 TEST(PolicyClientConfigTest, RejectsOverlappingJointLayout) {
   // Two entries whose slices overlap (both cover column 3) sum to a width that
-  // can still match the chunk, yet they address the same joints — reject it.
+  // can still match the chunk, yet they address the same joints - reject it.
   auto j = nlohmann::json::parse(kCanonicalConfig);
   j["joint_layout"] = nlohmann::json::parse(R"([
     { "leader_id": "a", "joint_offset": 0, "joint_count": 7 },
@@ -252,7 +252,7 @@ TEST(PolicyClientConfigTest, AcceptsWssScheme) {
 
 TEST(PolicyClientConfigTest, AcceptsNonWebsocketUrl) {
   // URL format is transport-specific (a gRPC transport takes host:port), so
-  // the shared config no longer enforces a scheme — the selected transport's
+  // the shared config no longer enforces a scheme - the selected transport's
   // factory does (openpi_ws rejection is pinned in the transport tests).
   auto j = nlohmann::json::parse(kCanonicalConfig);
   j["server_url"] = "10.0.0.5:50051";


### PR DESCRIPTION
## Summary

First PR in the **PolicyClient** stack — the SDK bridge that drives Trossen arms from a remote inference server (openpi or LeRobot). This PR adds only the configuration schema so the rest of the stack has a validated config type to build against; no runtime code or dependencies yet.

> **Stack:** part of the PolicyClient stack, based on #248. Each PR is a self-contained component; the stack tip equals the validated working integration. Review bottom-up.

## Changes

- In `include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp`: new `PolicyClientConfig` schema — transport selection (`transport` name + opaque `transport_config`), `joint_layout` (per-arm groups with `joint_names`), record `subscriptions`, and playback/timing knobs (`drain_threshold`, `inference_hz`, output EMA alphas). Defaults preserve the openpi flow (`transport` defaults to `openpi_ws`).
- In `include/trossen_sdk/configuration/sdk_config.hpp` + `src/configuration/sdk_config.cpp`: carry `HardwareConfig.policy_clients` (zero or more) through `from_json`, with duplicate-`id` validation and per-entry error context.
- In `tests/test_policy_client_config.cpp` + `tests/CMakeLists.txt`: parse/validation coverage. The schema is header-only, so this test builds without the policy-client build gate.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass — `test_policy_client_config`
- [x] Lint passes (`pre-commit run --all-files`)
- [ ] Hardware — N/A (config schema only; exercised end-to-end by #255)

## Breaking Changes

None. `policy_clients` is a new optional `HardwareConfig` array; existing configs load unchanged.

## Related

Based on #248 (auto-retargets to `main` when it merges). Followed by #250–#255. No TDS ticket — experimental subsystem; design lives in the external `policy_client_docs`.
