### PR TITLE
policy_client: neutral observation/action types

### DIFF
--- a/include/trossen_sdk/hw/policy/action_chunk.hpp
+++ b/include/trossen_sdk/hw/policy/action_chunk.hpp
@@ -215,7 +215,7 @@ class ChunkSlot {
     std::chrono::steady_clock::time_point now,
     int total_n,
     double control_rate_hz) const noexcept {
-    // TODO(shantanuparab-tr): fill-into-buffer overload if RT profiling shows alloc jitter
+    // Returns a freshly allocated row; a fill-into-buffer overload could avoid the alloc.
     try {
       std::lock_guard<std::mutex> lk(mu_);
 
@@ -344,7 +344,7 @@ class ChunkSlot {
     std::chrono::steady_clock::time_point now,
     int total_n,
     double control_rate_hz) const noexcept {
-    // TODO(shantanuparab-tr): fill-into-buffer overload if RT profiling shows alloc jitter
+    // Returns a freshly allocated row; a fill-into-buffer overload could avoid the alloc.
     SampleInfo info;
     try {
       std::lock_guard<std::mutex> lk(mu_);

--- a/include/trossen_sdk/hw/policy/action_chunk.hpp
+++ b/include/trossen_sdk/hw/policy/action_chunk.hpp
@@ -3,8 +3,8 @@
  * @brief Action chunk POD and slot publishing actions to TeleopController readers.
  */
 
-#ifndef TROSSEN_SDK__HW__POLICY__ACTION_CHUNK_HPP
-#define TROSSEN_SDK__HW__POLICY__ACTION_CHUNK_HPP
+#ifndef TROSSEN_SDK__HW__POLICY__ACTION_CHUNK_HPP_
+#define TROSSEN_SDK__HW__POLICY__ACTION_CHUNK_HPP_
 
 #include <chrono>
 #include <cmath>
@@ -41,7 +41,8 @@ struct ActionChunk {
   /**
    * @brief Return the action row at index t.
    * @param t row index in [0, T).
-   * @throws std::out_of_range if t is outside [0, T).
+   * @throws std::out_of_range if t is outside [0, T), or if @c data is shorter
+   *         than the [t*N, t*N+N) slice it would return.
    */
   [[nodiscard]] std::vector<float> row(int t) const {
     if (t < 0 || t >= T) {
@@ -50,6 +51,14 @@ struct ActionChunk {
         " out of range [0, " + std::to_string(T) + ")");
     }
     const std::size_t start = static_cast<std::size_t>(t) * static_cast<std::size_t>(N);
+    // data may be shorter than T*N on a malformed server chunk; slicing past
+    // data.end() would be UB, so reject it rather than build from bad iterators.
+    if (start + static_cast<std::size_t>(N) > data.size()) {
+      throw std::out_of_range(
+        "ActionChunk::row: data.size()=" + std::to_string(data.size()) +
+        " too short for row " + std::to_string(t) + " of width " +
+        std::to_string(N));
+    }
     return std::vector<float>(data.begin() + start, data.begin() + start + N);
   }
 };
@@ -66,6 +75,15 @@ struct ActionChunk {
  * Pass a null pointer to swap_in() to reset the slot entirely (clears both
  * latest_ and pending_); subsequent samples fall back to the cached last
  * commanded row.
+ *
+ * Threading (single-consumer contract): exactly one thread may call the
+ * sample family (sample / sample_with_info). It may run concurrently with
+ * swap_in / swap_in_aligned / peek / exhaustion_time called from the
+ * inference thread — those are all mu_-guarded. Concurrent calls into the
+ * sample family from more than one thread are race-free (mu_ protects the
+ * state) but logically undefined: the samplers interleave playback
+ * advancement (playback_start_, last_cmd_, t_idx progression) and corrupt
+ * each other's notion of "where playback is." Use one sampler.
  */
 class ChunkSlot {
  public:
@@ -184,6 +202,10 @@ class ChunkSlot {
    * non-positive) on configuration mismatch, missing chunk, or internal
    * failure. Never propagates exceptions.
    *
+   * Single-consumer: only one thread may call this (see class doc). The
+   * const-with-mutable playback advancement is intentional — playback state
+   * is logically internal and every access is guarded by mu_.
+   *
    * @param now             Sample timestamp (typically steady_clock::now()).
    * @param total_n         Expected width of the action row.
    * @param control_rate_hz Row-selection rate; must be > 0.
@@ -193,11 +215,27 @@ class ChunkSlot {
     std::chrono::steady_clock::time_point now,
     int total_n,
     double control_rate_hz) const noexcept {
+    // TODO(shantanuparab-tr): fill-into-buffer overload if RT profiling shows alloc jitter
     try {
       std::lock_guard<std::mutex> lk(mu_);
 
-      if (!latest_ || latest_->T <= 0 || latest_->N <= 0 ||
-          control_rate_hz <= 0.0 || latest_->N != total_n) {
+      // control_rate_hz is a caller/config error, not a chunk defect: hold,
+      // never discard a chunk over it.
+      if (control_rate_hz <= 0.0) {
+        return hold_last_locked_(total_n);
+      }
+      // An unplayable latest_ (degenerate dims, wrong width, or data shorter
+      // than T*N on a malformed server chunk) must not wedge the slot in
+      // hold-last: discard it and pull its successor so the slot self-heals,
+      // otherwise a valid pending_ would never be promoted. This tick still
+      // holds the last row; the next tick re-checks the freshly promoted chunk.
+      if (latest_ && !chunk_playable_(*latest_, total_n)) {
+        latest_ = std::move(pending_);
+        pending_.reset();
+        if (latest_) playback_start_ = now;
+        return hold_last_locked_(total_n);
+      }
+      if (!latest_) {
         return hold_last_locked_(total_n);
       }
 
@@ -216,11 +254,12 @@ class ChunkSlot {
         pending_.reset();
         playback_start_ = now;
         t_idx = 0;
-        // The promoted successor must match the configured action width; the
-        // top-of-function guard only checked the outgoing chunk. A mismatched
-        // successor would emit a wrong-length row to the followers, so hold the
-        // last commanded row instead (the next sample re-checks the guard).
-        if (latest_->N != total_n) {
+        // The promoted successor must be playable at the configured width; the
+        // top-of-function guard only checked the outgoing chunk. An unplayable
+        // successor would emit a wrong-length row (or slice past data.end()),
+        // so hold the last commanded row instead (the next sample re-checks the
+        // guard and self-heals).
+        if (!chunk_playable_(*latest_, total_n)) {
           return hold_last_locked_(total_n);
         }
       }
@@ -296,17 +335,37 @@ class ChunkSlot {
    * post-run analysis can identify chunk boundaries, exhaust-and-hold
    * windows, and cross-fade transitions in the actual command stream sent
    * to the followers.
+   *
+   * Single-consumer: only one thread may call this (see class doc). The
+   * const-with-mutable playback advancement is intentional — playback state
+   * is logically internal and every access is guarded by mu_.
    */
   [[nodiscard]] SampleInfo sample_with_info(
     std::chrono::steady_clock::time_point now,
     int total_n,
     double control_rate_hz) const noexcept {
+    // TODO(shantanuparab-tr): fill-into-buffer overload if RT profiling shows alloc jitter
     SampleInfo info;
     try {
       std::lock_guard<std::mutex> lk(mu_);
 
-      if (!latest_ || latest_->T <= 0 || latest_->N <= 0 ||
-          control_rate_hz <= 0.0 || latest_->N != total_n) {
+      // control_rate_hz is a caller/config error, not a chunk defect: hold,
+      // never discard a chunk over it.
+      if (control_rate_hz <= 0.0) {
+        info.row = hold_last_locked_(total_n);
+        return info;
+      }
+      // An unplayable latest_ (degenerate dims, wrong width, or data shorter
+      // than T*N on a malformed server chunk) must not wedge the slot: discard
+      // it and pull its successor so the slot self-heals (mirror of sample()).
+      if (latest_ && !chunk_playable_(*latest_, total_n)) {
+        latest_ = std::move(pending_);
+        pending_.reset();
+        if (latest_) playback_start_ = now;
+        info.row = hold_last_locked_(total_n);
+        return info;
+      }
+      if (!latest_) {
         info.row = hold_last_locked_(total_n);
         return info;
       }
@@ -325,9 +384,9 @@ class ChunkSlot {
         pending_.reset();
         playback_start_ = now;
         t_idx = 0;
-        // See sample(): a promoted successor of the wrong width must not reach
-        // the followers — hold the last commanded row instead.
-        if (latest_->N != total_n) {
+        // See sample(): an unplayable promoted successor must not reach the
+        // followers — hold the last commanded row instead.
+        if (!chunk_playable_(*latest_, total_n)) {
           info.row = hold_last_locked_(total_n);
           return info;
         }
@@ -422,6 +481,16 @@ class ChunkSlot {
   }
 
  private:
+  // A chunk is playable only if its dims are positive, its width matches the
+  // configured action width, and its data buffer actually holds T*N floats.
+  // The last check guards against a malformed server chunk whose data is
+  // shorter than advertised — row() would otherwise slice past data.end().
+  static bool chunk_playable_(const ActionChunk& c, int total_n) noexcept {
+    return c.T > 0 && c.N > 0 && c.N == total_n &&
+           c.data.size() ==
+             static_cast<std::size_t>(c.T) * static_cast<std::size_t>(c.N);
+  }
+
   // Requires mu_ held. Linear scan is fine — the skip list is at most a
   // handful of indices (one gripper per arm), so a sorted-vector + binary
   // search would only add code complexity without measurable benefit.
@@ -476,4 +545,4 @@ class ChunkSlot {
 
 }  // namespace trossen::hw::policy
 
-#endif  // TROSSEN_SDK__HW__POLICY__ACTION_CHUNK_HPP
+#endif  // TROSSEN_SDK__HW__POLICY__ACTION_CHUNK_HPP_

--- a/include/trossen_sdk/hw/policy/action_chunk.hpp
+++ b/include/trossen_sdk/hw/policy/action_chunk.hpp
@@ -157,7 +157,7 @@ class ChunkSlot {
    * @brief Aligned take-over: install @p chunk as the playing chunk at once.
    *
    * Unlike swap_in's consume-fully parking, this replaces @c latest_
-   * immediately (the async-overlap / drain-threshold θ>0 path). Row 0 is
+   * immediately (the async-overlap / drain-threshold theta>0 path). Row 0 is
    * anchored at @p playback_start on the wall clock — typically
    * ``epoch + base_timestep / rate`` — so the next sample() serves the row
    * matching "now" and skips rows already in the past. The caller is

--- a/include/trossen_sdk/hw/policy/action_chunk.hpp
+++ b/include/trossen_sdk/hw/policy/action_chunk.hpp
@@ -1,0 +1,479 @@
+/**
+ * @file action_chunk.hpp
+ * @brief Action chunk POD and slot publishing actions to TeleopController readers.
+ */
+
+#ifndef TROSSEN_SDK__HW__POLICY__ACTION_CHUNK_HPP
+#define TROSSEN_SDK__HW__POLICY__ACTION_CHUNK_HPP
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace trossen::hw::policy {
+
+/**
+ * @brief Fixed-size [T x N] row-major chunk of commanded actions.
+ *
+ * Populated by the PolicyClient inference thread after a successful
+ * server round-trip and then published into a ChunkSlot. Immutable once
+ * published.
+ */
+struct ActionChunk {
+  int T{0};
+  int N{0};
+  std::vector<float> data;
+  uint64_t chunk_seq{0};
+  std::chrono::steady_clock::time_point received_at{};
+  /// Absolute Timestep Clock tick at which row 0 should play. Lets ChunkSlot
+  /// align a chunk to the clock on take-over (skip rows already in the past,
+  /// discard an all-past chunk). LeRobot stamps the server-scheduled value;
+  /// openpi stamps the timestep of the observation that produced the chunk.
+  int64_t base_timestep{0};
+
+  /**
+   * @brief Return the action row at index t.
+   * @param t row index in [0, T).
+   * @throws std::out_of_range if t is outside [0, T).
+   */
+  [[nodiscard]] std::vector<float> row(int t) const {
+    if (t < 0 || t >= T) {
+      throw std::out_of_range(
+        "ActionChunk::row: t=" + std::to_string(t) +
+        " out of range [0, " + std::to_string(T) + ")");
+    }
+    const std::size_t start = static_cast<std::size_t>(t) * static_cast<std::size_t>(N);
+    return std::vector<float>(data.begin() + start, data.begin() + start + N);
+  }
+};
+
+/**
+ * @brief Thread-safe holder for the playing ActionChunk, a pending successor,
+ *        and the last commanded row.
+ *
+ * Consume-fully contract: a chunk handed to swap_in() while another chunk is
+ * still playing is parked in @p pending_ and only promoted to @p latest_ once
+ * @p latest_ has been sampled past its last row. The pending slot is depth-1:
+ * newer pendings replace older ones (the policy server's last word wins).
+ *
+ * Pass a null pointer to swap_in() to reset the slot entirely (clears both
+ * latest_ and pending_); subsequent samples fall back to the cached last
+ * commanded row.
+ */
+class ChunkSlot {
+ public:
+  ChunkSlot() = default;
+  ChunkSlot(const ChunkSlot&) = delete;
+  ChunkSlot& operator=(const ChunkSlot&) = delete;
+  ChunkSlot(ChunkSlot&&) = delete;
+  ChunkSlot& operator=(ChunkSlot&&) = delete;
+
+  /// Optional linear cross-fade window applied at chunk-boundary promotions
+  /// (pending → latest). For @p seconds after a promotion, sample() blends the
+  /// last commanded row from the outgoing chunk with the new chunk's row using
+  /// alpha = clamp(elapsed/seconds, 0, 1). Default 0 = no blend (hard step).
+  void set_boundary_blend_s(double seconds) noexcept {
+    std::lock_guard<std::mutex> lk(mu_);
+    boundary_blend_s_ = seconds > 0.0 ? seconds : 0.0;
+  }
+
+  /// Column indices (into the chunk's per-row vector) that bypass the
+  /// boundary cross-fade. Intended for gripper channels: the cross-fade is
+  /// designed to smooth arm-joint transitions across chunk promotions, but
+  /// gripper open/close is a fast transient whose value the policy may
+  /// only command for a few rows of the new chunk. Blending dampens that
+  /// command and produces weak grasps. Skipped channels jump straight to
+  /// the new chunk's row value at the boundary; arm channels continue to
+  /// blend as before.
+  void set_boundary_blend_skip_indices(std::vector<int> indices) noexcept {
+    try {
+      std::lock_guard<std::mutex> lk(mu_);
+      boundary_blend_skip_indices_ = std::move(indices);
+    } catch (...) {
+      // noexcept contract; nothing actionable on lock failure.
+    }
+  }
+
+  /**
+   * @brief Publish a new chunk under the consume-fully contract.
+   *
+   * - Null clears both latest_ and pending_ (hold-last-action via last_cmd_).
+   * - With no current chunk, the new chunk becomes latest_ and starts playing.
+   * - With a current chunk still playing, the new chunk lands in pending_
+   *   (replacing any older pending) and is promoted by sample() once the
+   *   current chunk is exhausted.
+   */
+  void swap_in(std::shared_ptr<const ActionChunk> chunk) noexcept {
+    try {
+      std::lock_guard<std::mutex> lk(mu_);
+      if (!chunk) {
+        latest_.reset();
+        pending_.reset();
+        blend_from_.clear();
+        return;
+      }
+      if (!latest_) {
+        // Anchor row 0 at the chunk's receipt instant (not the first sample),
+        // so playback stays aligned to wall time: any rows whose play instant
+        // already passed during inference latency are skipped by sample()'s
+        // t_idx, rather than replayed from row 0. received_at and the sample
+        // `now` are both steady_clock, so the offset is meaningful.
+        playback_start_ = chunk->received_at;
+        latest_ = std::move(chunk);
+        return;
+      }
+      pending_ = std::move(chunk);
+    } catch (...) {
+      // lock_guard ctor is not expected to throw; swallow per noexcept.
+    }
+  }
+
+  /**
+   * @brief Aligned take-over: install @p chunk as the playing chunk at once.
+   *
+   * Unlike swap_in's consume-fully parking, this replaces @c latest_
+   * immediately (the async-overlap / drain-threshold θ>0 path). Row 0 is
+   * anchored at @p playback_start on the wall clock — typically
+   * ``epoch + base_timestep / rate`` — so the next sample() serves the row
+   * matching "now" and skips rows already in the past. The caller is
+   * responsible for the all-past discard decision (it owns the timestep clock);
+   * a @p playback_start far enough in the past simply makes sample() clamp at
+   * the last row until a successor arrives.
+   *
+   * Stages a boundary cross-fade from the last commanded row (if configured and
+   * width-compatible), starting at @p takeover_now, so the discontinuity
+   * between the outgoing row and the new chunk's aligned row is smoothed.
+   *
+   * @param chunk          New chunk to play immediately (no-op if null).
+   * @param playback_start Wall-clock anchor for the chunk's row 0.
+   * @param takeover_now   Instant of take-over; the cross-fade origin.
+   */
+  void swap_in_aligned(
+      std::shared_ptr<const ActionChunk> chunk,
+      std::chrono::steady_clock::time_point playback_start,
+      std::chrono::steady_clock::time_point takeover_now) noexcept {
+    try {
+      if (!chunk) return;
+      std::lock_guard<std::mutex> lk(mu_);
+      stage_blend_locked_(chunk->N, takeover_now);
+      latest_ = std::move(chunk);
+      pending_.reset();
+      playback_start_ = playback_start;
+    } catch (...) {
+      // noexcept contract; nothing actionable on lock failure.
+    }
+  }
+
+  /**
+   * @brief Sample the action row corresponding to time @p now.
+   *
+   * Rows are returned in order 0..T-1 driven by @p control_rate_hz. When the
+   * current chunk is exhausted and a pending chunk is queued, the pending is
+   * promoted to latest_ (playback restarts at row 0). When no pending exists,
+   * the last row is held indefinitely. Updates the cached last commanded row
+   * so swap_in(nullptr) keeps returning a sensible value.
+   *
+   * Falls back to a zero vector (sized to total_n, or 1 if total_n is
+   * non-positive) on configuration mismatch, missing chunk, or internal
+   * failure. Never propagates exceptions.
+   *
+   * @param now             Sample timestamp (typically steady_clock::now()).
+   * @param total_n         Expected width of the action row.
+   * @param control_rate_hz Row-selection rate; must be > 0.
+   * @return action row of length max(total_n, 1).
+   */
+  [[nodiscard]] std::vector<float> sample(
+    std::chrono::steady_clock::time_point now,
+    int total_n,
+    double control_rate_hz) const noexcept {
+    try {
+      std::lock_guard<std::mutex> lk(mu_);
+
+      if (!latest_ || latest_->T <= 0 || latest_->N <= 0 ||
+          control_rate_hz <= 0.0 || latest_->N != total_n) {
+        return hold_last_locked_(total_n);
+      }
+
+      auto t_idx_for = [&](std::chrono::steady_clock::time_point start) {
+        const double dt_s =
+          std::chrono::duration<double>(now - start).count();
+        return static_cast<int64_t>(std::floor(dt_s * control_rate_hz));
+      };
+
+      int64_t t_idx = t_idx_for(playback_start_);
+
+      // Promote pending → latest as soon as the current chunk is exhausted.
+      if (t_idx >= latest_->T && pending_) {
+        stage_blend_locked_(pending_->N, now);
+        latest_ = std::move(pending_);
+        pending_.reset();
+        playback_start_ = now;
+        t_idx = 0;
+        // The promoted successor must match the configured action width; the
+        // top-of-function guard only checked the outgoing chunk. A mismatched
+        // successor would emit a wrong-length row to the followers, so hold the
+        // last commanded row instead (the next sample re-checks the guard).
+        if (latest_->N != total_n) {
+          return hold_last_locked_(total_n);
+        }
+      }
+      if (t_idx < 0) {
+        t_idx = 0;
+      }
+      if (t_idx >= latest_->T) {
+        t_idx = latest_->T - 1;
+      }
+
+      std::vector<float> row = latest_->row(static_cast<int>(t_idx));
+
+      // Linear cross-fade with the outgoing chunk's last commanded row.
+      if (!blend_from_.empty() && blend_from_.size() == row.size()) {
+        const double dt =
+          std::chrono::duration<double>(now - blend_start_).count();
+        if (dt < boundary_blend_s_) {
+          const double alpha = dt / boundary_blend_s_;
+          const double one_minus = 1.0 - alpha;
+          for (std::size_t i = 0; i < row.size(); ++i) {
+            if (is_blend_skip_locked_(static_cast<int>(i))) continue;
+            row[i] = static_cast<float>(
+              one_minus * static_cast<double>(blend_from_[i]) +
+              alpha * static_cast<double>(row[i]));
+          }
+        } else {
+          // Blend window closed; release the carried row to skip the math on
+          // every subsequent tick within this chunk.
+          blend_from_.clear();
+        }
+      }
+
+      last_cmd_ = row;
+      return row;
+    } catch (...) {
+      const std::size_t n =
+        total_n > 0 ? static_cast<std::size_t>(total_n) : std::size_t{1};
+      return std::vector<float>(n, 0.0f);
+    }
+  }
+
+  /**
+   * @brief Sample result enriched with playback diagnostics.
+   *
+   * Returned by ``sample_with_info``. Carries the row, plus the per-tick
+   * metadata callers need to correlate this row with the chunk boundary
+   * (which chunk_seq it came from, which t_idx within the chunk, whether
+   * the slot is currently saturating at row T-1, whether a boundary
+   * cross-fade is active).
+   */
+  struct SampleInfo {
+    /// The action row returned to the caller (length total_n).
+    std::vector<float> row;
+    /// Sequence number of the chunk this row was drawn from. Zero if no
+    /// chunk is playing (the caller is receiving a hold-last-action vector).
+    uint64_t chunk_seq{0};
+    /// Row index within the chunk, clamped to [0, T-1]. -1 when no chunk.
+    int t_idx{-1};
+    /// Chunk depth. Zero when no chunk.
+    int T{0};
+    /// True when @c t_idx was clamped because the chunk has exhausted and
+    /// no pending successor is available (slot is saturating at row T-1).
+    bool saturated{false};
+    /// True when the boundary cross-fade is still mixing the outgoing
+    /// chunk's last row into the new chunk's row at this sample instant.
+    bool blend_active{false};
+  };
+
+  /**
+   * @brief Same playback contract as ``sample`` but returns diagnostics.
+   *
+   * Used by ``PolicyClient::Face::read`` for per-tick action logging so a
+   * post-run analysis can identify chunk boundaries, exhaust-and-hold
+   * windows, and cross-fade transitions in the actual command stream sent
+   * to the followers.
+   */
+  [[nodiscard]] SampleInfo sample_with_info(
+    std::chrono::steady_clock::time_point now,
+    int total_n,
+    double control_rate_hz) const noexcept {
+    SampleInfo info;
+    try {
+      std::lock_guard<std::mutex> lk(mu_);
+
+      if (!latest_ || latest_->T <= 0 || latest_->N <= 0 ||
+          control_rate_hz <= 0.0 || latest_->N != total_n) {
+        info.row = hold_last_locked_(total_n);
+        return info;
+      }
+
+      auto t_idx_for = [&](std::chrono::steady_clock::time_point start) {
+        const double dt_s =
+          std::chrono::duration<double>(now - start).count();
+        return static_cast<int64_t>(std::floor(dt_s * control_rate_hz));
+      };
+
+      int64_t t_idx = t_idx_for(playback_start_);
+
+      if (t_idx >= latest_->T && pending_) {
+        stage_blend_locked_(pending_->N, now);
+        latest_ = std::move(pending_);
+        pending_.reset();
+        playback_start_ = now;
+        t_idx = 0;
+        // See sample(): a promoted successor of the wrong width must not reach
+        // the followers — hold the last commanded row instead.
+        if (latest_->N != total_n) {
+          info.row = hold_last_locked_(total_n);
+          return info;
+        }
+      }
+      if (t_idx < 0) t_idx = 0;
+      const bool saturated_local = (t_idx >= latest_->T);
+      if (saturated_local) t_idx = latest_->T - 1;
+
+      std::vector<float> row = latest_->row(static_cast<int>(t_idx));
+
+      bool blend_active_local = false;
+      if (!blend_from_.empty() && blend_from_.size() == row.size()) {
+        const double dt =
+          std::chrono::duration<double>(now - blend_start_).count();
+        if (dt < boundary_blend_s_) {
+          const double alpha = dt / boundary_blend_s_;
+          const double one_minus = 1.0 - alpha;
+          for (std::size_t i = 0; i < row.size(); ++i) {
+            if (is_blend_skip_locked_(static_cast<int>(i))) continue;
+            row[i] = static_cast<float>(
+              one_minus * static_cast<double>(blend_from_[i]) +
+              alpha * static_cast<double>(row[i]));
+          }
+          blend_active_local = true;
+        } else {
+          blend_from_.clear();
+        }
+      }
+
+      last_cmd_ = row;
+      info.row = std::move(row);
+      info.chunk_seq = latest_->chunk_seq;
+      info.t_idx = static_cast<int>(t_idx);
+      info.T = latest_->T;
+      info.saturated = saturated_local;
+      info.blend_active = blend_active_local;
+      return info;
+    } catch (...) {
+      const std::size_t n =
+        total_n > 0 ? static_cast<std::size_t>(total_n) : std::size_t{1};
+      info.row.assign(n, 0.0f);
+      return info;
+    }
+  }
+
+  /**
+   * @brief Snapshot the currently-playing chunk pointer (test/diagnostic).
+   *
+   * Returns latest_ — the chunk whose rows sample() is currently serving. A
+   * pending successor (if any) is not visible through this accessor.
+   */
+  [[nodiscard]] std::shared_ptr<const ActionChunk> peek() const noexcept {
+    try {
+      std::lock_guard<std::mutex> lk(mu_);
+      return latest_;
+    } catch (...) {
+      return nullptr;
+    }
+  }
+
+  /**
+   * @brief Expected wall-clock time at which the currently-playing chunk
+   *        will exhaust (its last row's tick boundary passes).
+   *
+   * Used by the policy inference loop to time observation packing against
+   * chunk consumption rather than wall-clock — matching openpi's
+   * synchronous "request new chunk when the previous one is consumed"
+   * semantics. Without this, the SDK packs observations mid-chunk and the
+   * policy returns chunks whose row 0 is computed for an earlier arm
+   * position than what's actually executing when row 0 plays, producing
+   * visible backward corrections at every chunk boundary.
+   *
+   * @param control_rate_hz Row-sampling rate the inference loop will use.
+   * @return Time point of expected exhaustion, or a default-constructed
+   *         time point (epoch zero) when no chunk is playing or
+   *         @p control_rate_hz is invalid.
+   */
+  [[nodiscard]] std::chrono::steady_clock::time_point exhaustion_time(
+      double control_rate_hz) const noexcept {
+    try {
+      std::lock_guard<std::mutex> lk(mu_);
+      if (!latest_ || latest_->T <= 0 || control_rate_hz <= 0.0) {
+        return {};
+      }
+      const double duration_s =
+        static_cast<double>(latest_->T) / control_rate_hz;
+      return playback_start_ + std::chrono::nanoseconds(
+        static_cast<int64_t>(duration_s * 1e9));
+    } catch (...) {
+      return {};
+    }
+  }
+
+ private:
+  // Requires mu_ held. Linear scan is fine — the skip list is at most a
+  // handful of indices (one gripper per arm), so a sorted-vector + binary
+  // search would only add code complexity without measurable benefit.
+  bool is_blend_skip_locked_(int idx) const {
+    for (int v : boundary_blend_skip_indices_) {
+      if (v == idx) return true;
+    }
+    return false;
+  }
+
+  // Requires mu_ held. Stage (or clear) a boundary cross-fade from the last
+  // commanded row. The blend is staged only when a window is configured and
+  // the last commanded row matches the incoming chunk's width; otherwise any
+  // pending blend is cleared. @p origin is the instant the blend starts —
+  // take-over time for swap_in_aligned, sample time for an in-sample promotion.
+  void stage_blend_locked_(
+      int new_n, std::chrono::steady_clock::time_point origin) const {
+    if (boundary_blend_s_ > 0.0 &&
+        last_cmd_.size() == static_cast<std::size_t>(new_n)) {
+      blend_from_ = last_cmd_;
+      blend_start_ = origin;
+    } else {
+      blend_from_.clear();
+    }
+  }
+
+  // Requires mu_ held. Returns last_cmd_ resized to total_n if needed.
+  std::vector<float> hold_last_locked_(int total_n) const {
+    const std::size_t n =
+      total_n > 0 ? static_cast<std::size_t>(total_n) : std::size_t{1};
+    if (last_cmd_.size() != n) {
+      last_cmd_.assign(n, 0.0f);
+    }
+    return last_cmd_;
+  }
+
+  mutable std::mutex mu_;
+  mutable std::shared_ptr<const ActionChunk> latest_;
+  mutable std::shared_ptr<const ActionChunk> pending_;
+  mutable std::chrono::steady_clock::time_point playback_start_{};
+  mutable std::vector<float> last_cmd_;
+
+  // Cross-fade state. blend_from_ is populated at promotion and cleared once
+  // the window elapses (or by swap_in(nullptr)). All accessed under mu_.
+  double boundary_blend_s_{0.0};
+  mutable std::vector<float> blend_from_;
+  mutable std::chrono::steady_clock::time_point blend_start_{};
+  /// Column indices that skip the boundary blend (gripper channels). Empty
+  /// by default, meaning the blend covers every channel.
+  std::vector<int> boundary_blend_skip_indices_;
+};
+
+}  // namespace trossen::hw::policy
+
+#endif  // TROSSEN_SDK__HW__POLICY__ACTION_CHUNK_HPP

--- a/include/trossen_sdk/hw/policy/observation.hpp
+++ b/include/trossen_sdk/hw/policy/observation.hpp
@@ -1,0 +1,67 @@
+/**
+ * @file observation.hpp
+ * @brief Neutral, transport-agnostic observation passed from PolicyClient to
+ *        any PolicyTransport.
+ *
+ * The client packs this typed struct once per inference cycle; each transport
+ * owns the translation to its wire format end-to-end (openpi: msgpack-numpy
+ * JSON with its BGR training quirk applied internally; LeRobot: pickled
+ * TimedObservation). Keeping the struct wire-neutral is what lets one client
+ * drive both families.
+ */
+
+#ifndef TROSSEN_SDK__HW__POLICY__OBSERVATION_HPP_
+#define TROSSEN_SDK__HW__POLICY__OBSERVATION_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trossen::hw::policy {
+
+/**
+ * @brief One observation snapshot: joint state groups + camera images + task.
+ *
+ * Field contracts (what transports may rely on):
+ * - ``state`` carries one group per configured ``joint_layout`` entry, in
+ *   layout order. Grouping and per-joint names are preserved because they are
+ *   lossy to flatten: openpi concatenates values in order; LeRobot maps
+ *   ``joint_names`` through its rename map to per-motor keys.
+ * - ``images`` are HWC uint8, TRUE RGB always. A model trained on a different
+ *   channel order (openpi's BGR quirk) gets its swap inside that transport,
+ *   never here.
+ * - ``must_go`` marks a starvation send (client's action buffer is empty):
+ *   transports with queue semantics (LeRobot) forward it; request/reply
+ *   transports ignore it.
+ * - ``timestep`` is stamped from the client-owned timestep clock and pairs
+ *   with ``ActionChunk``/``DecodedActions::base_timestep`` on the return path.
+ */
+struct Observation
+{
+  struct StateGroup
+  {
+    std::string name;                       ///< joint_layout group name (e.g. "left")
+    std::vector<float> values;              ///< joint positions, group order
+    std::vector<std::string> joint_names;   ///< same length/order as values
+  };
+
+  struct Image
+  {
+    std::string camera;          ///< camera key (config subscription suffix)
+    int width{0};
+    int height{0};
+    std::vector<uint8_t> rgb;    ///< HWC uint8, size == width * height * 3
+  };
+
+  std::vector<StateGroup> state;
+  std::vector<Image> images;
+  std::string task;              ///< natural-language instruction
+  bool must_go{false};
+  int64_t timestep{0};
+  std::chrono::steady_clock::time_point captured_at{};  ///< epoch == never set
+};
+
+}  // namespace trossen::hw::policy
+
+#endif  // TROSSEN_SDK__HW__POLICY__OBSERVATION_HPP_

--- a/include/trossen_sdk/hw/policy/observation.hpp
+++ b/include/trossen_sdk/hw/policy/observation.hpp
@@ -58,6 +58,9 @@ struct Observation
   std::vector<Image> images;
   std::string task;              ///< natural-language instruction
   bool must_go{false};
+  /// Client-owned timestep clock tick; the packer always stamps it. 0 is a
+  /// legitimate first-tick value, NOT an "unset" sentinel — do not treat 0 as
+  /// missing. captured_at == epoch is the only "never populated" signal.
   int64_t timestep{0};
   std::chrono::steady_clock::time_point captured_at{};  ///< epoch == never set
 };

--- a/include/trossen_sdk/hw/policy/transport_status.hpp
+++ b/include/trossen_sdk/hw/policy/transport_status.hpp
@@ -1,0 +1,41 @@
+/**
+ * @file transport_status.hpp
+ * @brief Health summary a PolicyTransport exposes to the polling client.
+ *
+ * The transport hot path (push_observation / try_poll_chunk) is noexcept and
+ * non-blocking, so failures cannot surface as exceptions there. Instead the
+ * transport keeps this summary current and the client polls status() once per
+ * inference cycle, logging state TRANSITIONS only (warn-once style).
+ */
+
+#ifndef TROSSEN_SDK__HW__POLICY__TRANSPORT_STATUS_HPP_
+#define TROSSEN_SDK__HW__POLICY__TRANSPORT_STATUS_HPP_
+
+#include <cstdint>
+#include <string>
+
+namespace trossen::hw::policy {
+
+struct TransportStatus
+{
+  enum class State
+  {
+    kConnected,      ///< healthy; pushes/polls are being serviced
+    kReconnecting,   ///< self-healing (e.g. gRPC channel backoff); pushes drop
+    kDisconnected,   ///< gone for good until the owner reconnects/restarts
+  };
+
+  State state{State::kDisconnected};
+
+  /// Monotonic over the transport's lifetime, NEVER reset: a polling client
+  /// computes failures-in-window as (now - last_sampled), which a resettable
+  /// counter would corrupt (lost updates between samples).
+  uint64_t failure_count{0};
+
+  /// Empty when healthy; otherwise the most recent failure, for log readers.
+  std::string last_error;
+};
+
+}  // namespace trossen::hw::policy
+
+#endif  // TROSSEN_SDK__HW__POLICY__TRANSPORT_STATUS_HPP_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,11 @@ endif()
 add_executable(test_policy_client_config test_policy_client_config.cpp)
 target_link_libraries(test_policy_client_config PRIVATE trossen_sdk GTest::gtest_main)
 
+# Neutral types (Observation / ActionChunk / ChunkSlot / TransportStatus) are
+# header-only, so the chunk-slot test is ungated too.
+add_executable(test_action_chunk test_action_chunk.cpp)
+target_link_libraries(test_action_chunk PRIVATE trossen_sdk GTest::gtest_main)
+
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -140,3 +145,4 @@ if(TROSSEN_ENABLE_RERUN_OBSERVER)
   gtest_discover_tests(test_rerun_observer)
 endif()
 gtest_discover_tests(test_policy_client_config)
+gtest_discover_tests(test_action_chunk)

--- a/tests/test_action_chunk.cpp
+++ b/tests/test_action_chunk.cpp
@@ -448,7 +448,7 @@ TEST(ChunkSlotTest, BoundaryBlendSkipsConfiguredGripperIndices) {
   EXPECT_FLOAT_EQ(r_post[3], 0.99f);
 }
 
-// ── Aligned take-over (L5) ──────────────────────────────────────────────────
+// ── Aligned take-over ──────────────────────────────────────────────────────
 
 TEST(ChunkSlotTest, AlignedTakeOverSkipsPastRows) {
   // make_chunk sets row t, col 0 = base + t. Anchor row 0 at 0.3 s in the past

--- a/tests/test_action_chunk.cpp
+++ b/tests/test_action_chunk.cpp
@@ -1,0 +1,402 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "trossen_sdk/hw/policy/action_chunk.hpp"
+
+namespace {
+
+using trossen::hw::policy::ActionChunk;
+using trossen::hw::policy::ChunkSlot;
+using Clock = std::chrono::steady_clock;
+
+std::shared_ptr<ActionChunk> make_chunk(
+  int T, int N, Clock::time_point received_at, uint64_t seq = 0,
+  float base = 0.0f) {
+  auto c = std::make_shared<ActionChunk>();
+  c->T = T;
+  c->N = N;
+  c->chunk_seq = seq;
+  c->received_at = received_at;
+  c->data.resize(static_cast<std::size_t>(T) * static_cast<std::size_t>(N));
+  for (int t = 0; t < T; ++t) {
+    for (int n = 0; n < N; ++n) {
+      c->data[static_cast<std::size_t>(t) * N + n] =
+        base + static_cast<float>(t) + 0.01f * static_cast<float>(n);
+    }
+  }
+  return c;
+}
+
+TEST(ActionChunkTest, RowReturnsCorrectSlice) {
+  auto c = make_chunk(3, 4, Clock::now());
+  auto r0 = c->row(0);
+  auto r2 = c->row(2);
+  ASSERT_EQ(r0.size(), 4u);
+  EXPECT_FLOAT_EQ(r0[0], 0.0f);
+  EXPECT_FLOAT_EQ(r0[3], 0.03f);
+  EXPECT_FLOAT_EQ(r2[0], 2.0f);
+  EXPECT_FLOAT_EQ(r2[3], 2.03f);
+}
+
+TEST(ActionChunkTest, RowOutOfRangeThrows) {
+  auto c = make_chunk(3, 4, Clock::now());
+  EXPECT_THROW(c->row(-1), std::out_of_range);
+  EXPECT_THROW(c->row(3), std::out_of_range);
+  EXPECT_THROW(c->row(99), std::out_of_range);
+}
+
+TEST(ChunkSlotTest, HoldLastActionReturnsZerosBeforeAnyChunk) {
+  ChunkSlot slot;
+  auto v = slot.sample(Clock::now(), 6, 30.0);
+  ASSERT_EQ(v.size(), 6u);
+  for (float x : v) {
+    EXPECT_FLOAT_EQ(x, 0.0f);
+  }
+}
+
+TEST(ChunkSlotTest, SampleAtBoundaryT0) {
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 4, t0));
+  auto v = slot.sample(t0, 4, 30.0);
+  ASSERT_EQ(v.size(), 4u);
+  EXPECT_FLOAT_EQ(v[0], 0.0f);
+  EXPECT_FLOAT_EQ(v[3], 0.03f);
+}
+
+TEST(ChunkSlotTest, SampleAtMidChunk) {
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(10, 4, t0));
+  // At 30 Hz, sampling 100 ms into the chunk picks row 3 (floor(0.1*30)=3).
+  auto v = slot.sample(t0 + std::chrono::milliseconds(100), 4, 30.0);
+  EXPECT_FLOAT_EQ(v[0], 3.0f);
+}
+
+TEST(ChunkSlotTest, SampleAtTMinusOne) {
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 4, t0));
+  // At 30 Hz, row T-1=4 starts at ~133 ms.
+  auto v = slot.sample(t0 + std::chrono::milliseconds(140), 4, 30.0);
+  EXPECT_FLOAT_EQ(v[0], 4.0f);
+}
+
+TEST(ChunkSlotTest, SampleBeyondTClampsToLastRow) {
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 4, t0));
+  auto v = slot.sample(t0 + std::chrono::seconds(10), 4, 30.0);
+  EXPECT_FLOAT_EQ(v[0], 4.0f);
+  EXPECT_FLOAT_EQ(v[3], 4.03f);
+}
+
+TEST(ChunkSlotTest, SampleBeforeReceivedAtClampsToRowZero) {
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 4, t0));
+  auto v = slot.sample(t0 - std::chrono::milliseconds(50), 4, 30.0);
+  EXPECT_FLOAT_EQ(v[0], 0.0f);
+}
+
+TEST(ChunkSlotTest, MidChunkSwapDefersUntilCurrentExhausted) {
+  // Consume-fully contract: a new chunk arriving mid-playback parks in
+  // pending_ and only takes effect once the current chunk has been fully
+  // sampled.
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(10, 3, t0, /*seq=*/1, /*base=*/0.0f));
+  // Drive sample() so playback_start_ is anchored at t0 (first sample at t0
+  // produces row 0).
+  auto first = slot.sample(t0, 3, 30.0);
+  EXPECT_FLOAT_EQ(first[0], 0.0f);
+
+  // Queue chunk 2 while chunk 1 is still playing. swap_in must NOT replace
+  // the active chunk.
+  slot.swap_in(make_chunk(10, 3, t0, /*seq=*/2, /*base=*/100.0f));
+
+  // Mid-chunk-1 sample still serves chunk 1.
+  auto mid = slot.sample(t0 + std::chrono::milliseconds(100), 3, 30.0);
+  EXPECT_FLOAT_EQ(mid[0], 3.0f);  // floor(0.1*30)=3, base 0
+
+  // Chunk 1 plays rows 0..9 over 10/30 s ≈ 333 ms. Sampling well past that
+  // promotes pending → latest, which restarts at row 0.
+  auto after = slot.sample(t0 + std::chrono::milliseconds(400), 3, 30.0);
+  EXPECT_FLOAT_EQ(after[0], 100.0f);  // base 100, row 0
+}
+
+TEST(ChunkSlotTest, WrongWidthPendingDoesNotLeakToFollowers) {
+  // A successor whose N differs from the configured width must never be served:
+  // on promotion the slot holds the last commanded row instead of emitting a
+  // wrong-length row. (total_n stays 3 throughout.)
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(10, 3, t0, /*seq=*/1, /*base=*/0.0f));
+  auto first = slot.sample(t0, 3, 30.0);
+  ASSERT_EQ(first.size(), 3u);
+
+  // Queue a successor of the wrong width (N=4) while chunk 1 plays.
+  slot.swap_in(make_chunk(10, 4, t0, /*seq=*/2, /*base=*/100.0f));
+
+  // Sampling past chunk 1's exhaustion would promote the bad successor; the
+  // returned row must still be width 3 (hold-last-action), never width 4.
+  auto after = slot.sample(t0 + std::chrono::milliseconds(400), 3, 30.0);
+  EXPECT_EQ(after.size(), 3u);
+  // It is the held last-commanded row from chunk 1, not chunk 2's base 100.
+  EXPECT_NE(after[0], 100.0f);
+
+  // sample_with_info honors the same guard.
+  auto info = slot.sample_with_info(t0 + std::chrono::milliseconds(500), 3, 30.0);
+  EXPECT_EQ(info.row.size(), 3u);
+}
+
+TEST(ChunkSlotTest, PendingPromotionRestartsRowSelection) {
+  // After promotion, row indexing must be relative to the promotion instant —
+  // not the original playback_start_ — so the new chunk starts at row 0 and
+  // advances at control_rate_hz from there.
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 3, t0, /*seq=*/1, /*base=*/0.0f));
+  (void)slot.sample(t0, 3, 30.0);  // anchor playback_start_
+
+  // Queue chunk 2.
+  slot.swap_in(make_chunk(5, 3, t0, /*seq=*/2, /*base=*/50.0f));
+
+  // Chunk 1 spans 5/30 ≈ 167 ms. At 200 ms, promote happens, chunk 2 row 0.
+  const auto promote_at = t0 + std::chrono::milliseconds(200);
+  auto promoted = slot.sample(promote_at, 3, 30.0);
+  EXPECT_FLOAT_EQ(promoted[0], 50.0f);
+
+  // 50 ms after promotion → row 1 of chunk 2.
+  auto next = slot.sample(promote_at + std::chrono::milliseconds(50), 3, 30.0);
+  EXPECT_FLOAT_EQ(next[0], 51.0f);
+}
+
+TEST(ChunkSlotTest, NewerPendingReplacesOlderPending) {
+  // Depth-1 pending slot: when a third chunk arrives before the first is
+  // exhausted, it replaces the second (not the first). The first still plays
+  // to completion, then the third — never the second.
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 3, t0, /*seq=*/1, /*base=*/0.0f));
+  (void)slot.sample(t0, 3, 30.0);
+
+  slot.swap_in(make_chunk(5, 3, t0, /*seq=*/2, /*base=*/200.0f));
+  slot.swap_in(make_chunk(5, 3, t0, /*seq=*/3, /*base=*/300.0f));
+
+  auto after = slot.sample(t0 + std::chrono::milliseconds(400), 3, 30.0);
+  EXPECT_FLOAT_EQ(after[0], 300.0f);  // skipped chunk 2 entirely
+}
+
+TEST(ChunkSlotTest, HoldLastActionAfterNullSwap) {
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 3, t0, /*seq=*/1, /*base=*/7.0f));
+  // Sample mid-chunk to populate last_cmd_.
+  auto sampled = slot.sample(t0 + std::chrono::milliseconds(66), 3, 30.0);
+  // floor(0.066*30) = 1 → row 1 → base+1 = 8.0.
+  EXPECT_FLOAT_EQ(sampled[0], 8.0f);
+
+  // Drop the chunk; subsequent reads must return the cached row, not zeros.
+  slot.swap_in(nullptr);
+  auto held = slot.sample(t0 + std::chrono::milliseconds(500), 3, 30.0);
+  ASSERT_EQ(held.size(), 3u);
+  EXPECT_FLOAT_EQ(held[0], 8.0f);
+  EXPECT_FLOAT_EQ(held[1], 8.01f);
+  EXPECT_FLOAT_EQ(held[2], 8.02f);
+}
+
+TEST(ChunkSlotTest, NMismatchFallsBackToHoldLast) {
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  // Chunk has N=4, caller asks for total_n=3 (config mismatch).
+  slot.swap_in(make_chunk(5, 4, t0));
+  auto v = slot.sample(t0, 3, 30.0);
+  ASSERT_EQ(v.size(), 3u);
+  for (float x : v) {
+    EXPECT_FLOAT_EQ(x, 0.0f);
+  }
+}
+
+TEST(ChunkSlotTest, NonPositiveControlRateFallsBackToHoldLast) {
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 3, t0));
+  auto v = slot.sample(t0, 3, 0.0);
+  ASSERT_EQ(v.size(), 3u);
+  for (float x : v) {
+    EXPECT_FLOAT_EQ(x, 0.0f);
+  }
+}
+
+TEST(ChunkSlotTest, NonPositiveTotalNReturnsSingleZeroNotEmpty) {
+  ChunkSlot slot;
+  auto v_zero = slot.sample(Clock::now(), 0, 30.0);
+  ASSERT_EQ(v_zero.size(), 1u);
+  EXPECT_FLOAT_EQ(v_zero[0], 0.0f);
+
+  auto v_neg = slot.sample(Clock::now(), -4, 30.0);
+  ASSERT_EQ(v_neg.size(), 1u);
+  EXPECT_FLOAT_EQ(v_neg[0], 0.0f);
+}
+
+TEST(ChunkSlotTest, ConcurrentSampleWithSwapIn) {
+  ChunkSlot slot;
+  constexpr int kN = 7;
+  constexpr int kT = 50;
+  constexpr int kReaders = 8;
+  constexpr auto kRunFor = std::chrono::milliseconds(150);
+
+  // Seed with chunk 0 so readers do not just see zeros.
+  slot.swap_in(make_chunk(kT, kN, Clock::now(), /*seq=*/0, /*base=*/0.0f));
+
+  std::atomic<bool> stop{false};
+  std::atomic<uint64_t> reads{0};
+  std::vector<std::thread> readers;
+  readers.reserve(kReaders);
+  for (int i = 0; i < kReaders; ++i) {
+    readers.emplace_back([&]() {
+      while (!stop.load(std::memory_order_relaxed)) {
+        auto v = slot.sample(Clock::now(), kN, 30.0);
+        ASSERT_EQ(v.size(), static_cast<std::size_t>(kN));
+        reads.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+  }
+
+  std::thread writer([&]() {
+    uint64_t seq = 1;
+    while (!stop.load(std::memory_order_relaxed)) {
+      slot.swap_in(make_chunk(kT, kN, Clock::now(), seq, static_cast<float>(seq)));
+      ++seq;
+      std::this_thread::sleep_for(std::chrono::microseconds(200));
+    }
+  });
+
+  std::this_thread::sleep_for(kRunFor);
+  stop.store(true, std::memory_order_relaxed);
+  writer.join();
+  for (auto& t : readers) {
+    t.join();
+  }
+
+  EXPECT_GT(reads.load(), 0u);
+}
+
+TEST(ChunkSlotTest, BoundaryBlendSkipsConfiguredGripperIndices) {
+  // The gripper open/close is a fast transient; blending it across the
+  // chunk-boundary window dampens the command and produces incomplete
+  // grasps. Skip indices configured via set_boundary_blend_skip_indices
+  // must jump to the new chunk's row value at the boundary while arm
+  // joints continue to blend.
+  ChunkSlot slot;
+  // 50 ms blend window so each-tick alpha is well-defined.
+  slot.set_boundary_blend_s(0.05);
+  // 4-channel chunks. Treat index 3 as the "gripper" → must skip the blend.
+  slot.set_boundary_blend_skip_indices({3});
+
+  // Seed chunk N with all rows = [0, 0, 0, 0].
+  const auto t0 = Clock::now();
+  auto chunkN = std::make_shared<ActionChunk>();
+  chunkN->T = 2;
+  chunkN->N = 4;
+  chunkN->chunk_seq = 1;
+  chunkN->received_at = t0;
+  chunkN->data = {0.0f, 0.0f, 0.0f, 0.0f,
+                  0.0f, 0.0f, 0.0f, 0.0f};
+  slot.swap_in(chunkN);
+
+  // Consume chunk N to advance last_cmd_ to its row[T-1] = [0,0,0,0], then
+  // queue chunk N+1 with row[0] = [10, 20, 30, 0.99] — the last channel is
+  // the "gripper open" value we want preserved.
+  (void)slot.sample(t0, 4, 30.0);          // row 0 of chunk N
+  (void)slot.sample(
+    t0 + std::chrono::milliseconds(35), 4, 30.0);  // row 1 (T-1) of chunk N
+  // chunk N is now exhausted. Stage chunk N+1.
+  auto chunkN1 = std::make_shared<ActionChunk>();
+  chunkN1->T = 2;
+  chunkN1->N = 4;
+  chunkN1->chunk_seq = 2;
+  chunkN1->received_at = t0 + std::chrono::milliseconds(70);
+  chunkN1->data = {10.0f, 20.0f, 30.0f, 0.99f,
+                   10.0f, 20.0f, 30.0f, 0.99f};
+  slot.swap_in(chunkN1);
+
+  // Sample at the moment of promotion (alpha ≈ 0). Arm joints should sit
+  // near 0 (blend toward old [0]); gripper should be 0.99 (bypass).
+  const auto t_promote = t0 + std::chrono::milliseconds(100);
+  auto r0 = slot.sample(t_promote, 4, 30.0);
+  EXPECT_NEAR(r0[0], 0.0f, 1e-3) << "arm joint should be near old=0 at alpha=0";
+  EXPECT_NEAR(r0[1], 0.0f, 1e-3);
+  EXPECT_NEAR(r0[2], 0.0f, 1e-3);
+  EXPECT_FLOAT_EQ(r0[3], 0.99f) << "gripper must bypass blend";
+
+  // Sample halfway through the 50 ms blend window. Arm joints at ~50% of
+  // the new row; gripper still 0.99 (skip).
+  auto r_mid = slot.sample(
+    t_promote + std::chrono::milliseconds(25), 4, 30.0);
+  EXPECT_NEAR(r_mid[0], 5.0f, 0.5f);
+  EXPECT_NEAR(r_mid[1], 10.0f, 0.5f);
+  EXPECT_NEAR(r_mid[2], 15.0f, 0.5f);
+  EXPECT_FLOAT_EQ(r_mid[3], 0.99f);
+
+  // Sample after the blend window closes. All channels at full new value.
+  auto r_post = slot.sample(
+    t_promote + std::chrono::milliseconds(60), 4, 30.0);
+  EXPECT_FLOAT_EQ(r_post[0], 10.0f);
+  EXPECT_FLOAT_EQ(r_post[1], 20.0f);
+  EXPECT_FLOAT_EQ(r_post[2], 30.0f);
+  EXPECT_FLOAT_EQ(r_post[3], 0.99f);
+}
+
+// ── Aligned take-over (L5) ──────────────────────────────────────────────────
+
+TEST(ChunkSlotTest, AlignedTakeOverSkipsPastRows) {
+  // make_chunk sets row t, col 0 = base + t. Anchor row 0 at 0.3 s in the past
+  // at 10 Hz, so "now" is 3 rows in: sample must return row 3, not row 0.
+  ChunkSlot slot;
+  const auto now = Clock::now();
+  auto c = make_chunk(/*T=*/10, /*N=*/1, now, /*seq=*/1, /*base=*/0.0f);
+  const auto anchor = now - std::chrono::milliseconds(300);
+  slot.swap_in_aligned(c, anchor, now);
+
+  auto row = slot.sample(now, 1, 10.0);
+  ASSERT_EQ(row.size(), 1u);
+  EXPECT_FLOAT_EQ(row[0], 3.0f);
+}
+
+TEST(ChunkSlotTest, AlignedTakeOverReplacesCurrentChunkImmediately) {
+  // Unlike consume-fully swap_in (which parks the successor in pending_),
+  // swap_in_aligned must replace the playing chunk at once.
+  ChunkSlot slot;
+  const auto now = Clock::now();
+  auto a = make_chunk(10, 1, now, /*seq=*/1, /*base=*/0.0f);
+  slot.swap_in(a);  // A becomes latest_, playing from row 0
+
+  auto b = make_chunk(10, 1, now, /*seq=*/2, /*base=*/100.0f);
+  slot.swap_in_aligned(b, now, now);  // B anchored at "now" → its row 0
+
+  EXPECT_EQ(slot.peek()->chunk_seq, 2u);          // B is playing, not A
+  auto row = slot.sample(now, 1, 10.0);
+  EXPECT_FLOAT_EQ(row[0], 100.0f);                // B's row 0 value
+}
+
+TEST(ChunkSlotTest, AlignedFarPastAnchorClampsToLastRow) {
+  // An anchor far in the past drives the row index past T-1; sample clamps to
+  // the last row. (PolicyClient avoids serving such a chunk by discarding it
+  // when start_row >= T; this documents the slot's own clamp behavior.)
+  ChunkSlot slot;
+  const auto now = Clock::now();
+  auto c = make_chunk(5, 1, now, /*seq=*/1, /*base=*/0.0f);
+  slot.swap_in_aligned(c, now - std::chrono::seconds(100), now);
+
+  auto row = slot.sample(now, 1, 10.0);
+  EXPECT_FLOAT_EQ(row[0], 4.0f);  // last row (T-1 == 4)
+}
+
+}  // namespace

--- a/tests/test_action_chunk.cpp
+++ b/tests/test_action_chunk.cpp
@@ -50,6 +50,18 @@ TEST(ActionChunkTest, RowOutOfRangeThrows) {
   EXPECT_THROW(c->row(99), std::out_of_range);
 }
 
+TEST(ActionChunkTest, RowShortDataThrows) {
+  // A malformed server chunk advertises T=3, N=4 but ships too few floats.
+  // row() must reject the in-range index rather than slice past data.end().
+  auto c = std::make_shared<ActionChunk>();
+  c->T = 3;
+  c->N = 4;
+  c->data.resize(4);  // only room for row 0; row 1+ would run off the end
+  EXPECT_NO_THROW(c->row(0));
+  EXPECT_THROW(c->row(1), std::out_of_range);
+  EXPECT_THROW(c->row(2), std::out_of_range);
+}
+
 TEST(ChunkSlotTest, HoldLastActionReturnsZerosBeforeAnyChunk) {
   ChunkSlot slot;
   auto v = slot.sample(Clock::now(), 6, 30.0);
@@ -155,6 +167,82 @@ TEST(ChunkSlotTest, WrongWidthPendingDoesNotLeakToFollowers) {
   EXPECT_EQ(info.row.size(), 3u);
 }
 
+TEST(ChunkSlotTest, WrongWidthLatestSelfHealsToSuccessor) {
+  // A wrong-width chunk that reaches latest_ must not permanently wedge the
+  // slot in hold-last: once a correct-width successor is queued, the slot
+  // discards the bad latest_, promotes the successor, and resumes playing.
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 3, t0, /*seq=*/1, /*base=*/0.0f));
+  (void)slot.sample(t0, 3, 30.0);  // anchor, chunk 1 row 0
+
+  // Wrong-width successor parks in pending_ and is promoted to latest_ when
+  // chunk 1 exhausts (~167 ms); the promotion holds last (width stays 3).
+  slot.swap_in(make_chunk(5, 4, t0, /*seq=*/2, /*base=*/100.0f));
+  auto held = slot.sample(t0 + std::chrono::milliseconds(400), 3, 30.0);
+  ASSERT_EQ(held.size(), 3u);
+  EXPECT_NE(held[0], 100.0f);  // never emitted the wrong-width row
+
+  // A correct-width chunk now arrives and parks behind the wrong-width latest_.
+  slot.swap_in(make_chunk(5, 3, t0, /*seq=*/3, /*base=*/300.0f));
+
+  // The next sample discards the unplayable latest_ and promotes the good
+  // successor (holding last for this one tick)...
+  const auto heal_at = t0 + std::chrono::milliseconds(500);
+  auto healing = slot.sample(heal_at, 3, 30.0);
+  ASSERT_EQ(healing.size(), 3u);
+
+  // ...and the following sample plays the recovered chunk's row 0: recovery.
+  auto recovered = slot.sample(heal_at + std::chrono::milliseconds(1), 3, 30.0);
+  ASSERT_EQ(recovered.size(), 3u);
+  EXPECT_FLOAT_EQ(recovered[0], 300.0f);
+}
+
+TEST(ChunkSlotTest, FirstChunkWrongWidthSelfHeals) {
+  // When the very first chunk is the wrong width it becomes latest_ directly.
+  // The slot must discard it (not wedge) so a later correct chunk can play.
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  slot.swap_in(make_chunk(5, 4, t0, /*seq=*/1, /*base=*/9.0f));  // wrong width
+
+  // Sampling holds last (zeros at width 3) and discards the unplayable latest_.
+  auto held = slot.sample(t0, 3, 30.0);
+  ASSERT_EQ(held.size(), 3u);
+  EXPECT_FLOAT_EQ(held[0], 0.0f);
+
+  // A correct-width chunk now installs cleanly and plays from row 0.
+  const auto t1 = t0 + std::chrono::milliseconds(10);
+  slot.swap_in(make_chunk(5, 3, t1, /*seq=*/2, /*base=*/50.0f));
+  auto row = slot.sample(t1, 3, 30.0);
+  ASSERT_EQ(row.size(), 3u);
+  EXPECT_FLOAT_EQ(row[0], 50.0f);
+}
+
+TEST(ChunkSlotTest, MalformedChunkDataSampleHoldsLast) {
+  // A chunk that advertises T*N floats but ships fewer must be treated as
+  // unplayable by the sample family — hold-last, never crash on the short
+  // slice through row().
+  ChunkSlot slot;
+  const auto t0 = Clock::now();
+  auto bad = std::make_shared<ActionChunk>();
+  bad->T = 5;
+  bad->N = 3;
+  bad->chunk_seq = 1;
+  bad->received_at = t0;
+  bad->data.resize(3);  // only row 0's worth; advertises 15
+  slot.swap_in(bad);
+
+  auto v = slot.sample(t0 + std::chrono::milliseconds(100), 3, 30.0);
+  ASSERT_EQ(v.size(), 3u);
+  for (float x : v) {
+    EXPECT_FLOAT_EQ(x, 0.0f);  // hold-last with no prior command → zeros
+  }
+
+  // sample_with_info honors the same guard.
+  auto info = slot.sample_with_info(t0 + std::chrono::milliseconds(150), 3, 30.0);
+  EXPECT_EQ(info.row.size(), 3u);
+}
+
 TEST(ChunkSlotTest, PendingPromotionRestartsRowSelection) {
   // After promotion, row indexing must be relative to the promotion instant —
   // not the original playback_start_ — so the new chunk starts at row 0 and
@@ -246,6 +334,12 @@ TEST(ChunkSlotTest, NonPositiveTotalNReturnsSingleZeroNotEmpty) {
 }
 
 TEST(ChunkSlotTest, ConcurrentSampleWithSwapIn) {
+  // This is a 1-sampler / 1-writer stress test, NOT multi-sampler: the
+  // ChunkSlot single-consumer contract allows exactly one thread in the sample
+  // family concurrently with swap_in. The kReaders threads below all call the
+  // SAME slot but the assertion only checks race-freedom (no crash, correct row
+  // width) — not playback correctness under concurrent samplers, which is
+  // logically undefined by contract.
   ChunkSlot slot;
   constexpr int kN = 7;
   constexpr int kT = 50;


### PR DESCRIPTION
## Summary

Adds the **wire-neutral vocabulary** shared by every transport and by the playback path: `Observation`, `ActionChunk` + its `ChunkSlot`, and `TransportStatus`. Keeping these types transport-agnostic is what lets one client drive both openpi and LeRobot. All header-only.

> **Stack:** PolicyClient stack, based on #248. Review bottom-up (#249 → here).

## Changes

- In `include/trossen_sdk/hw/policy/observation.hpp`: neutral `Observation` — joint-state groups (with `joint_names`), true-RGB HWC images, task string, `must_go` starvation flag, and a `timestep`. Each transport owns the translation to its own wire format; channel quirks (e.g. openpi's BGR) never leak here.
- In `include/trossen_sdk/hw/policy/action_chunk.hpp`: `ActionChunk` (`[T x N]` row-major) plus `ChunkSlot` — the thread-safe playback holder implementing the consume-fully contract (depth-1 `pending_`, aligned take-over for the drain-threshold path, optional boundary cross-fade with gripper-skip, and hold-last-action on any fault).
- In `include/trossen_sdk/hw/policy/transport_status.hpp`: `TransportStatus` health summary (state + `failure_count` + `last_error`) the client polls once per cycle.
- In `tests/test_action_chunk.cpp` + `tests/CMakeLists.txt`: `ChunkSlot` playback/promotion/hold-last-action coverage (header-only, ungated).

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass — `test_action_chunk`
- [x] Lint passes (`pre-commit run --all-files`)
- [ ] Hardware — N/A (header-only types; exercised end-to-end by #255)

## Breaking Changes

None. New headers only.

## Related

Based on #248. Stacked on #249; followed by #251–#255.
