### PR TITLE
policy_client: PolicyClient bridge, Face adapters, inference loop

### DIFF
--- a/cmake/policy_client.cmake
+++ b/cmake/policy_client.cmake
@@ -82,6 +82,7 @@ target_sources(trossen_sdk PRIVATE
   src/hw/policy/lerobot_grpc_transport.cpp
   src/hw/policy/msgpack_ndarray.cpp
   src/hw/policy/openpi_websocket_transport.cpp
+  src/hw/policy/policy_client.cpp
   src/hw/policy/transport_registry.cpp
   ${_lerobot_proto_out}/lerobot_transport_services.pb.cc
   ${_lerobot_proto_out}/lerobot_transport_services.grpc.pb.cc

--- a/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
@@ -302,6 +302,17 @@ struct PolicyClientConfig {
   /// (one-shot). Default 200 ms is ~6 camera periods at 30 Hz throttling.
   double freshness_timeout_ms{200.0};
 
+  /// Maximum time (ms) the inference loop will wait for a reply chunk after
+  /// pushing an observation before abandoning that round-trip. A half-open
+  /// server that stays ``kConnected`` but never returns a chunk would
+  /// otherwise stall the loop forever with no new observations sent. On the
+  /// deadline the loop stops polling this request, logs the elapsed time, and
+  /// proceeds to the next cycle (which re-packs and re-pushes a fresh
+  /// observation — latest-wins supersedes the abandoned one). 0 disables the
+  /// deadline (unbounded wait). Default 15 s is well beyond normal inference
+  /// (~1-2 s) and typical cold starts, so it only trips on a genuine stall.
+  double inference_timeout_ms{15000.0};
+
   /// First-order EMA coefficient applied to each Face's per-tick output:
   /// ``out_t = alpha * chunk_row_t + (1-alpha) * out_{t-1}``. Acts as a low-pass
   /// filter on the action stream sent to the followers - masks per-row
@@ -472,6 +483,22 @@ struct PolicyClientConfig {
       if (!(c.freshness_timeout_ms >= 0.0 && c.freshness_timeout_ms <= 10000.0)) {
         throw std::runtime_error(
           "PolicyClientConfig: 'freshness_timeout_ms' must be within [0, 10000] "
+          "for policy_client '" + c.id + "'");
+      }
+    }
+
+    if (j.contains("inference_timeout_ms")) {
+      if (!j.at("inference_timeout_ms").is_number()) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'inference_timeout_ms' must be a number for "
+          "policy_client '" + c.id + "'");
+      }
+      j.at("inference_timeout_ms").get_to(c.inference_timeout_ms);
+      // [0, 600000]: 0 disables the deadline; 10 min is a generous ceiling.
+      // Negated bounded comparison also rejects NaN.
+      if (!(c.inference_timeout_ms >= 0.0 && c.inference_timeout_ms <= 600000.0)) {
+        throw std::runtime_error(
+          "PolicyClientConfig: 'inference_timeout_ms' must be within [0, 600000] "
           "for policy_client '" + c.id + "'");
       }
     }

--- a/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/policy_client_config.hpp
@@ -308,7 +308,7 @@ struct PolicyClientConfig {
   /// otherwise stall the loop forever with no new observations sent. On the
   /// deadline the loop stops polling this request, logs the elapsed time, and
   /// proceeds to the next cycle (which re-packs and re-pushes a fresh
-  /// observation — latest-wins supersedes the abandoned one). 0 disables the
+  /// observation - latest-wins supersedes the abandoned one). 0 disables the
   /// deadline (unbounded wait). Default 15 s is well beyond normal inference
   /// (~1-2 s) and typical cold starts, so it only trips on a genuine stall.
   double inference_timeout_ms{15000.0};

--- a/include/trossen_sdk/hw/active_hardware_registry.hpp
+++ b/include/trossen_sdk/hw/active_hardware_registry.hpp
@@ -82,6 +82,14 @@ public:
   static bool is_registered(const std::string& id);
 
   /**
+   * @brief Remove a single hardware component from the registry.
+   *
+   * @param id Hardware component identifier
+   * @return true if @p id was registered and has been removed; false if no such id.
+   */
+  static bool unregister(const std::string& id);
+
+  /**
    * @brief Clear all active hardware components
    *
    * @note Should be called during application shutdown or when

--- a/include/trossen_sdk/hw/policy/openpi_websocket_transport.hpp
+++ b/include/trossen_sdk/hw/policy/openpi_websocket_transport.hpp
@@ -44,7 +44,7 @@ namespace trossen::hw::policy {
  * ``failure_count`` and (matching the previous die-on-disconnect behavior)
  * the transport reports kDisconnected until close()/connect() cycles it.
  *
- * Wire protocol (see ADR-004 §5.1):
+ * Wire protocol:
  *  - On connect, the server immediately pushes one msgpack-encoded
  *    ``server_metadata`` dict that ``connect()`` recv's once and stores.
  *  - Each request sends ``msgpack(obs_json)`` as one binary frame and blocks

--- a/include/trossen_sdk/hw/policy/policy_client.hpp
+++ b/include/trossen_sdk/hw/policy/policy_client.hpp
@@ -213,7 +213,7 @@ private:
   /// at entry, or until ``cfg_.freshness_timeout_ms`` elapses. Guarantees that
   /// every record in the next observation snapshot was produced after this
   /// call began — and therefore within one producer period of every other
-  /// record in the snapshot. Subsumes the legacy first-arrival prime: at
+  /// record in the snapshot. At
   /// startup/resume the baseline counters are zero, so the wait reduces to
   /// "every subscription has delivered at least once". On timeout, logs the
   /// stale record_ids (one-shot) and returns; the caller proceeds with the

--- a/include/trossen_sdk/hw/policy/policy_client.hpp
+++ b/include/trossen_sdk/hw/policy/policy_client.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "nlohmann/json.hpp"
@@ -70,8 +71,8 @@ struct ObservationDiagnostics {
  * ``cache_mu_``; handlers never block on the network.
  *
  * Failure mode: server stalls or exceptions keep the inference thread alive and
- * leave the previous chunk in place; ``Face::read()`` returns the last commanded
- * row indefinitely (see ADR-004 hold-last-action).
+ * leave the previous chunk in place; ``Face::read()`` holds the last commanded
+ * row indefinitely rather than emitting a fresh command (hold-last-action).
  */
 class PolicyClient
   : public hw::HardwareComponent,
@@ -79,6 +80,17 @@ class PolicyClient
 public:
   class Face;
 
+private:
+  /// State shared between a ``PolicyClient`` and the ``Face`` adapters it owns.
+  /// Held by ``shared_ptr`` so a Face that outlives its client — a
+  /// ``TeleopController`` retains its leader Face for its whole life and may be
+  /// torn down after the client — degrades to hold-last instead of
+  /// dereferencing freed memory. ``Face::read()`` touches ONLY this block, never
+  /// the client. Defined in the .cpp (implementation detail). Contains exactly
+  /// what a read touches: the action slot, the scalars, and the tick-log sink.
+  struct SharedState;
+
+public:
   /**
    * @brief Construct with a logical id only; configuration is deferred to
    *        ``configure()``.
@@ -128,16 +140,14 @@ public:
   std::string get_type() const override { return "policy_client"; }
 
   /// Sum of ``joint_count`` across the configured ``joint_layout``.
-  [[nodiscard]] int total_joint_count() const noexcept { return total_n_; }
+  [[nodiscard]] int total_joint_count() const noexcept;
 
   /// Row currently being commanded to all Faces; length is ``total_joint_count()``.
   [[nodiscard]] std::vector<float> current_command() const;
 
   /// Row-selection rate Faces and ``current_command()`` use when indexing the chunk.
   void set_control_rate_hz(double hz) noexcept;
-  [[nodiscard]] double control_rate_hz() const noexcept {
-    return control_rate_hz_.load(std::memory_order_acquire);
-  }
+  [[nodiscard]] double control_rate_hz() const noexcept;
 
   /// Faces registered by this client, in ``joint_layout`` order.
   [[nodiscard]] const std::vector<std::shared_ptr<Face>>& faces() const noexcept {
@@ -149,12 +159,17 @@ public:
     return chunks_published_.load(std::memory_order_acquire);
   }
 
+  /// Monotonic count of chunks rejected by a client-side safety gate (width
+  /// mismatch, non-finite element, all-past or far-future alignment). Held
+  /// last on every rejection; never published (test/diagnostic accessor).
+  [[nodiscard]] uint64_t chunks_rejected() const noexcept {
+    return chunks_rejected_.load(std::memory_order_acquire);
+  }
+
   /// Snapshot of the currently-published action chunk; null if none has been
   /// received yet. Used by ``PolicyClientProducer`` to derive a chunk-aligned
   /// timestamp when ``use_device_time`` is enabled.
-  [[nodiscard]] std::shared_ptr<const ActionChunk> latest_chunk() const noexcept {
-    return chunk_slot_.peek();
-  }
+  [[nodiscard]] std::shared_ptr<const ActionChunk> latest_chunk() const noexcept;
 
   /// Transport health snapshot. ``failure_count`` is the transport-lifetime
   /// failure counter (replaces the old ``round_trip_failures()``); episode
@@ -227,13 +242,32 @@ private:
   /// (ages, skew) into @p diag. The skew/age math uses the steady-clock
   /// timestamps producers attach to every record. Wire shaping (flattening,
   /// channel quirks, transposes) is the transport's job, not done here.
-  Observation pack_observation_(ObservationDiagnostics& diag);
+  /// Pack the neutral Observation. Returns ``std::nullopt`` when a configured
+  /// camera cannot be represented this cycle (no valid frame and no dimensions
+  /// to synthesize a placeholder), which tells the inference loop to skip
+  /// publishing rather than ship an observation with a diverging image set.
+  std::optional<Observation> pack_observation_(ObservationDiagnostics& diag);
 
-  /// Extract one camera frame as a neutral Image: resized per @p sub, HWC,
-  /// TRUE RGB (bgr8 records are converted; rgb8 pass through). Returns
-  /// nullopt to skip the camera (bad record with no configured resize).
+  /// Resolve one configured camera into a neutral Image. @p rec may be null
+  /// (no record delivered yet). A valid, non-empty, channel-mappable frame is
+  /// resized per @p sub, delivered HWC and TRUE RGB (mono8 is expanded to RGB,
+  /// bgr8 is converted, rgb8 passes through). Any other case (missing/wrong
+  /// record type, empty Mat, unmappable channel count) falls back to a zero
+  /// (black) placeholder of the same shape so the observation's image set stays
+  /// stable. Returns ``std::nullopt`` ONLY when even a placeholder cannot be
+  /// sized (no resize configured and no prior frame seen), signalling the
+  /// caller to fail the whole observation.
   std::optional<Observation::Image> pack_image_(
     const std::shared_ptr<data::RecordBase>& rec,
+    const configuration::PolicyClientSubscriptionConfig& sub,
+    const std::string& camera_key);
+
+  /// Produce a zero (black) placeholder Image for @p camera_key, sized from the
+  /// subscription's ``resize`` if set, else from the last successfully packed
+  /// frame for this camera. Returns ``std::nullopt`` when neither source of
+  /// dimensions is available (a configured camera we have never seen and that
+  /// declares no resize) — the observation then cannot be represented uniformly.
+  std::optional<Observation::Image> substitute_image_(
     const configuration::PolicyClientSubscriptionConfig& sub,
     const std::string& camera_key);
 
@@ -246,6 +280,14 @@ private:
   void apply_chunk_(ActionChunk chunk, uint64_t request_seq, double rt_ms);
 
   void warn_once_(const std::string& key, const std::string& message);
+
+  /// Rate-limited sibling of ``warn_once_``: logs @p message when at least
+  /// @p interval_ms has elapsed since the last log for @p key (always logs the
+  /// first time). Used for conditions that must keep surfacing while they
+  /// persist — a server streaming non-finite actions, say — where a one-shot
+  /// warning would hide an ongoing hazard yet per-event logging would flood.
+  void warn_throttled_(const std::string& key, const std::string& message,
+                       std::chrono::milliseconds interval_ms);
 
   /// Open the JSONL log file declared in @p log_path. No-op when empty.
   /// Performs tilde expansion and creates parent directories. Logs but does
@@ -262,16 +304,6 @@ private:
                      std::chrono::steady_clock::time_point t_recv,
                      double rt_ms,
                      const std::shared_ptr<const ActionChunk>& chunk);
-
-  /// Per-tick log emitted from @c Face::read on every control-loop sample.
-  /// Carries the action row slice the follower actually executed, plus the
-  /// chunk-playback metadata (chunk_seq, t_idx, saturated, blend_active)
-  /// required to correlate the action stream with chunk boundaries and
-  /// wait windows. Thread-safe (multiple faces poll concurrently).
-  void log_tick_(const std::string& face_id,
-                 std::chrono::steady_clock::time_point t,
-                 const std::vector<float>& action,
-                 const ChunkSlot::SampleInfo* info_ptr);
 
   bool configured_{false};
   configuration::PolicyClientConfig cfg_;
@@ -308,7 +340,7 @@ private:
   /// only updated on the next face sample after a chunk is applied —
   /// a stale read here was the cause of the "wait skipped after cycle ~6"
   /// regression where the loop fell back to wall-clock cadence and
-  /// re-introduced the mid-chunk observation problem (4.3). Updated in
+  /// re-introduced the mid-chunk observation problem. Updated in
   /// @c apply_chunk_ on every successful publish; consumed by
   /// @c wait_for_fire_point_ on the following cycle. Cleared to the default
   /// (epoch zero) by the inference thread when it wakes from a pause, and on
@@ -330,9 +362,17 @@ private:
   /// window yet". Inference-thread only (set in inference_loop_).
   std::chrono::steady_clock::time_point inference_epoch_{};
 
-  ChunkSlot chunk_slot_;
+  /// The action slot, control scalars, and JSONL log sink read by Faces. Owned
+  /// jointly with every Face (see @c SharedState) so a surviving Face is safe.
+  /// Created in the ctor / @c init_; never null once the object is constructed.
+  std::shared_ptr<SharedState> shared_;
   std::vector<std::shared_ptr<Face>> faces_;
-  int total_n_{0};
+
+  /// Per-camera dimensions of the last successfully packed frame, used to size
+  /// a zero placeholder when a camera's record is missing or unmappable and no
+  /// ``resize`` is configured. Inference-thread only (written in @c pack_image_,
+  /// read in @c substitute_image_), so no synchronization is required.
+  std::unordered_map<std::string, std::pair<int, int>> last_image_dims_;
 
   std::thread inference_thread_;
   std::atomic<bool> inference_running_{false};
@@ -340,35 +380,36 @@ private:
   std::mutex inference_mu_;
   std::condition_variable inference_cv_;
 
-  std::atomic<double> control_rate_hz_{30.0};
   // Chunk identity (chunk_seq) is stamped by the transport, per connection —
   // the client deliberately has no counter of its own, so JSONL logs and
   // Face tick logs can never disagree on a chunk's number.
   std::atomic<uint64_t> chunks_published_{0};
+  /// Count of chunks dropped by a client-side safety gate (see @c chunks_rejected).
+  std::atomic<uint64_t> chunks_rejected_{0};
 
   std::mutex warn_mu_;
   std::unordered_map<std::string, bool> warned_;
-
-  /// JSONL log shared by the inference thread (request/response events) and
-  /// every Face::read tick (tick events). The mutex serializes line writes
-  /// so multi-arm setups don't interleave bytes mid-line.
-  std::ofstream log_file_;
-  std::mutex log_mu_;
-  std::chrono::steady_clock::time_point log_t0_;
+  /// Last-log instants for @c warn_throttled_, keyed like @c warned_. Guarded
+  /// by @c warn_mu_ alongside @c warned_.
+  std::unordered_map<std::string, std::chrono::steady_clock::time_point> warn_throttle_at_;
 };
 
 /**
- * @brief Per-arm leader Face: presents a sliced view of the owner's action chunk.
+ * @brief Per-arm leader Face: presents a sliced view of the action chunk.
  *
- * Owns no state of its own besides ``[offset, count)``; ``read()`` delegates to
- * the owner's ``ChunkSlot``. ``write()`` is a no-op because Faces are leader-only.
- * Lifetime is tied to the owning ``PolicyClient``; Faces hold a raw back-pointer.
+ * Owns no state of its own besides ``[offset, count)`` and the EMA history;
+ * ``read()`` delegates to the shared ``ChunkSlot``. ``write()`` is a no-op
+ * because Faces are leader-only. A Face holds a ``shared_ptr`` to the client's
+ * ``SharedState`` (the action slot + scalars + log sink), NOT a back-pointer to
+ * the client, so a Face that outlives its ``PolicyClient`` still reads valid
+ * memory and safely holds last.
  */
 class PolicyClient::Face
   : public hw::HardwareComponent,
     public hw::teleop::JointSpaceTeleop {
 public:
-  Face(PolicyClient* owner, std::string id, int joint_offset, int joint_count);
+  Face(std::shared_ptr<SharedState> state, std::string id,
+       int joint_offset, int joint_count);
 
   /// No-op: Face is configured at construction by its owning PolicyClient.
   void configure(const nlohmann::json& cfg) override { (void)cfg; }
@@ -376,8 +417,10 @@ public:
   std::string get_type() const override { return "policy_client_face"; }
 
   /// Returns the per-arm slice of the latest commanded action row.
-  /// Honors hold-last-action: under any failure path (including allocation
-  /// failure) returns a ``joint_count``-sized zero vector and never throws.
+  /// Honors hold-last-action: on any failure path it returns the previous
+  /// output (or an empty vector meaning "no command this tick" when no prior
+  /// output exists) rather than a zero vector — commanding every joint to zero
+  /// would be a large, unsafe motion. Never throws.
   std::vector<float> read() noexcept override;
 
   /// No-op: Faces are leader-only; commands are produced by the policy server.
@@ -392,8 +435,22 @@ public:
   /// blend the new chunk against pre-pause output on resume.
   void reset_output_filter() noexcept { prev_out_.clear(); }
 
+  /// Apply the two-alpha output EMA in place: for each channel
+  /// ``out[i] = a·out[i] + (1-a)·prev[i]``, with ``a = alpha_arm`` for arm
+  /// joints and ``a = alpha_gripper`` for the last channel (the gripper by
+  /// convention). Channels whose alpha is >= 1 pass through unchanged. A
+  /// non-finite history term is NOT blended against (it would latch NaN/Inf
+  /// through the recurrence forever); that channel passes the current value
+  /// through instead. @p prev is then updated per-channel with the new finite
+  /// outputs only, so one bad row never poisons subsequent ticks. Exposed as a
+  /// pure static helper so the non-finite guard is unit-testable in isolation.
+  static void apply_output_ema(std::vector<float>& out,
+                               std::vector<float>& prev,
+                               double alpha_arm,
+                               double alpha_gripper) noexcept;
+
 private:
-  PolicyClient* owner_;
+  std::shared_ptr<SharedState> state_;
   int joint_offset_;
   int joint_count_;
   /// Output of the previous ``read()`` after EMA application, used as the

--- a/include/trossen_sdk/hw/policy/policy_client.hpp
+++ b/include/trossen_sdk/hw/policy/policy_client.hpp
@@ -224,9 +224,9 @@ private:
   double wait_for_fresh_observations_();
 
   /// Block until the firing instant of the currently-playing chunk
-  /// (@c next_chunk_fire_target_): the drain-threshold θ point. At θ=0 this is
+  /// (@c next_chunk_fire_target_): the drain-threshold theta point. At theta=0 this is
   /// the chunk's exhaustion instant, so the next observation captures the arm
-  /// at its end-of-chunk pose (openpi's synchronous cadence); at θ>0 it fires
+  /// at its end-of-chunk pose (openpi's synchronous cadence); at theta>0 it fires
   /// earlier, overlapping inference with playback. No-op when no chunk is
   /// playing (first cycle, after pause/clear, or when the previous round-trip
   /// produced no chunk). Interruptible by pause or shutdown via @c inference_cv_.
@@ -348,9 +348,9 @@ private:
   /// (the pause path defers the clear here rather than writing from the caller).
   std::chrono::steady_clock::time_point next_chunk_exhaust_target_{};
 
-  /// Instant at which to fire the next observation: the drain-threshold θ point
-  /// of the last applied chunk, ``exhaust - θ·duration`` (= exhaust when θ=0).
-  /// For θ>0 this is earlier than @c next_chunk_exhaust_target_, overlapping
+  /// Instant at which to fire the next observation: the drain-threshold theta point
+  /// of the last applied chunk, ``exhaust - theta·duration`` (= exhaust when theta=0).
+  /// For theta>0 this is earlier than @c next_chunk_exhaust_target_, overlapping
   /// the next inference with the current chunk's playback. Cleared with the
   /// exhaust target on resume/shutdown. Consumed by @c wait_for_fire_point_.
   /// Inference-thread only.

--- a/include/trossen_sdk/hw/policy/policy_client.hpp
+++ b/include/trossen_sdk/hw/policy/policy_client.hpp
@@ -1,0 +1,410 @@
+/**
+ * @file policy_client.hpp
+ * @brief PolicyClient hardware/observer bridge and its per-arm Face adapters.
+ */
+
+#ifndef TROSSEN_SDK__HW__POLICY__POLICY_CLIENT_HPP_
+#define TROSSEN_SDK__HW__POLICY__POLICY_CLIENT_HPP_
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/configuration/types/hardware/policy_client_config.hpp"
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/policy/action_chunk.hpp"
+#include "trossen_sdk/hw/policy/policy_transport.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+#include "trossen_sdk/observer/observer_base.hpp"
+
+namespace trossen::hw::policy {
+
+/**
+ * @brief Per-cycle diagnostics emitted into the JSONL log alongside the
+ *        observation payload.
+ *
+ * Carried separately from the on-wire observation so the openpi-format
+ * payload (state / images / prompt) stays minimal. Populated in
+ * ``pack_observation_`` and ``wait_for_fresh_observations_``; consumed by
+ * ``log_request_``. Sized to fit on one cache line for cheap pass-by-value.
+ */
+struct ObservationDiagnostics {
+  /// Per-record-id age, computed as ``cycle_start - rec.ts.monotonic`` at
+  /// packing time. Same map key set as the subscriptions vector. Missing
+  /// records (no entry in the cache) get a NaN entry so the consumer can
+  /// distinguish "missing" from "fresh".
+  std::unordered_map<std::string, double> ages_ms;
+  /// ``max(ages_ms) - min(ages_ms)``; the cross-source temporal skew that
+  /// the freshness barrier exists to bound. Zero when fewer than two
+  /// subscriptions have a record.
+  double skew_ms{0.0};
+  /// Wall time the freshness barrier blocked before packing began.
+  double freshness_wait_ms{0.0};
+  /// Interval to the previous successful packing in ms; zero on the first
+  /// cycle of an active window.
+  double cycle_interval_ms{0.0};
+};
+
+/**
+ * @brief Bridge between a remote policy server and the SDK teleop machinery.
+ *
+ * Multi-inherits ``HardwareComponent`` (for registry placement) and ``ObserverBase``
+ * (for record-stream subscriptions). Owns one ``PolicyTransport``, one inference
+ * thread, and N ``Face`` adapters that present per-arm slices of the latest action
+ * chunk to existing ``TeleopController`` instances.
+ *
+ * Threading: ``ObserverBase`` spawns its subscription-dispatch worker via
+ * ``start()``; ``on_start()`` additionally spawns the inference thread. Subscription
+ * handlers and the inference loop share the per-record latest-record cache through
+ * ``cache_mu_``; handlers never block on the network.
+ *
+ * Failure mode: server stalls or exceptions keep the inference thread alive and
+ * leave the previous chunk in place; ``Face::read()`` returns the last commanded
+ * row indefinitely (see ADR-004 hold-last-action).
+ */
+class PolicyClient
+  : public hw::HardwareComponent,
+    public observer::ObserverBase {
+public:
+  class Face;
+
+  /**
+   * @brief Construct with a logical id only; configuration is deferred to
+   *        ``configure()``.
+   *
+   * Used by the hardware registry factory path: the registry constructs by id,
+   * the data-collection layer then calls ``configure(json)`` which parses the
+   * config, builds the transport, registers Faces, and adds subscriptions.
+   *
+   * @param id Logical hardware id (registry key and observer name).
+   */
+  explicit PolicyClient(std::string id);
+
+  /**
+   * @brief Construct with pre-built config + transport, registering Faces and
+   *        subscriptions immediately.
+   *
+   * Intended for tests and direct programmatic construction (e.g. ``FakeTransport``).
+   *
+   * @param cfg       Pre-validated configuration (see PR 01).
+   * @param transport Owned transport instance, not yet connected.
+   *
+   * @throws std::invalid_argument if @p transport is null.
+   * @throws std::runtime_error if a ``leader_id`` is already registered or if
+   *         the configuration violates the openpi observation contract.
+   */
+  PolicyClient(configuration::PolicyClientConfig cfg,
+               std::unique_ptr<PolicyTransport> transport);
+
+  ~PolicyClient() override;
+
+  PolicyClient(const PolicyClient&) = delete;
+  PolicyClient& operator=(const PolicyClient&) = delete;
+  PolicyClient(PolicyClient&&) = delete;
+  PolicyClient& operator=(PolicyClient&&) = delete;
+
+  /**
+   * @brief Parse @p cfg, build the transport, register Faces, and add
+   *        subscriptions. Must be called at most once.
+   *
+   * No-op when the two-arg constructor was used (configuration already applied).
+   *
+   * @throws std::runtime_error if configuration parsing fails, if a ``leader_id``
+   *         is already registered, or if the observation contract is violated.
+   */
+  void configure(const nlohmann::json& cfg) override;
+
+  std::string get_type() const override { return "policy_client"; }
+
+  /// Sum of ``joint_count`` across the configured ``joint_layout``.
+  [[nodiscard]] int total_joint_count() const noexcept { return total_n_; }
+
+  /// Row currently being commanded to all Faces; length is ``total_joint_count()``.
+  [[nodiscard]] std::vector<float> current_command() const;
+
+  /// Row-selection rate Faces and ``current_command()`` use when indexing the chunk.
+  void set_control_rate_hz(double hz) noexcept;
+  [[nodiscard]] double control_rate_hz() const noexcept {
+    return control_rate_hz_.load(std::memory_order_acquire);
+  }
+
+  /// Faces registered by this client, in ``joint_layout`` order.
+  [[nodiscard]] const std::vector<std::shared_ptr<Face>>& faces() const noexcept {
+    return faces_;
+  }
+
+  /// Monotonic count of successful chunk publishes (test/diagnostic accessor).
+  [[nodiscard]] uint64_t chunks_published() const noexcept {
+    return chunks_published_.load(std::memory_order_acquire);
+  }
+
+  /// Snapshot of the currently-published action chunk; null if none has been
+  /// received yet. Used by ``PolicyClientProducer`` to derive a chunk-aligned
+  /// timestamp when ``use_device_time`` is enabled.
+  [[nodiscard]] std::shared_ptr<const ActionChunk> latest_chunk() const noexcept {
+    return chunk_slot_.peek();
+  }
+
+  /// Transport health snapshot. ``failure_count`` is the transport-lifetime
+  /// failure counter (replaces the old ``round_trip_failures()``); episode
+  /// abort-on-failure policy is the application's call, made through this
+  /// accessor — the SDK itself only reports and holds last action.
+  /// Default-constructed (kDisconnected) when no transport is configured.
+  [[nodiscard]] TransportStatus transport_status() const noexcept {
+    return transport_ ? transport_->status() : TransportStatus{};
+  }
+
+  /// Pause or resume the inference loop without tearing down the transport.
+  /// When @p active is false the loop blocks (efficiently, on the condition
+  /// variable) and skips all round-trips; the active chunk is also cleared so
+  /// a stale action does not drive the mirror after resume. When transitioning
+  /// from false to true the loop wakes and waits for the observation cache to
+  /// be re-primed before sending the first request, matching the cold-start
+  /// behavior. Default state is active (true) to preserve existing test
+  /// behavior; lifecycle-aware examples should flip this around
+  /// on_episode_started / on_episode_ended.
+  void set_inference_active(bool active) noexcept;
+  [[nodiscard]] bool inference_active() const noexcept {
+    return inference_active_.load(std::memory_order_acquire);
+  }
+
+protected:
+  /// Open the transport and spawn the inference thread.
+  bool on_start() override;
+
+  /// Signal, join the inference thread, then close the transport.
+  void on_stop() override;
+
+private:
+  /// Shared wiring used by both ctors and the deferred ``configure()`` path.
+  void init_(configuration::PolicyClientConfig cfg,
+             std::unique_ptr<PolicyTransport> transport);
+
+  void inference_loop_();
+
+  /// Block until every subscribed @c record_id has delivered a record whose
+  /// per-subscription delivery counter has advanced past the baseline captured
+  /// at entry, or until ``cfg_.freshness_timeout_ms`` elapses. Guarantees that
+  /// every record in the next observation snapshot was produced after this
+  /// call began — and therefore within one producer period of every other
+  /// record in the snapshot. Subsumes the legacy first-arrival prime: at
+  /// startup/resume the baseline counters are zero, so the wait reduces to
+  /// "every subscription has delivered at least once". On timeout, logs the
+  /// stale record_ids (one-shot) and returns; the caller proceeds with the
+  /// stalest available records.
+  ///
+  /// @return Wall time the call blocked, in milliseconds. Used by the
+  ///         inference loop to populate ``ObservationDiagnostics``.
+  double wait_for_fresh_observations_();
+
+  /// Block until the firing instant of the currently-playing chunk
+  /// (@c next_chunk_fire_target_): the drain-threshold θ point. At θ=0 this is
+  /// the chunk's exhaustion instant, so the next observation captures the arm
+  /// at its end-of-chunk pose (openpi's synchronous cadence); at θ>0 it fires
+  /// earlier, overlapping inference with playback. No-op when no chunk is
+  /// playing (first cycle, after pause/clear, or when the previous round-trip
+  /// produced no chunk). Interruptible by pause or shutdown via @c inference_cv_.
+  void wait_for_fire_point_();
+
+  /// The Timestep Clock at instant @p now: the count of control-rate ticks
+  /// since @c inference_epoch_. Zero before the epoch is set or when the
+  /// control rate is unknown. Inference-thread only.
+  [[nodiscard]] int64_t current_timestep_(
+    std::chrono::steady_clock::time_point now) const noexcept;
+
+  /// Pack the neutral Observation and populate per-record diagnostics
+  /// (ages, skew) into @p diag. The skew/age math uses the steady-clock
+  /// timestamps producers attach to every record. Wire shaping (flattening,
+  /// channel quirks, transposes) is the transport's job, not done here.
+  Observation pack_observation_(ObservationDiagnostics& diag);
+
+  /// Extract one camera frame as a neutral Image: resized per @p sub, HWC,
+  /// TRUE RGB (bgr8 records are converted; rgb8 pass through). Returns
+  /// nullopt to skip the camera (bad record with no configured resize).
+  std::optional<Observation::Image> pack_image_(
+    const std::shared_ptr<data::RecordBase>& rec,
+    const configuration::PolicyClientSubscriptionConfig& sub,
+    const std::string& camera_key);
+
+  /// All-black neutral Image placeholder for a missing camera frame.
+  Observation::Image zero_image_(
+    const std::string& camera_key, int width, int height) const;
+  /// Gate, log, and publish one transport-decoded chunk into the slot.
+  /// Consumes @p chunk (already validated and stamped by the transport);
+  /// the only client-side check is chunk width vs the configured layout.
+  void apply_chunk_(ActionChunk chunk, uint64_t request_seq, double rt_ms);
+
+  void warn_once_(const std::string& key, const std::string& message);
+
+  /// Open the JSONL log file declared in @p log_path. No-op when empty.
+  /// Performs tilde expansion and creates parent directories. Logs but does
+  /// not throw on failure (logging is best-effort).
+  void open_log_file_(const std::string& log_path);
+
+  /// Append one request/response JSONL record. Both helpers are no-ops when
+  /// the log file is not open.
+  void log_request_(uint64_t seq,
+                    std::chrono::steady_clock::time_point t_send,
+                    const Observation& obs,
+                    const ObservationDiagnostics& diag);
+  void log_response_(uint64_t seq,
+                     std::chrono::steady_clock::time_point t_recv,
+                     double rt_ms,
+                     const std::shared_ptr<const ActionChunk>& chunk);
+
+  /// Per-tick log emitted from @c Face::read on every control-loop sample.
+  /// Carries the action row slice the follower actually executed, plus the
+  /// chunk-playback metadata (chunk_seq, t_idx, saturated, blend_active)
+  /// required to correlate the action stream with chunk boundaries and
+  /// wait windows. Thread-safe (multiple faces poll concurrently).
+  void log_tick_(const std::string& face_id,
+                 std::chrono::steady_clock::time_point t,
+                 const std::vector<float>& action,
+                 const ChunkSlot::SampleInfo* info_ptr);
+
+  bool configured_{false};
+  configuration::PolicyClientConfig cfg_;
+  std::unique_ptr<PolicyTransport> transport_;
+
+  /// Subscriptions whose ``obs_key`` is ``state.*``, paired by position to
+  /// ``cfg_.joint_layout`` entries.
+  std::vector<const configuration::PolicyClientSubscriptionConfig*> state_subs_;
+  /// Subscriptions whose ``obs_key`` is ``images.<camera>``; the camera key is
+  /// the suffix after ``images.``.
+  std::vector<const configuration::PolicyClientSubscriptionConfig*> image_subs_;
+  std::vector<std::string> image_camera_keys_;
+
+  mutable std::mutex cache_mu_;
+  std::unordered_map<std::string, std::shared_ptr<data::RecordBase>> latest_records_;
+  /// Per-subscription monotonic delivery counter, incremented every time the
+  /// subscription handler stores a record. Read under @c cache_mu_; signaled
+  /// to @c cache_fresh_cv_ on increment. The freshness barrier uses these as
+  /// generation numbers to detect new deliveries without inspecting record
+  /// content (so tests that reuse one record object work unchanged).
+  std::unordered_map<std::string, uint64_t> cache_gen_;
+  /// Signaled by every subscription handler after it bumps @c cache_gen_;
+  /// waited on by @c wait_for_fresh_observations_. Distinct from
+  /// @c inference_cv_ so a freshness wait does not race with the pause CV.
+  std::condition_variable cache_fresh_cv_;
+  /// Latched true the first time @c wait_for_fresh_observations_ returns
+  /// (successfully or via timeout). Suppresses the "waiting for first
+  /// observation" banner on every subsequent cycle. Touched only by the
+  /// inference thread, so no synchronization is required.
+  bool primed_observation_cache_{false};
+
+  /// Expected exhaust instant of the last applied chunk, tracked in
+  /// PolicyClient (not in ChunkSlot) because the slot's @c latest_ is
+  /// only updated on the next face sample after a chunk is applied —
+  /// a stale read here was the cause of the "wait skipped after cycle ~6"
+  /// regression where the loop fell back to wall-clock cadence and
+  /// re-introduced the mid-chunk observation problem (4.3). Updated in
+  /// @c apply_chunk_ on every successful publish; consumed by
+  /// @c wait_for_fire_point_ on the following cycle. Cleared to the default
+  /// (epoch zero) by the inference thread when it wakes from a pause, and on
+  /// shutdown. Inference-thread only: every read and write is on that thread
+  /// (the pause path defers the clear here rather than writing from the caller).
+  std::chrono::steady_clock::time_point next_chunk_exhaust_target_{};
+
+  /// Instant at which to fire the next observation: the drain-threshold θ point
+  /// of the last applied chunk, ``exhaust - θ·duration`` (= exhaust when θ=0).
+  /// For θ>0 this is earlier than @c next_chunk_exhaust_target_, overlapping
+  /// the next inference with the current chunk's playback. Cleared with the
+  /// exhaust target on resume/shutdown. Consumed by @c wait_for_fire_point_.
+  /// Inference-thread only.
+  std::chrono::steady_clock::time_point next_chunk_fire_target_{};
+
+  /// Epoch of the current active window (the Timestep Clock origin). Set when
+  /// inference becomes active and re-set on resume, so any observation packed
+  /// before a pause is stale by construction. Epoch-zero means "no active
+  /// window yet". Inference-thread only (set in inference_loop_).
+  std::chrono::steady_clock::time_point inference_epoch_{};
+
+  ChunkSlot chunk_slot_;
+  std::vector<std::shared_ptr<Face>> faces_;
+  int total_n_{0};
+
+  std::thread inference_thread_;
+  std::atomic<bool> inference_running_{false};
+  std::atomic<bool> inference_active_{true};
+  std::mutex inference_mu_;
+  std::condition_variable inference_cv_;
+
+  std::atomic<double> control_rate_hz_{30.0};
+  // Chunk identity (chunk_seq) is stamped by the transport, per connection —
+  // the client deliberately has no counter of its own, so JSONL logs and
+  // Face tick logs can never disagree on a chunk's number.
+  std::atomic<uint64_t> chunks_published_{0};
+
+  std::mutex warn_mu_;
+  std::unordered_map<std::string, bool> warned_;
+
+  /// JSONL log shared by the inference thread (request/response events) and
+  /// every Face::read tick (tick events). The mutex serializes line writes
+  /// so multi-arm setups don't interleave bytes mid-line.
+  std::ofstream log_file_;
+  std::mutex log_mu_;
+  std::chrono::steady_clock::time_point log_t0_;
+};
+
+/**
+ * @brief Per-arm leader Face: presents a sliced view of the owner's action chunk.
+ *
+ * Owns no state of its own besides ``[offset, count)``; ``read()`` delegates to
+ * the owner's ``ChunkSlot``. ``write()`` is a no-op because Faces are leader-only.
+ * Lifetime is tied to the owning ``PolicyClient``; Faces hold a raw back-pointer.
+ */
+class PolicyClient::Face
+  : public hw::HardwareComponent,
+    public hw::teleop::JointSpaceTeleop {
+public:
+  Face(PolicyClient* owner, std::string id, int joint_offset, int joint_count);
+
+  /// No-op: Face is configured at construction by its owning PolicyClient.
+  void configure(const nlohmann::json& cfg) override { (void)cfg; }
+
+  std::string get_type() const override { return "policy_client_face"; }
+
+  /// Returns the per-arm slice of the latest commanded action row.
+  /// Honors hold-last-action: under any failure path (including allocation
+  /// failure) returns a ``joint_count``-sized zero vector and never throws.
+  std::vector<float> read() noexcept override;
+
+  /// No-op: Faces are leader-only; commands are produced by the policy server.
+  void write(const std::vector<float>& cmd) noexcept override { (void)cmd; }
+
+  [[nodiscard]] int joint_offset() const noexcept { return joint_offset_; }
+  [[nodiscard]] int joint_count() const noexcept { return joint_count_; }
+
+  /// Clear the EMA filter history so the next ``read()`` returns the raw
+  /// chunk row (no carry-over from before a pause). Called by
+  /// ``PolicyClient::set_inference_active(false)`` so the filter doesn't
+  /// blend the new chunk against pre-pause output on resume.
+  void reset_output_filter() noexcept { prev_out_.clear(); }
+
+private:
+  PolicyClient* owner_;
+  int joint_offset_;
+  int joint_count_;
+  /// Output of the previous ``read()`` after EMA application, used as the
+  /// "previous output" term in ``out_t = α·row + (1-α)·prev_out``. Empty
+  /// when no prior tick has run since construction / last reset; the next
+  /// read passes the chunk row through unchanged and seeds this vector.
+  /// Touched only by the teleop loop polling this face (single thread per
+  /// face), so no synchronization is required.
+  std::vector<float> prev_out_;
+};
+
+}  // namespace trossen::hw::policy
+
+#endif  // TROSSEN_SDK__HW__POLICY__POLICY_CLIENT_HPP_

--- a/src/hw/active_hardware_registry.cpp
+++ b/src/hw/active_hardware_registry.cpp
@@ -57,6 +57,16 @@ bool ActiveHardwareRegistry::is_registered(const std::string& id) {
   return get_registry().find(id) != get_registry().end();
 }
 
+bool ActiveHardwareRegistry::unregister(const std::string& id) {
+  auto& registry = get_registry();
+  auto it = registry.find(id);
+  if (it == registry.end()) {
+    return false;
+  }
+  registry.erase(it);
+  return true;
+}
+
 void ActiveHardwareRegistry::clear() {
   get_registry().clear();
 }

--- a/src/hw/policy/policy_client.cpp
+++ b/src/hw/policy/policy_client.cpp
@@ -205,8 +205,7 @@ void PolicyClient::init_(configuration::PolicyClientConfig cfg,
     const std::string record_id = sub.record_id;
     // Initialize the generation counter to 0 so the freshness barrier's
     // baseline lookup never falls through to an inserted-default and so the
-    // first wait reduces to "every subscription has delivered at least once"
-    // (the legacy prime behavior).
+    // first wait reduces to "every subscription has delivered at least once".
     cache_gen_[record_id] = 0;
     add_subscription(
       record_id, sub.throttle_hz,
@@ -469,8 +468,8 @@ void PolicyClient::inference_loop_() {
     if (!inference_active_.load(std::memory_order_acquire)) continue;
 
     // Wait for a fresh delivery from every subscription before packing.
-    // Subsumes the legacy first-arrival prime: at startup/resume the
-    // generation counters are all zero and this reduces to "wait for one
+    // At startup/resume the generation counters are all zero and this
+    // reduces to "wait for one
     // record per sub". Steady state: ensures every observation snapshot is
     // co-temporal (all records produced within one producer period).
     ObservationDiagnostics diag;
@@ -528,7 +527,7 @@ void PolicyClient::inference_loop_() {
       transport_->push_observation(*obs);
 
       // Poll for the reply chunk (theta=0 cadence: the cycle re-synchronizes on
-      // arrival, exactly like the old blocking round_trip). The 1 ms tick is
+      // arrival). The 1 ms tick is
       // noise against ~1 s inference, and using inference_cv_ keeps the wait
       // shutdown-interruptible. Exits: chunk, shutdown, or transport gone
       // unhealthy (a disconnected transport polls nullopt forever). NOT on
@@ -572,7 +571,6 @@ void PolicyClient::inference_loop_() {
       if (chunk) {
         const auto t_recv = clock::now();
         // Push-to-arrival latency: true round trip plus up to one poll tick.
-        // Same field name as the old blocking measurement (paired logs).
         const auto rt_ms =
           std::chrono::duration<double, std::milli>(t_recv - t_send).count();
         std::cerr << "[policy_client:" << name() << "] req#" << req_seq

--- a/src/hw/policy/policy_client.cpp
+++ b/src/hw/policy/policy_client.cpp
@@ -1,0 +1,1344 @@
+/**
+ * @file policy_client.cpp
+ * @brief Implementation of PolicyClient and PolicyClient::Face.
+ */
+
+#include "trossen_sdk/hw/policy/policy_client.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <exception>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "opencv2/core.hpp"
+#include "opencv2/imgproc.hpp"
+
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/policy/transport_registry.hpp"
+
+namespace trossen::hw::policy {
+
+namespace {
+
+constexpr const char* kObsPrefixState = "state.";
+constexpr const char* kObsPrefixImages = "images.";
+
+// EXPECTED_CAMERAS from openpi/src/openpi/policies/aloha_policy.py:40 — the
+// server rejects any image key outside this set.
+const std::vector<std::string>& expected_cameras() {
+  static const std::vector<std::string> kCams = {
+    "cam_high", "cam_low", "cam_left_wrist", "cam_right_wrist"};
+  return kCams;
+}
+
+bool is_expected_camera(const std::string& key) {
+  for (const auto& c : expected_cameras()) {
+    if (c == key) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+PolicyClient::PolicyClient(std::string id)
+  : HardwareComponent(id),
+    ObserverBase(id) {}
+
+PolicyClient::PolicyClient(configuration::PolicyClientConfig cfg,
+                           std::unique_ptr<PolicyTransport> transport)
+  : HardwareComponent(cfg.id),
+    ObserverBase(cfg.id) {
+  if (!transport) {
+    throw std::invalid_argument(
+      "PolicyClient: transport must not be null for policy_client '" + cfg.id + "'");
+  }
+  init_(std::move(cfg), std::move(transport));
+}
+
+PolicyClient::~PolicyClient() {
+  // Order: stop the inference thread + observer worker first so no live thread
+  // can dereference owner_/transport_ during teardown, then drop each Face from
+  // the registry so external lookups cannot resolve to a soon-dead object.
+  try {
+    stop();
+  } catch (...) {
+    // stop() already swallows derived hook exceptions; nothing useful to do here.
+  }
+  for (const auto& face : faces_) {
+    ActiveHardwareRegistry::unregister(face->get_identifier());
+  }
+}
+
+void PolicyClient::configure(const nlohmann::json& cfg) {
+  if (configured_) {
+    return;
+  }
+  auto parsed = configuration::PolicyClientConfig::from_json(cfg);
+  // Back-compat shim: top-level "api_key" predates transport_config. Inject
+  // it so factories read a single place; an explicit transport_config entry
+  // wins (the more specific setting beats the more general one).
+  nlohmann::json transport_config = parsed.transport_config;
+  if (parsed.api_key.has_value() && !transport_config.contains("api_key")) {
+    transport_config["api_key"] = *parsed.api_key;
+  }
+  // Inject the flattened per-motor keys ("<joint_name>.pos", layout order) so a
+  // name-keyed transport (LeRobot) has a single source of truth for the
+  // observation.state component names — the same names map_observation_ stamps
+  // on the per-step observation. Skipped when joint_names are unset (the
+  // transport then requires explicit feature names or, like openpi, ignores it).
+  // An explicit transport_config entry wins.
+  if (!transport_config.contains("motor_names")) {
+    nlohmann::json motor_names = nlohmann::json::array();
+    for (const auto& row : parsed.joint_layout) {
+      for (const auto& jn : row.joint_names) {
+        motor_names.push_back(jn + ".pos");
+      }
+    }
+    if (!motor_names.empty()) {
+      transport_config["motor_names"] = std::move(motor_names);
+    }
+  }
+  auto transport = TransportRegistry::create(
+    parsed.transport, parsed.id, parsed.server_url, transport_config);
+  init_(std::move(parsed), std::move(transport));
+}
+
+void PolicyClient::init_(configuration::PolicyClientConfig cfg,
+                         std::unique_ptr<PolicyTransport> transport) {
+  cfg_ = std::move(cfg);
+  transport_ = std::move(transport);
+
+  // inference_hz drives the loop period as 1e9 / inference_hz; a zero, negative,
+  // or non-finite value would make the period UB or run the schedule backward.
+  // The from_json path validates this, but the direct (two-arg) constructor and
+  // programmatic callers do not go through it, so guard here as well.
+  if (!(cfg_.inference_hz > 0.0) || !std::isfinite(cfg_.inference_hz)) {
+    throw std::runtime_error(
+      "PolicyClient: inference_hz must be finite and > 0 (got " +
+      std::to_string(cfg_.inference_hz) + ") for '" + cfg_.id + "'");
+  }
+
+  // Partition subscriptions by obs_key prefix and validate openpi conventions.
+  for (const auto& sub : cfg_.subscriptions) {
+    if (sub.obs_key.rfind(kObsPrefixState, 0) == 0) {
+      state_subs_.push_back(&sub);
+      continue;
+    }
+    if (sub.obs_key.rfind(kObsPrefixImages, 0) == 0) {
+      const std::string cam_key = sub.obs_key.substr(std::strlen(kObsPrefixImages));
+      if (!is_expected_camera(cam_key)) {
+        throw std::runtime_error(
+          "PolicyClient: obs_key '" + sub.obs_key +
+          "' references unsupported camera '" + cam_key +
+          "'. EXPECTED_CAMERAS = {cam_high, cam_low, cam_left_wrist, cam_right_wrist}");
+      }
+      image_subs_.push_back(&sub);
+      image_camera_keys_.push_back(cam_key);
+      continue;
+    }
+    throw std::runtime_error(
+      "PolicyClient: obs_key '" + sub.obs_key +
+      "' must start with 'state.' or 'images.'");
+  }
+
+  if (state_subs_.size() != cfg_.joint_layout.size()) {
+    throw std::runtime_error(
+      "PolicyClient: number of state.* subscriptions (" +
+      std::to_string(state_subs_.size()) +
+      ") must equal joint_layout entries (" +
+      std::to_string(cfg_.joint_layout.size()) + ")");
+  }
+
+  for (const auto& sub : cfg_.subscriptions) {
+    const std::string record_id = sub.record_id;
+    // Initialize the generation counter to 0 so the freshness barrier's
+    // baseline lookup never falls through to an inserted-default and so the
+    // first wait reduces to "every subscription has delivered at least once"
+    // (the legacy prime behavior).
+    cache_gen_[record_id] = 0;
+    add_subscription(
+      record_id, sub.throttle_hz,
+      [this, record_id](const std::shared_ptr<data::RecordBase>& rec) {
+        {
+          std::lock_guard<std::mutex> lk(cache_mu_);
+          latest_records_[record_id] = rec;
+          ++cache_gen_[record_id];
+        }
+        // notify_all without holding cache_mu_ keeps the producer hot path
+        // short and matches the existing observer notify_one pattern.
+        cache_fresh_cv_.notify_all();
+      });
+  }
+
+  // All-or-nothing Face registration: detect collisions first so an unrecoverable
+  // partial state cannot leak into the registry, then register with an RAII
+  // rollback guard in case a later step throws.
+  std::vector<std::shared_ptr<Face>> staged;
+  staged.reserve(cfg_.joint_layout.size());
+  for (const auto& row : cfg_.joint_layout) {
+    if (ActiveHardwareRegistry::is_registered(row.leader_id)) {
+      throw std::runtime_error(
+        "PolicyClient: leader_id '" + row.leader_id +
+        "' is already registered in ActiveHardwareRegistry");
+    }
+    staged.push_back(std::make_shared<Face>(
+      this, row.leader_id, row.joint_offset, row.joint_count));
+  }
+
+  std::vector<std::string> registered_ids;
+  registered_ids.reserve(staged.size());
+  auto rollback = [&]() noexcept {
+    for (const auto& id : registered_ids) {
+      ActiveHardwareRegistry::unregister(id);
+    }
+  };
+  try {
+    for (std::size_t i = 0; i < staged.size(); ++i) {
+      ActiveHardwareRegistry::register_active(
+        cfg_.joint_layout[i].leader_id, staged[i]);
+      registered_ids.push_back(cfg_.joint_layout[i].leader_id);
+    }
+    faces_ = std::move(staged);
+    total_n_ = 0;
+    for (const auto& row : cfg_.joint_layout) {
+      total_n_ += row.joint_count;
+    }
+  } catch (...) {
+    rollback();
+    throw;
+  }
+
+  open_log_file_(cfg_.log_path);
+
+  chunk_slot_.set_boundary_blend_s(cfg_.chunk_boundary_blend_s);
+
+  // Tell the slot to skip the boundary cross-fade on gripper channels. By
+  // joint_layout convention each entry's last column is the gripper; with
+  // bimanual ALOHA that's indices 6 and 13. The blend exists to smooth arm
+  // motion across chunk promotions, but gripper transitions are fast and
+  // commanding-the-old-value-during-blend produces incomplete grasps.
+  std::vector<int> gripper_indices;
+  gripper_indices.reserve(cfg_.joint_layout.size());
+  for (const auto& row : cfg_.joint_layout) {
+    if (row.joint_count > 0) {
+      gripper_indices.push_back(row.joint_offset + row.joint_count - 1);
+    }
+  }
+  chunk_slot_.set_boundary_blend_skip_indices(std::move(gripper_indices));
+
+  configured_ = true;
+}
+
+void PolicyClient::set_inference_active(bool active) noexcept {
+  const bool was_active = inference_active_.exchange(active, std::memory_order_acq_rel);
+  if (was_active && !active) {
+    // Going active → paused: clear the chunk slot so a stale chunk does not
+    // drive the mirror after resume. Faces fall back to hold-last-action,
+    // which keeps the follower at its last commanded pose during reset.
+    // (ChunkSlot is internally synchronized, so this cross-thread call is safe.)
+    chunk_slot_.swap_in(nullptr);
+    // The chunk-exhaust/fire wait targets are NOT touched here: they are owned
+    // by the inference thread, which clears them when it wakes from the pause
+    // (see inference_loop_). Writing them from this thread would race the loop.
+    // Reset each Face's EMA filter history so the first read after resume
+    // doesn't blend the new episode's chunks against pre-pause output.
+    for (const auto& face : faces_) {
+      if (face) face->reset_output_filter();
+    }
+  }
+  inference_cv_.notify_all();
+  // Unblock any in-flight freshness wait so a pause/resume takes effect
+  // immediately rather than after the freshness_timeout_ms deadline.
+  cache_fresh_cv_.notify_all();
+}
+
+void PolicyClient::set_control_rate_hz(double hz) noexcept {
+  if (hz > 0.0) {
+    control_rate_hz_.store(hz, std::memory_order_release);
+  }
+}
+
+std::vector<float> PolicyClient::current_command() const {
+  return chunk_slot_.sample(
+    std::chrono::steady_clock::now(),
+    total_n_,
+    control_rate_hz_.load(std::memory_order_acquire));
+}
+
+bool PolicyClient::on_start() {
+  if (!transport_) {
+    std::cerr << "[policy_client:" << name()
+              << "] on_start invoked without a configured transport\n";
+    return false;
+  }
+  try {
+    transport_->connect();
+  } catch (const std::exception& e) {
+    std::cerr << "[policy_client:" << name() << "] transport connect failed: "
+              << e.what() << "\n";
+    return false;
+  } catch (...) {
+    std::cerr << "[policy_client:" << name() << "] transport connect failed (unknown)\n";
+    return false;
+  }
+
+  inference_running_.store(true, std::memory_order_release);
+  try {
+    inference_thread_ = std::thread(&PolicyClient::inference_loop_, this);
+  } catch (...) {
+    inference_running_.store(false, std::memory_order_release);
+    transport_->close();
+    std::cerr << "[policy_client:" << name() << "] failed to spawn inference thread\n";
+    return false;
+  }
+  return true;
+}
+
+void PolicyClient::on_stop() {
+  inference_running_.store(false, std::memory_order_release);
+  inference_cv_.notify_all();
+  // Also wake any freshness wait so shutdown does not block for up to
+  // freshness_timeout_ms.
+  cache_fresh_cv_.notify_all();
+  // Transport close() joins its own worker (unblocking any in-flight round
+  // trip); the loop's chunk-poll wait exits via inference_running_ + the cv
+  // notifies above. Order is free now — nothing here can block on the server.
+  if (transport_) {
+    transport_->close();
+  }
+  if (inference_thread_.joinable()) {
+    inference_thread_.join();
+  }
+}
+
+void PolicyClient::inference_loop_() {
+  using clock = std::chrono::steady_clock;
+  const double inference_hz = cfg_.inference_hz;
+  const auto period = std::chrono::nanoseconds(
+    static_cast<int64_t>(1e9 / inference_hz));
+
+  uint64_t req_seq = 0;
+  auto next = clock::now();
+  // Timestep Clock origin for the initial active window (re-set on resume).
+  inference_epoch_ = next;
+  // Wall-clock timestamp of the previous successful packing. Used to populate
+  // cycle_interval_ms; zero on the first cycle of an active window. Reset to
+  // zero whenever the loop pauses so a pause/resume doesn't masquerade as a
+  // very long cycle interval.
+  std::chrono::steady_clock::time_point prev_pack_time{};
+
+  // Transport health is logged on TRANSITIONS only — a disconnect mid-episode
+  // is one warning line, not a per-cycle error stream. kConnected start state
+  // is correct by construction: on_start() connected before spawning us.
+  auto prev_transport_state = TransportStatus::State::kConnected;
+  auto state_name = [](TransportStatus::State s) {
+    switch (s) {
+      case TransportStatus::State::kConnected: return "connected";
+      case TransportStatus::State::kReconnecting: return "reconnecting";
+      case TransportStatus::State::kDisconnected: return "disconnected";
+    }
+    return "unknown";
+  };
+
+  while (inference_running_.load(std::memory_order_acquire)) {
+    // Block while paused. Skip work, do not consume the period budget — the
+    // loop should resume in real time, not catch up on missed cycles.
+    if (!inference_active_.load(std::memory_order_acquire)) {
+      std::unique_lock<std::mutex> lk(inference_mu_);
+      inference_cv_.wait(lk, [this] {
+        return !inference_running_.load(std::memory_order_acquire) ||
+               inference_active_.load(std::memory_order_acquire);
+      });
+      if (!inference_running_.load(std::memory_order_acquire)) break;
+      // Reset the schedule clock so we do not fire a burst of catch-up
+      // requests immediately after resume. Drop the previous pack time
+      // so the first cycle after resume reports cycle_interval_ms=0.
+      lk.unlock();
+      next = clock::now();
+      prev_pack_time = {};
+      // Reset the Timestep Clock epoch: post-resume observations restart at
+      // tick 0, so anything packed before the pause is stale by construction.
+      inference_epoch_ = next;
+      // Clear the chunk-exhaust/fire wait targets here, on the inference
+      // thread, rather than from set_inference_active() on the caller's thread:
+      // these members are read by wait_for_fire_point_/pack_observation_/
+      // apply_chunk_ (all inference-thread), so keeping every write on this
+      // thread makes them genuinely single-threaded and race-free. A stale
+      // target from the prior episode would otherwise gate the first cycle on
+      // an instant that has already passed (or is far in the future).
+      next_chunk_exhaust_target_ = {};
+      next_chunk_fire_target_ = {};
+    }
+
+    // One status poll per cycle (§7 failure model); log transitions only.
+    {
+      const TransportStatus st = transport_->status();
+      if (st.state != prev_transport_state) {
+        std::cerr << "[policy_client:" << name() << "] transport "
+                  << state_name(prev_transport_state) << " -> "
+                  << state_name(st.state)
+                  << " (failures=" << st.failure_count
+                  << (st.last_error.empty() ? std::string()
+                                            : ", last_error: " + st.last_error)
+                  << ")\n";
+        prev_transport_state = st.state;
+      }
+    }
+
+    // Gate observation packing on the drain-threshold firing instant. At θ=0
+    // this is chunk exhaustion (openpi semantics): packing waits until the
+    // current chunk is about to exhaust so the observation captures the arm at
+    // its end-of-chunk pose, avoiding the mid-chunk wall-clock schedule that
+    // made the policy return chunks computed for a stale pose. At θ>0 it fires
+    // earlier, overlapping inference with playback. Skipped on the first cycle
+    // (no chunk yet) and after a pause-driven slot clear.
+    wait_for_fire_point_();
+    if (!inference_running_.load(std::memory_order_acquire)) break;
+    if (!inference_active_.load(std::memory_order_acquire)) continue;
+
+    // Wait for a fresh delivery from every subscription before packing.
+    // Subsumes the legacy first-arrival prime: at startup/resume the
+    // generation counters are all zero and this reduces to "wait for one
+    // record per sub". Steady state: ensures every observation snapshot is
+    // co-temporal (all records produced within one producer period).
+    ObservationDiagnostics diag;
+    diag.freshness_wait_ms = wait_for_fresh_observations_();
+    // Pause / shutdown may have been requested while we were waiting.
+    if (!inference_running_.load(std::memory_order_acquire)) break;
+    if (!inference_active_.load(std::memory_order_acquire)) continue;
+
+    std::optional<Observation> obs;
+    try {
+      obs = pack_observation_(diag);
+    } catch (const std::exception& e) {
+      warn_once_("pack_observation",
+                 std::string("pack_observation threw: ") + e.what());
+    } catch (...) {
+      warn_once_("pack_observation", "pack_observation threw (unknown)");
+    }
+
+    if (obs) {
+      ++req_seq;
+      const auto t_send = clock::now();
+      // Populate cycle_interval before logging; zero on the very first cycle
+      // or first cycle after resume (prev_pack_time was reset).
+      if (prev_pack_time.time_since_epoch().count() != 0) {
+        diag.cycle_interval_ms =
+          std::chrono::duration<double, std::milli>(t_send - prev_pack_time)
+            .count();
+      }
+      prev_pack_time = t_send;
+      log_request_(req_seq, t_send, *obs, diag);
+      try {
+        std::ostringstream line;
+        line << "[policy_client:" << name() << "] req#" << req_seq << " state=[";
+        line << std::fixed << std::setprecision(3);
+        bool first = true;
+        for (const auto& group : obs->state) {
+          for (float v : group.values) {
+            line << (first ? "" : ", ") << v;
+            first = false;
+          }
+        }
+        line << "] images=[";
+        std::size_t k = 0;
+        for (const auto& img : obs->images) {
+          if (k++) line << ", ";
+          line << img.camera
+               << "(3x" << img.height << "x" << img.width << ")";
+        }
+        line << "] prompt=\"" << obs->task << "\"\n";
+        std::cerr << line.str();
+      } catch (...) {
+        // Logging is best-effort; do not propagate.
+      }
+
+      transport_->push_observation(*obs);
+
+      // Poll for the reply chunk (θ=0 cadence: the cycle re-synchronizes on
+      // arrival, exactly like the old blocking round_trip). The 1 ms tick is
+      // noise against ~1 s inference, and using inference_cv_ keeps the wait
+      // shutdown-interruptible. Exits: chunk, shutdown, or transport gone
+      // unhealthy (a disconnected transport polls nullopt forever). NOT on
+      // pause — a chunk completing mid-pause is still applied, as before.
+      std::optional<ActionChunk> chunk;
+      while (inference_running_.load(std::memory_order_acquire)) {
+        chunk = transport_->try_poll_chunk();
+        if (chunk) break;
+        if (transport_->status().state !=
+            TransportStatus::State::kConnected) {
+          break;  // next cycle's status poll logs the transition
+        }
+        std::unique_lock<std::mutex> lk(inference_mu_);
+        inference_cv_.wait_for(lk, std::chrono::milliseconds(1), [this] {
+          return !inference_running_.load(std::memory_order_acquire);
+        });
+      }
+
+      if (chunk) {
+        const auto t_recv = clock::now();
+        // Push-to-arrival latency: true round trip plus up to one poll tick.
+        // Same field name as the old blocking measurement (paired logs).
+        const auto rt_ms =
+          std::chrono::duration<double, std::milli>(t_recv - t_send).count();
+        std::cerr << "[policy_client:" << name() << "] req#" << req_seq
+                  << " round_trip=" << std::fixed << std::setprecision(1)
+                  << rt_ms << " ms\n";
+        apply_chunk_(std::move(*chunk), req_seq, rt_ms);
+      }
+    }
+
+    next += period;
+    std::unique_lock<std::mutex> lk(inference_mu_);
+    inference_cv_.wait_until(lk, next, [this] {
+      return !inference_running_.load(std::memory_order_acquire);
+    });
+  }
+}
+
+int64_t PolicyClient::current_timestep_(
+    std::chrono::steady_clock::time_point now) const noexcept {
+  const auto epoch = inference_epoch_;
+  if (epoch.time_since_epoch().count() == 0) {
+    return 0;  // no active window yet
+  }
+  const double rate = control_rate_hz_.load(std::memory_order_acquire);
+  if (!(rate > 0.0)) {
+    return 0;  // control rate unknown — the clock cannot advance
+  }
+  const double secs = std::chrono::duration<double>(now - epoch).count();
+  if (secs <= 0.0) {
+    return 0;
+  }
+  return static_cast<int64_t>(std::floor(secs * rate));
+}
+
+void PolicyClient::wait_for_fire_point_() {
+  // Read the target captured by the previous cycle's apply_chunk_. Tracking
+  // it here (rather than asking the slot via exhaustion_time) is deliberate:
+  // chunk N+1 lands in the slot's pending_ slot, and the slot's latest_ is
+  // only swapped to N+1 by the next face sample(), which happens up to one
+  // face period later. Reading the slot at the top of cycle N+2 therefore
+  // sees chunk N's already-expired time and the wait short-circuits. We
+  // instead wait for the *applied* chunk's firing instant (θ point).
+  const auto target = next_chunk_fire_target_;
+  // Default-constructed (epoch zero) signals "no chunk applied yet" — first
+  // cycle of an active window or just after a pause clear. Proceed
+  // immediately; the freshness barrier still holds us off until a record
+  // per subscription is in the cache.
+  if (target.time_since_epoch().count() == 0) {
+    return;
+  }
+  const auto now = std::chrono::steady_clock::now();
+  if (target <= now) {
+    // Already exhausted (e.g. an inference round-trip was longer than the
+    // chunk's playback duration). Pack right away.
+    return;
+  }
+  std::unique_lock<std::mutex> lk(inference_mu_);
+  inference_cv_.wait_until(lk, target, [this] {
+    // Wake immediately on pause/shutdown. Chunk delivery and observation
+    // arrivals don't signal inference_cv_, so they can't false-wake us.
+    return !inference_running_.load(std::memory_order_acquire) ||
+           !inference_active_.load(std::memory_order_acquire);
+  });
+}
+
+double PolicyClient::wait_for_fresh_observations_() {
+  using clock = std::chrono::steady_clock;
+  const auto start = clock::now();
+  // RAII-style timer that always reports the wait duration in ms, regardless
+  // of how the function exits (success, timeout, or shutdown race).
+  auto elapsed_ms = [&]() {
+    return std::chrono::duration<double, std::milli>(clock::now() - start)
+      .count();
+  };
+
+  // Snapshot baseline generation per subscription, then block on the CV until
+  // every counter has advanced. Implements the openpi-equivalent of clearing
+  // each camera's new_frame_event before issuing async_read.
+  std::unordered_map<std::string, uint64_t> baseline;
+  baseline.reserve(cfg_.subscriptions.size());
+
+  std::unique_lock<std::mutex> lk(cache_mu_);
+  for (const auto& sub : cfg_.subscriptions) {
+    // cache_gen_[id] was initialized to 0 in init_(); the map already
+    // contains every subscription key. Use at() to assert that invariant
+    // under hardened builds.
+    baseline[sub.record_id] = cache_gen_.at(sub.record_id);
+  }
+
+  // Distinguish "every sub has delivered at least once since baseline" (true)
+  // from "shutdown / pause requested" (also true; outer loop reacts) for the
+  // post-wait diagnostic.
+  const bool first_wait = !primed_observation_cache_;
+  if (first_wait) {
+    std::cerr << "[policy_client:" << name()
+              << "] waiting for first observation from "
+              << cfg_.subscriptions.size() << " subscription(s)...\n";
+  }
+
+  const auto timeout = std::chrono::milliseconds(
+    static_cast<int64_t>(cfg_.freshness_timeout_ms));
+
+  auto all_advanced = [&]() {
+    for (const auto& sub : cfg_.subscriptions) {
+      if (cache_gen_.at(sub.record_id) <= baseline.at(sub.record_id)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const bool advanced = cache_fresh_cv_.wait_for(lk, timeout, [&]() {
+    if (!inference_running_.load(std::memory_order_acquire)) return true;
+    if (!inference_active_.load(std::memory_order_acquire)) return true;
+    return all_advanced();
+  });
+
+  if (!inference_running_.load(std::memory_order_acquire) ||
+      !inference_active_.load(std::memory_order_acquire)) {
+    // Shutdown / pause raced the wait; outer loop handles it.
+    return elapsed_ms();
+  }
+
+  if (advanced && all_advanced()) {
+    if (first_wait) {
+      std::cerr << "[policy_client:" << name()
+                << "] observation cache primed in "
+                << std::fixed << std::setprecision(2)
+                << elapsed_ms() / 1000.0 << "s\n";
+      primed_observation_cache_ = true;
+    }
+    return elapsed_ms();
+  }
+
+  // Timeout. Identify stale subscriptions for the one-shot warning.
+  std::vector<std::string> stale;
+  for (const auto& sub : cfg_.subscriptions) {
+    if (cache_gen_.at(sub.record_id) <= baseline.at(sub.record_id)) {
+      stale.push_back(sub.record_id);
+    }
+  }
+  lk.unlock();  // release before formatting / logging
+
+  std::ostringstream oss;
+  oss << "freshness barrier timed out after "
+      << std::fixed << std::setprecision(0) << cfg_.freshness_timeout_ms
+      << "ms; proceeding with stale snapshot for: ";
+  for (std::size_t i = 0; i < stale.size(); ++i) {
+    oss << stale[i] << (i + 1 < stale.size() ? ", " : "");
+  }
+  warn_once_("freshness_timeout", oss.str());
+  // Latch primed_ even on first-wait timeout so the "waiting for first
+  // observation" banner doesn't repeat each cycle when a source is stuck.
+  primed_observation_cache_ = true;
+  return elapsed_ms();
+}
+
+Observation PolicyClient::pack_observation_(
+    ObservationDiagnostics& diag) {
+  std::unordered_map<std::string, std::shared_ptr<data::RecordBase>> snapshot;
+  {
+    std::lock_guard<std::mutex> lk(cache_mu_);
+    snapshot = latest_records_;
+  }
+
+  // Compute per-record age relative to packing instant. Records carry their
+  // monotonic capture timestamp; subtract from steady_clock::now() to get age
+  // in ms. NaN signals "record missing from cache" so the consumer can tell
+  // missing from fresh.
+  {
+    const uint64_t now_ns =
+      static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now().time_since_epoch()).count());
+    constexpr double kNanToMilli = 1.0 / 1e6;
+    double min_age = std::numeric_limits<double>::infinity();
+    double max_age = -std::numeric_limits<double>::infinity();
+    bool any_age = false;
+    diag.ages_ms.clear();
+    diag.ages_ms.reserve(cfg_.subscriptions.size());
+    for (const auto& sub : cfg_.subscriptions) {
+      auto it = snapshot.find(sub.record_id);
+      if (it == snapshot.end() || !it->second) {
+        diag.ages_ms[sub.record_id] = std::numeric_limits<double>::quiet_NaN();
+        continue;
+      }
+      const uint64_t rec_ns = it->second->ts.monotonic.to_ns();
+      const double age_ms =
+        rec_ns <= now_ns ? static_cast<double>(now_ns - rec_ns) * kNanToMilli
+                         : 0.0;  // clock skew guard (rec stamped after now)
+      diag.ages_ms[sub.record_id] = age_ms;
+      if (age_ms < min_age) min_age = age_ms;
+      if (age_ms > max_age) max_age = age_ms;
+      any_age = true;
+    }
+    diag.skew_ms = any_age ? max_age - min_age : 0.0;
+  }
+
+  // state: one named group per joint_layout entry, layout order. Grouping is
+  // preserved (not flattened) because flattening is lossy: LeRobot's rename
+  // map needs group identity; openpi re-flattens inside its transport.
+  Observation obs;
+  obs.captured_at = std::chrono::steady_clock::now();
+  obs.task = cfg_.prompt;
+  // Timestep Clock: control-rate ticks since this active window's epoch. Pairs
+  // with the returned chunk's base_timestep for aligned take-over.
+  obs.timestep = current_timestep_(obs.captured_at);
+  // must_go: the action buffer is empty — no chunk applied yet, or the last
+  // applied chunk has played past its final row by now. The server prioritizes
+  // such observations. At θ>0 the fire point precedes exhaustion (overlap), so
+  // must_go marks the exceptional stall/slow-server case; at θ=0 the buffer
+  // empties every cycle by design, so it is set each time.
+  obs.must_go = (next_chunk_exhaust_target_.time_since_epoch().count() == 0) ||
+                (obs.captured_at >= next_chunk_exhaust_target_);
+
+  obs.state.reserve(state_subs_.size());
+  for (std::size_t i = 0; i < state_subs_.size(); ++i) {
+    const auto* sub = state_subs_[i];
+    const int joint_count = cfg_.joint_layout[i].joint_count;
+    Observation::StateGroup group;
+    group.name = cfg_.joint_layout[i].leader_id;
+    // Per-joint motor names from config (may be empty). Transports that key
+    // state by name (LeRobot's "<name>.pos") use them; openpi ignores them.
+    group.joint_names = cfg_.joint_layout[i].joint_names;
+    auto it = snapshot.find(sub->record_id);
+    std::shared_ptr<data::RecordBase> rec =
+      (it != snapshot.end()) ? it->second : nullptr;
+    auto js = rec
+      ? std::dynamic_pointer_cast<data::JointStateRecord>(rec)
+      : nullptr;
+    if (!js) {
+      if (!rec) {
+        warn_once_("missing_record:" + sub->record_id,
+                   "no record yet for '" + sub->record_id +
+                   "', zero-filling state slice");
+      } else {
+        warn_once_("unsupported_record:" + sub->record_id,
+                   "record '" + sub->record_id +
+                   "' is not a JointStateRecord; zero-filling state slice");
+      }
+      group.values.assign(static_cast<std::size_t>(joint_count), 0.0f);
+    } else {
+      group.values = js->positions;
+      // Pad-or-truncate to the layout's declared width (resize zero-fills).
+      group.values.resize(static_cast<std::size_t>(joint_count), 0.0f);
+    }
+    obs.state.push_back(std::move(group));
+  }
+
+  obs.images.reserve(image_subs_.size());
+  for (std::size_t i = 0; i < image_subs_.size(); ++i) {
+    const auto* sub = image_subs_[i];
+    const std::string& cam_key = image_camera_keys_[i];
+    auto it = snapshot.find(sub->record_id);
+    std::shared_ptr<data::RecordBase> rec =
+      (it != snapshot.end()) ? it->second : nullptr;
+    if (!rec) {
+      warn_once_("missing_record:" + sub->record_id,
+                 "no image record yet for '" + sub->record_id + "'");
+      if (sub->resize.has_value()) {
+        obs.images.push_back(
+          zero_image_(cam_key, sub->resize->first, sub->resize->second));
+      }
+      continue;
+    }
+    if (auto img = pack_image_(rec, *sub, cam_key)) {
+      obs.images.push_back(std::move(*img));
+    }
+  }
+
+  return obs;
+}
+
+std::optional<Observation::Image> PolicyClient::pack_image_(
+    const std::shared_ptr<data::RecordBase>& rec,
+    const configuration::PolicyClientSubscriptionConfig& sub,
+    const std::string& camera_key) {
+  auto img_ptr = std::dynamic_pointer_cast<data::ImageRecord>(rec);
+  if (!img_ptr || img_ptr->image.empty()) {
+    warn_once_("unsupported_image:" + sub.record_id,
+               "record '" + sub.record_id +
+               "' is not a non-empty ImageRecord; skipping camera '" +
+               camera_key + "'");
+    if (sub.resize.has_value()) {
+      return zero_image_(camera_key, sub.resize->first, sub.resize->second);
+    }
+    return std::nullopt;
+  }
+  const auto& img = *img_ptr;
+
+  int target_w = img.image.cols;
+  int target_h = img.image.rows;
+  if (sub.resize.has_value()) {
+    target_w = sub.resize->first;
+    target_h = sub.resize->second;
+  }
+
+  cv::Mat resized;
+  if (target_w != img.image.cols || target_h != img.image.rows) {
+    cv::resize(img.image, resized, cv::Size(target_w, target_h));
+  } else {
+    resized = img.image;
+  }
+
+  // The neutral Observation contract is TRUE RGB, always. Producers deliver
+  // either rgb8 (camera-native, pass through) or bgr8 (already converted by
+  // the producer; convert back). Any model-specific channel quirk (openpi's
+  // BGR training convention) is applied inside that transport, never here.
+  cv::Mat rgb;
+  if (img.encoding == "bgr8") {
+    cv::cvtColor(resized, rgb, cv::COLOR_BGR2RGB);
+  } else {
+    rgb = resized;
+  }
+
+  Observation::Image out;
+  out.camera = camera_key;
+  out.width = rgb.cols;
+  out.height = rgb.rows;
+  const std::size_t row_bytes = static_cast<std::size_t>(rgb.cols) * 3;
+  out.rgb.resize(static_cast<std::size_t>(rgb.rows) * row_bytes);
+  // Row-wise copy: cv::Mat rows may be padded (non-continuous), e.g. for
+  // views; HWC interleaved layout is shared by cv::Mat and the contract.
+  for (int y = 0; y < rgb.rows; ++y) {
+    std::memcpy(out.rgb.data() + static_cast<std::size_t>(y) * row_bytes,
+                rgb.ptr<uint8_t>(y), row_bytes);
+  }
+  return out;
+}
+
+Observation::Image PolicyClient::zero_image_(
+    const std::string& camera_key, int width, int height) const {
+  Observation::Image img;
+  img.camera = camera_key;
+  img.width = width;
+  img.height = height;
+  img.rgb.assign(static_cast<std::size_t>(width) *
+                 static_cast<std::size_t>(height) * 3,
+                 uint8_t{0});
+  return img;
+}
+
+void PolicyClient::apply_chunk_(ActionChunk chunk_in,
+                                uint64_t request_seq, double rt_ms) {
+  // Wire validation (shape/dtype/size) happened in the transport's decoder,
+  // which also stamped chunk_seq (per-connection) and received_at. The
+  // client's own gate is the one fact the transport cannot know: the chunk
+  // width must match the configured joint layout.
+  if (chunk_in.N != total_n_) {
+    warn_once_("chunk_n_mismatch",
+               "policy reply actions N=" + std::to_string(chunk_in.N) +
+               " does not match sum(joint_count)=" + std::to_string(total_n_) +
+               "; ignoring chunk (hold-last-action)");
+    return;
+  }
+
+  auto chunk = std::make_shared<const ActionChunk>(std::move(chunk_in));
+
+  try {
+    std::ostringstream line;
+    line << "[policy_client:" << name() << "] chunk#" << chunk->chunk_seq
+         << " T=" << chunk->T << " N=" << chunk->N << " row[0]=["
+         << std::fixed << std::setprecision(3);
+    for (int i = 0; i < chunk->N; ++i) {
+      line << chunk->data[i] << (i + 1 < chunk->N ? ", " : "");
+    }
+    line << "]\n";
+    std::cerr << line.str();
+  } catch (...) {
+    // Logging is best-effort.
+  }
+
+  log_response_(request_seq, chunk->received_at, rt_ms, chunk);
+
+  const double rate = control_rate_hz_.load(std::memory_order_acquire);
+
+  // Async-overlap path (drain threshold θ>0): the chunk was inferred while the
+  // previous one still plays, so it takes over immediately, aligned to the
+  // Timestep Clock. Row 0 anchors at epoch + base_timestep/rate; rows already
+  // in the past are skipped by sample(), and an all-past chunk is discarded.
+  if (cfg_.drain_threshold > 0.0 && rate > 0.0 && chunk->T > 0 &&
+      inference_epoch_.time_since_epoch().count() != 0) {
+    const auto now = std::chrono::steady_clock::now();
+    const int64_t start_row = current_timestep_(now) - chunk->base_timestep;
+    if (start_row >= chunk->T) {
+      warn_once_("chunk_all_past",
+                 "policy reply chunk is already fully in the past "
+                 "(base_timestep behind the timestep clock); discarding");
+      return;  // hold-last-action; keep the chunk currently playing
+    }
+    const auto tick_ns = [rate](int64_t ticks) {
+      return std::chrono::nanoseconds(
+        static_cast<int64_t>(static_cast<double>(ticks) / rate * 1e9));
+    };
+    const auto aligned_start = inference_epoch_ + tick_ns(chunk->base_timestep);
+    next_chunk_exhaust_target_ = aligned_start + tick_ns(chunk->T);
+    // Fire the next observation when the remaining playable fraction drops to
+    // θ: at (1-θ)·T ticks into this chunk.
+    const double play_fraction = 1.0 - cfg_.drain_threshold;
+    next_chunk_fire_target_ = aligned_start + std::chrono::nanoseconds(
+      static_cast<int64_t>(play_fraction * static_cast<double>(chunk->T) /
+                           rate * 1e9));
+    chunk_slot_.swap_in_aligned(chunk, aligned_start, now);
+    chunks_published_.fetch_add(1, std::memory_order_relaxed);
+    return;
+  }
+
+  // Consume-fully path (openpi θ=0 cadence) — unchanged.
+  // Compute the freshly-applied chunk's expected exhaust BEFORE moving it
+  // into the slot — once swap_in runs we no longer own the pointer.
+  // The new chunk's playback_start_ inside the slot will be
+  // max(received_at, prev_chunk_exhaust) (the slot promotes pending → latest
+  // only when the previous chunk has played to its last row). Mirror that
+  // here so the next cycle's wait gates on the right instant regardless of
+  // whether the previous chunk was still playing when this one arrived.
+  if (rate > 0.0 && chunk->T > 0) {
+    const auto duration_ns = std::chrono::nanoseconds(
+      static_cast<int64_t>(
+        static_cast<double>(chunk->T) / rate * 1e9));
+    const auto base = (next_chunk_exhaust_target_ > chunk->received_at)
+      ? next_chunk_exhaust_target_   // previous chunk hadn't exhausted yet
+      : chunk->received_at;           // previous chunk done; we play from now
+    next_chunk_exhaust_target_ = base + duration_ns;
+    // θ=0 on this path (θ>0 takes the aligned branch above), so the fire point
+    // coincides with exhaustion. Compute it via the same θ rule for clarity.
+    const double play_fraction = 1.0 - cfg_.drain_threshold;
+    next_chunk_fire_target_ = base + std::chrono::nanoseconds(
+      static_cast<int64_t>(play_fraction * static_cast<double>(chunk->T) /
+                           rate * 1e9));
+  }
+
+  chunk_slot_.swap_in(std::move(chunk));
+  chunks_published_.fetch_add(1, std::memory_order_relaxed);
+}
+
+namespace {
+
+// Expand a leading "~" or "~/..." to the value of $HOME. Other paths pass
+// through unchanged.
+std::filesystem::path expand_tilde(const std::string& path) {
+  if (path.empty() || path[0] != '~') return path;
+  const char* home = std::getenv("HOME");
+  if (!home || *home == '\0') return path;
+  if (path == "~") return home;
+  if (path.size() >= 2 && path[1] == '/') {
+    return std::filesystem::path(home) / path.substr(2);
+  }
+  return path;
+}
+
+// Render a steady_clock::time_point as seconds since steady epoch (relative,
+// for inter-event timing) and a wall-clock ISO 8601 instant (absolute).
+struct LogTimestamps {
+  double mono_s;
+  std::string wall_iso;
+};
+LogTimestamps render_timestamps(std::chrono::steady_clock::time_point t_mono,
+                                std::chrono::steady_clock::time_point t0) {
+  LogTimestamps ts;
+  ts.mono_s = std::chrono::duration<double>(t_mono - t0).count();
+  // Wall-clock approximation: take system_clock::now() at log time. This is
+  // close enough for cross-process comparison (the openpi reference will
+  // capture the same wall instant for its own line).
+  const auto sys_now = std::chrono::system_clock::now();
+  const auto sec = std::chrono::time_point_cast<std::chrono::seconds>(sys_now);
+  const auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+                    sys_now - sec).count();
+  std::time_t tt = std::chrono::system_clock::to_time_t(sec);
+  std::tm tm{};
+#if defined(_WIN32)
+  gmtime_s(&tm, &tt);
+#else
+  gmtime_r(&tt, &tm);
+#endif
+  std::ostringstream oss;
+  oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S")
+      << '.' << std::setw(6) << std::setfill('0') << us << 'Z';
+  ts.wall_iso = oss.str();
+  return ts;
+}
+
+// Compute per-channel mean over HWC uint8 bytes (interleaved RGB layout).
+std::vector<double> per_channel_mean_hwc(const uint8_t* bytes, int H, int W) {
+  std::vector<double> out(3, 0.0);
+  if (!bytes || H <= 0 || W <= 0) return out;
+  const std::size_t pixels = static_cast<std::size_t>(H) *
+                             static_cast<std::size_t>(W);
+  uint64_t sums[3] = {0, 0, 0};
+  for (std::size_t i = 0; i < pixels; ++i) {
+    sums[0] += bytes[i * 3];
+    sums[1] += bytes[i * 3 + 1];
+    sums[2] += bytes[i * 3 + 2];
+  }
+  for (int c = 0; c < 3; ++c) {
+    out[static_cast<std::size_t>(c)] =
+      static_cast<double>(sums[c]) / static_cast<double>(pixels);
+  }
+  return out;
+}
+
+}  // namespace
+
+void PolicyClient::open_log_file_(const std::string& log_path) {
+  if (log_path.empty()) return;
+  try {
+    const auto resolved = expand_tilde(log_path);
+    std::error_code ec;
+    if (resolved.has_parent_path()) {
+      std::filesystem::create_directories(resolved.parent_path(), ec);
+      if (ec) {
+        std::cerr << "[policy_client:" << name()
+                  << "] failed to create log dir '"
+                  << resolved.parent_path() << "': " << ec.message() << "\n";
+        return;
+      }
+    }
+    log_file_.open(resolved, std::ios::out | std::ios::app);
+    if (!log_file_) {
+      std::cerr << "[policy_client:" << name()
+                << "] failed to open log file '" << resolved << "'\n";
+      return;
+    }
+    log_t0_ = std::chrono::steady_clock::now();
+    std::cerr << "[policy_client:" << name()
+              << "] JSONL log → " << resolved << "\n";
+  } catch (const std::exception& e) {
+    std::cerr << "[policy_client:" << name()
+              << "] open_log_file_ threw: " << e.what() << "\n";
+  }
+}
+
+void PolicyClient::log_request_(uint64_t seq,
+                                std::chrono::steady_clock::time_point t_send,
+                                const Observation& obs,
+                                const ObservationDiagnostics& diag) {
+  if (!log_file_.is_open()) return;
+  try {
+    const auto ts = render_timestamps(t_send, log_t0_);
+
+    nlohmann::json line;
+    line["event"] = "request";
+    line["seq"] = seq;
+    line["t_mono_s"] = ts.mono_s;
+    line["t_wall"] = ts.wall_iso;
+
+    // Diagnostics — emitted before the heavy payload fields so a casual `tail`
+    // shows the small fields first. obs_collect_ms uses the same field name
+    // as the openpi side so they collate cleanly even though the underlying
+    // measurement differs (freshness wait vs. get_observation duration).
+    line["obs_collect_ms"] = diag.freshness_wait_ms;
+    line["cycle_interval_ms"] = diag.cycle_interval_ms;
+    {
+      nlohmann::json ages = nlohmann::json::object();
+      for (const auto& [rec_id, age] : diag.ages_ms) {
+        // JSON has no NaN; serialize missing records as null instead.
+        if (std::isnan(age)) {
+          ages[rec_id] = nullptr;
+        } else {
+          ages[rec_id] = age;
+        }
+      }
+      line["obs_ages_ms"] = std::move(ages);
+    }
+    line["obs_skew_ms"] = diag.skew_ms;
+
+    // State: flat concatenation in group order — the same field and shape the
+    // wire-JSON version logged, so existing paired-log tooling keeps working.
+    nlohmann::json state_arr = nlohmann::json::array();
+    for (const auto& group : obs.state) {
+      for (float v : group.values) state_arr.push_back(v);
+    }
+    line["state"] = std::move(state_arr);
+
+    // Per-camera shape + per-channel mean. mean_per_ch describes the NEUTRAL
+    // true-RGB bytes ([R, G, B] of the scene), not the wire bytes: against a
+    // reference openpi client log (which records the wire's BGR training
+    // quirk), channels 0 and 2 appear swapped BY DESIGN — not a bug.
+    nlohmann::json images = nlohmann::json::object();
+    for (const auto& img : obs.images) {
+      nlohmann::json entry;
+      entry["shape"] = {3, img.height, img.width};
+      entry["mean_per_ch"] =
+        per_channel_mean_hwc(img.rgb.data(), img.height, img.width);
+      images[img.camera] = std::move(entry);
+    }
+    line["images"] = std::move(images);
+
+    line["prompt"] = obs.task;
+    {
+      std::lock_guard<std::mutex> lk(log_mu_);
+      log_file_ << line.dump() << '\n';
+      log_file_.flush();
+    }
+  } catch (...) {
+    // Logging is best-effort.
+  }
+}
+
+void PolicyClient::log_response_(
+    uint64_t seq,
+    std::chrono::steady_clock::time_point t_recv,
+    double rt_ms,
+    const std::shared_ptr<const ActionChunk>& chunk) {
+  if (!log_file_.is_open() || !chunk) return;
+  try {
+    const auto ts = render_timestamps(t_recv, log_t0_);
+    nlohmann::json line;
+    line["event"] = "response";
+    line["seq"] = seq;
+    line["t_mono_s"] = ts.mono_s;
+    line["t_wall"] = ts.wall_iso;
+    line["rt_ms"] = rt_ms;
+    line["T"] = chunk->T;
+    line["N"] = chunk->N;
+    // No "dtype" field: the wire dtype is a transport-internal fact now (the
+    // decoder normalizes f64 to f32); logging a constant here would fabricate
+    // wire evidence in a log used for wire-parity diffs.
+
+    auto row_to_json = [&](int t) {
+      nlohmann::json arr = nlohmann::json::array();
+      const std::size_t start =
+        static_cast<std::size_t>(t) * static_cast<std::size_t>(chunk->N);
+      for (int n = 0; n < chunk->N; ++n) {
+        arr.push_back(chunk->data[start + static_cast<std::size_t>(n)]);
+      }
+      return arr;
+    };
+    if (chunk->T > 0) line["row0"] = row_to_json(0);
+    if (chunk->T > 1) line["row1"] = row_to_json(1);
+    if (chunk->T > 0) line["row_last"] = row_to_json(chunk->T - 1);
+    line["chunk_seq"] = chunk->chunk_seq;
+
+    // ─ Chunk shape diagnostics ─────────────────────────────────────────────
+    // col_l1: per-column total L1 across the chunk. Identifies which joints
+    // the policy is actually moving and by how much. Comparing this field
+    // between openpi and SDK runs at matched seqs immediately surfaces
+    // policy disagreement at the column level (e.g., one side is gripper-
+    // active, the other isn't).
+    if (chunk->T > 1 && chunk->N > 0) {
+      std::vector<double> col_l1(static_cast<std::size_t>(chunk->N), 0.0);
+      for (int t = 1; t < chunk->T; ++t) {
+        const std::size_t row_a =
+          static_cast<std::size_t>(t - 1) * static_cast<std::size_t>(chunk->N);
+        const std::size_t row_b =
+          static_cast<std::size_t>(t) * static_cast<std::size_t>(chunk->N);
+        for (int n = 0; n < chunk->N; ++n) {
+          col_l1[static_cast<std::size_t>(n)] +=
+            std::abs(chunk->data[row_b + static_cast<std::size_t>(n)] -
+                     chunk->data[row_a + static_cast<std::size_t>(n)]);
+        }
+      }
+      line["col_l1"] = col_l1;
+    }
+
+    // row_l1_samples: per-row L1 across all columns at five quartile points
+    // (rows 0,1 transition; T/4, T/2, 3T/4 transitions; T-1 transition).
+    // Cheap shape-of-trajectory fingerprint, length 5.
+    if (chunk->T > 1 && chunk->N > 0) {
+      auto row_l1_at = [&](int t) {
+        if (t <= 0 || t >= chunk->T) return 0.0;
+        const std::size_t row_a =
+          static_cast<std::size_t>(t - 1) * static_cast<std::size_t>(chunk->N);
+        const std::size_t row_b =
+          static_cast<std::size_t>(t) * static_cast<std::size_t>(chunk->N);
+        double s = 0.0;
+        for (int n = 0; n < chunk->N; ++n) {
+          s += std::abs(chunk->data[row_b + static_cast<std::size_t>(n)] -
+                        chunk->data[row_a + static_cast<std::size_t>(n)]);
+        }
+        return s;
+      };
+      const int T = chunk->T;
+      nlohmann::json samples = nlohmann::json::array();
+      samples.push_back(row_l1_at(1));
+      samples.push_back(row_l1_at(std::max(1, T / 4)));
+      samples.push_back(row_l1_at(std::max(1, T / 2)));
+      samples.push_back(row_l1_at(std::max(1, (3 * T) / 4)));
+      samples.push_back(row_l1_at(T - 1));
+      line["row_l1_samples"] = std::move(samples);
+    }
+
+    // gripper_traj_per_arm: trajectory of each arm's last column across the
+    // chunk, keyed by leader_id. Diagnoses the "block not released" case
+    // directly: a chunk that doesn't drive the gripper toward an open value
+    // means the policy itself isn't commanding a release. Convention: the
+    // gripper is the last joint of each layout entry.
+    if (chunk->T > 0 && chunk->N > 0) {
+      nlohmann::json grip = nlohmann::json::object();
+      for (const auto& row : cfg_.joint_layout) {
+        if (row.joint_count <= 0) continue;
+        const int col = row.joint_offset + row.joint_count - 1;
+        if (col < 0 || col >= chunk->N) continue;
+        nlohmann::json traj = nlohmann::json::array();
+        for (int t = 0; t < chunk->T; ++t) {
+          const std::size_t idx =
+            static_cast<std::size_t>(t) * static_cast<std::size_t>(chunk->N) +
+            static_cast<std::size_t>(col);
+          traj.push_back(chunk->data[idx]);
+        }
+        grip[row.leader_id] = std::move(traj);
+      }
+      line["gripper_traj_per_arm"] = std::move(grip);
+    }
+
+    {
+      std::lock_guard<std::mutex> lk(log_mu_);
+      log_file_ << line.dump() << '\n';
+      log_file_.flush();
+    }
+  } catch (...) {
+    // Logging is best-effort.
+  }
+}
+
+void PolicyClient::log_tick_(
+    const std::string& face_id,
+    std::chrono::steady_clock::time_point t,
+    const std::vector<float>& action,
+    const ChunkSlot::SampleInfo* info_ptr) {
+  // Cheap guard before any allocation: tick logging is best-effort and
+  // must add minimal overhead to the real-time face.read() path.
+  if (!log_file_.is_open()) return;
+  try {
+    const auto ts = render_timestamps(t, log_t0_);
+    nlohmann::json line;
+    line["event"] = "tick";
+    line["t_mono_s"] = ts.mono_s;
+    line["t_wall"] = ts.wall_iso;
+    line["face_id"] = face_id;
+    line["action"] = action;
+    if (info_ptr) {
+      line["chunk_seq"] = info_ptr->chunk_seq;
+      line["t_idx"] = info_ptr->t_idx;
+      line["T"] = info_ptr->T;
+      line["saturated"] = info_ptr->saturated;
+      line["blend_active"] = info_ptr->blend_active;
+    }
+    {
+      std::lock_guard<std::mutex> lk(log_mu_);
+      log_file_ << line.dump() << '\n';
+      // No flush per tick — 60 lines/s × flush() would dominate CPU.
+      // The file stream's internal buffer flushes on overflow; the
+      // request/response paths flush(), which also flushes any buffered
+      // tick lines, so on-disk completeness is bounded by inference
+      // cadence (~2 s).
+    }
+  } catch (...) {
+    // Logging is best-effort.
+  }
+}
+
+void PolicyClient::warn_once_(const std::string& key, const std::string& message) {
+  bool first = false;
+  {
+    std::lock_guard<std::mutex> lk(warn_mu_);
+    auto [it, inserted] = warned_.emplace(key, true);
+    (void)it;
+    first = inserted;
+  }
+  if (!first) {
+    return;
+  }
+  try {
+    std::cerr << "[policy_client:" << name() << "] " << message << "\n";
+  } catch (...) {
+    // Logging failures are not propagated.
+  }
+}
+
+// ── PolicyClient::Face ───────────────────────────────────────────────────────
+
+PolicyClient::Face::Face(PolicyClient* owner, std::string id,
+                         int joint_offset, int joint_count)
+  : HardwareComponent(std::move(id)),
+    owner_(owner),
+    joint_offset_(joint_offset),
+    joint_count_(joint_count) {}
+
+std::vector<float> PolicyClient::Face::read() noexcept {
+  try {
+    const auto now = std::chrono::steady_clock::now();
+    const auto info = owner_->chunk_slot_.sample_with_info(
+      now,
+      owner_->total_n_,
+      owner_->control_rate_hz_.load(std::memory_order_acquire));
+
+    std::vector<float> out(static_cast<std::size_t>(joint_count_), 0.0f);
+    const int avail = static_cast<int>(info.row.size());
+    const int begin = std::min(joint_offset_, avail);
+    const int end = std::min(joint_offset_ + joint_count_, avail);
+    if (end > begin) {
+      std::copy(info.row.begin() + begin, info.row.begin() + end, out.begin());
+    }
+    // EMA smoothing: layered on top of the arm's write_moving_time_s
+    // controller filter to reject per-row chunk noise. Two alphas — one
+    // for the arm joints and a separate one for the last joint (gripper
+    // by convention). The gripper alpha defaults to 1.0 (pass-through)
+    // because gripper open/close is a fast transient that needs to
+    // reach full extent within a few rows; filtering it like the arm
+    // joints causes incomplete grasps. α=1.0 is a no-op on either side;
+    // the filter activates only when at least one channel needs it.
+    // prev_out_ seeds itself from the first non-trivial read so we never
+    // blend against zeros on the first tick.
+    const double alpha_arm = owner_->cfg_.output_ema_alpha;
+    const double alpha_grip = owner_->cfg_.output_ema_alpha_gripper;
+    const bool filter_arm = (alpha_arm > 0.0 && alpha_arm < 1.0);
+    const bool filter_grip = (alpha_grip > 0.0 && alpha_grip < 1.0);
+    if (filter_arm || filter_grip) {
+      if (prev_out_.size() == out.size()) {
+        const float a_arm = static_cast<float>(alpha_arm);
+        const float a_grip = static_cast<float>(alpha_grip);
+        const std::size_t grip_idx =
+          out.empty() ? 0 : out.size() - 1;  // last joint of the slice
+        for (std::size_t i = 0; i < out.size(); ++i) {
+          const bool is_grip = (i == grip_idx);
+          const float a = is_grip ? a_grip : a_arm;
+          // Skip the blend entirely on channels whose alpha is 1.0 — that
+          // preserves bit-for-bit pass-through and avoids needless float
+          // rounding when only one of the two filters is active.
+          if (a >= 1.0f) continue;
+          const float one_minus = 1.0f - a;
+          out[i] = a * out[i] + one_minus * prev_out_[i];
+        }
+      }
+      // Cache for next tick whether or not any channel was filtered.
+      prev_out_ = out;
+    }
+    // Per-tick action log. log_tick_ early-exits when no log file is open,
+    // so this is essentially free in non-diagnostic runs.
+    try {
+      owner_->log_tick_(get_identifier(), now, out, &info);
+    } catch (...) {
+      // Logging must never propagate into the real-time control loop.
+    }
+    return out;
+  } catch (...) {
+    try {
+      return std::vector<float>(static_cast<std::size_t>(joint_count_), 0.0f);
+    } catch (...) {
+      return std::vector<float>{};
+    }
+  }
+}
+
+}  // namespace trossen::hw::policy

--- a/src/hw/policy/policy_client.cpp
+++ b/src/hw/policy/policy_client.cpp
@@ -58,14 +58,46 @@ bool is_expected_camera(const std::string& key) {
 
 }  // namespace
 
+// State shared (by shared_ptr) between a PolicyClient and its Faces. Face::read
+// touches ONLY this block, so a Face that outlives the client stays safe. The
+// JSONL log sink lives here (not on PolicyClient) for the same reason: a
+// surviving Face can still emit tick lines, and the ofstream is closed only
+// when the last owner — client or Face — drops. All scalars are atomic because
+// the inference thread writes them while Face threads read them.
+struct PolicyClient::SharedState {
+  ChunkSlot chunk_slot;
+  std::atomic<int> total_n{0};
+  std::atomic<double> control_rate_hz{30.0};
+  std::atomic<double> output_ema_alpha{1.0};
+  std::atomic<double> output_ema_alpha_gripper{1.0};
+
+  // JSONL log sink, shared with the owning client's request/response logging.
+  // The mutex serializes line writes so multi-arm setups don't interleave
+  // bytes mid-line.
+  std::ofstream log_file;
+  std::mutex log_mu;
+  std::chrono::steady_clock::time_point log_t0{};
+
+  /// Append one per-tick action line. Best-effort; a no-op when no log file is
+  /// open. Safe to call from any Face thread and after the owning client is
+  /// gone (the sink lives as long as this block). Defined out-of-line below,
+  /// after the timestamp helper it depends on.
+  void log_tick(const std::string& face_id,
+                std::chrono::steady_clock::time_point t,
+                const std::vector<float>& action,
+                const ChunkSlot::SampleInfo* info_ptr) noexcept;
+};
+
 PolicyClient::PolicyClient(std::string id)
   : HardwareComponent(id),
-    ObserverBase(id) {}
+    ObserverBase(id),
+    shared_(std::make_shared<SharedState>()) {}
 
 PolicyClient::PolicyClient(configuration::PolicyClientConfig cfg,
                            std::unique_ptr<PolicyTransport> transport)
   : HardwareComponent(cfg.id),
-    ObserverBase(cfg.id) {
+    ObserverBase(cfg.id),
+    shared_(std::make_shared<SharedState>()) {
   if (!transport) {
     throw std::invalid_argument(
       "PolicyClient: transport must not be null for policy_client '" + cfg.id + "'");
@@ -75,8 +107,10 @@ PolicyClient::PolicyClient(configuration::PolicyClientConfig cfg,
 
 PolicyClient::~PolicyClient() {
   // Order: stop the inference thread + observer worker first so no live thread
-  // can dereference owner_/transport_ during teardown, then drop each Face from
-  // the registry so external lookups cannot resolve to a soon-dead object.
+  // touches transport_ during teardown, then drop each Face from the registry
+  // so external lookups cannot resolve to a soon-dead object. Faces themselves
+  // stay safe regardless of order: they hold the shared state, not the client,
+  // so any Face retained elsewhere degrades to hold-last after we are gone.
   try {
     stop();
   } catch (...) {
@@ -200,7 +234,7 @@ void PolicyClient::init_(configuration::PolicyClientConfig cfg,
         "' is already registered in ActiveHardwareRegistry");
     }
     staged.push_back(std::make_shared<Face>(
-      this, row.leader_id, row.joint_offset, row.joint_count));
+      shared_, row.leader_id, row.joint_offset, row.joint_count));
   }
 
   std::vector<std::string> registered_ids;
@@ -217,18 +251,25 @@ void PolicyClient::init_(configuration::PolicyClientConfig cfg,
       registered_ids.push_back(cfg_.joint_layout[i].leader_id);
     }
     faces_ = std::move(staged);
-    total_n_ = 0;
+    int total = 0;
     for (const auto& row : cfg_.joint_layout) {
-      total_n_ += row.joint_count;
+      total += row.joint_count;
     }
+    shared_->total_n.store(total, std::memory_order_release);
   } catch (...) {
     rollback();
     throw;
   }
 
+  // Publish the output-filter coefficients into the shared block so Faces read
+  // them without touching the client (they are fixed for the object's life).
+  shared_->output_ema_alpha.store(cfg_.output_ema_alpha, std::memory_order_release);
+  shared_->output_ema_alpha_gripper.store(
+    cfg_.output_ema_alpha_gripper, std::memory_order_release);
+
   open_log_file_(cfg_.log_path);
 
-  chunk_slot_.set_boundary_blend_s(cfg_.chunk_boundary_blend_s);
+  shared_->chunk_slot.set_boundary_blend_s(cfg_.chunk_boundary_blend_s);
 
   // Tell the slot to skip the boundary cross-fade on gripper channels. By
   // joint_layout convention each entry's last column is the gripper; with
@@ -242,7 +283,7 @@ void PolicyClient::init_(configuration::PolicyClientConfig cfg,
       gripper_indices.push_back(row.joint_offset + row.joint_count - 1);
     }
   }
-  chunk_slot_.set_boundary_blend_skip_indices(std::move(gripper_indices));
+  shared_->chunk_slot.set_boundary_blend_skip_indices(std::move(gripper_indices));
 
   configured_ = true;
 }
@@ -254,7 +295,7 @@ void PolicyClient::set_inference_active(bool active) noexcept {
     // drive the mirror after resume. Faces fall back to hold-last-action,
     // which keeps the follower at its last commanded pose during reset.
     // (ChunkSlot is internally synchronized, so this cross-thread call is safe.)
-    chunk_slot_.swap_in(nullptr);
+    shared_->chunk_slot.swap_in(nullptr);
     // The chunk-exhaust/fire wait targets are NOT touched here: they are owned
     // by the inference thread, which clears them when it wakes from the pause
     // (see inference_loop_). Writing them from this thread would race the loop.
@@ -272,15 +313,27 @@ void PolicyClient::set_inference_active(bool active) noexcept {
 
 void PolicyClient::set_control_rate_hz(double hz) noexcept {
   if (hz > 0.0) {
-    control_rate_hz_.store(hz, std::memory_order_release);
+    shared_->control_rate_hz.store(hz, std::memory_order_release);
   }
 }
 
+double PolicyClient::control_rate_hz() const noexcept {
+  return shared_->control_rate_hz.load(std::memory_order_acquire);
+}
+
+int PolicyClient::total_joint_count() const noexcept {
+  return shared_->total_n.load(std::memory_order_acquire);
+}
+
+std::shared_ptr<const ActionChunk> PolicyClient::latest_chunk() const noexcept {
+  return shared_->chunk_slot.peek();
+}
+
 std::vector<float> PolicyClient::current_command() const {
-  return chunk_slot_.sample(
+  return shared_->chunk_slot.sample(
     std::chrono::steady_clock::now(),
-    total_n_,
-    control_rate_hz_.load(std::memory_order_acquire));
+    shared_->total_n.load(std::memory_order_acquire),
+    shared_->control_rate_hz.load(std::memory_order_acquire));
 }
 
 bool PolicyClient::on_start() {
@@ -388,7 +441,8 @@ void PolicyClient::inference_loop_() {
       next_chunk_fire_target_ = {};
     }
 
-    // One status poll per cycle (§7 failure model); log transitions only.
+    // One status poll per cycle; log transitions only (a disconnect mid-episode
+    // is one warning line, not a per-cycle error stream).
     {
       const TransportStatus st = transport_->status();
       if (st.state != prev_transport_state) {
@@ -479,6 +533,17 @@ void PolicyClient::inference_loop_() {
       // shutdown-interruptible. Exits: chunk, shutdown, or transport gone
       // unhealthy (a disconnected transport polls nullopt forever). NOT on
       // pause — a chunk completing mid-pause is still applied, as before.
+      // Inference deadline: a half-open server can stay kConnected yet never
+      // return a chunk. Without a bound the loop would spin here forever,
+      // silently sending no further observations while the arm holds last. On
+      // the deadline we abandon this round-trip and fall through to the next
+      // cycle, which re-packs and re-pushes a fresh observation (latest-wins
+      // supersedes the abandoned one). cfg_.inference_timeout_ms <= 0 disables
+      // the bound. Logged per-occurrence (ONGOING, not warn_once_) so a
+      // persistent stall keeps surfacing.
+      const bool deadline_enabled = (cfg_.inference_timeout_ms > 0.0);
+      const auto deadline_dur = std::chrono::duration_cast<clock::duration>(
+        std::chrono::duration<double, std::milli>(cfg_.inference_timeout_ms));
       std::optional<ActionChunk> chunk;
       while (inference_running_.load(std::memory_order_acquire)) {
         chunk = transport_->try_poll_chunk();
@@ -486,6 +551,17 @@ void PolicyClient::inference_loop_() {
         if (transport_->status().state !=
             TransportStatus::State::kConnected) {
           break;  // next cycle's status poll logs the transition
+        }
+        if (deadline_enabled && (clock::now() - t_send) > deadline_dur) {
+          const double waited_ms =
+            std::chrono::duration<double, std::milli>(clock::now() - t_send)
+              .count();
+          std::cerr << "[policy_client:" << name() << "] req#" << req_seq
+                    << " no chunk after " << std::fixed << std::setprecision(0)
+                    << waited_ms << " ms (deadline "
+                    << cfg_.inference_timeout_ms
+                    << " ms); abandoning round-trip, re-observing next cycle\n";
+          break;  // abandon; the next cycle re-observes and re-pushes
         }
         std::unique_lock<std::mutex> lk(inference_mu_);
         inference_cv_.wait_for(lk, std::chrono::milliseconds(1), [this] {
@@ -520,7 +596,7 @@ int64_t PolicyClient::current_timestep_(
   if (epoch.time_since_epoch().count() == 0) {
     return 0;  // no active window yet
   }
-  const double rate = control_rate_hz_.load(std::memory_order_acquire);
+  const double rate = shared_->control_rate_hz.load(std::memory_order_acquire);
   if (!(rate > 0.0)) {
     return 0;  // control rate unknown — the clock cannot advance
   }
@@ -654,7 +730,7 @@ double PolicyClient::wait_for_fresh_observations_() {
   return elapsed_ms();
 }
 
-Observation PolicyClient::pack_observation_(
+std::optional<Observation> PolicyClient::pack_observation_(
     ObservationDiagnostics& diag) {
   std::unordered_map<std::string, std::shared_ptr<data::RecordBase>> snapshot;
   {
@@ -746,6 +822,13 @@ Observation PolicyClient::pack_observation_(
     obs.state.push_back(std::move(group));
   }
 
+  // Images: one entry per configured camera, ALWAYS in image_subs_ order and
+  // count. pack_image_ handles a null/bad/unmappable record by substituting a
+  // same-shaped zero frame (see F7), so the observation's image set never
+  // depends on which cameras happened to deliver this cycle. A std::nullopt
+  // means a configured camera cannot be represented at all yet (no valid frame
+  // and no dimensions to synthesize one); publishing an observation with a
+  // missing camera would silently change its shape, so fail the whole cycle.
   obs.images.reserve(image_subs_.size());
   for (std::size_t i = 0; i < image_subs_.size(); ++i) {
     const auto* sub = image_subs_[i];
@@ -753,18 +836,15 @@ Observation PolicyClient::pack_observation_(
     auto it = snapshot.find(sub->record_id);
     std::shared_ptr<data::RecordBase> rec =
       (it != snapshot.end()) ? it->second : nullptr;
-    if (!rec) {
-      warn_once_("missing_record:" + sub->record_id,
-                 "no image record yet for '" + sub->record_id + "'");
-      if (sub->resize.has_value()) {
-        obs.images.push_back(
-          zero_image_(cam_key, sub->resize->first, sub->resize->second));
-      }
-      continue;
+    auto img = pack_image_(rec, *sub, cam_key);
+    if (!img) {
+      warn_once_("camera_unrepresentable:" + cam_key,
+                 "cannot represent configured camera '" + cam_key +
+                 "' (no valid frame and no resize/last-known dimensions to "
+                 "synthesize a placeholder); skipping this observation");
+      return std::nullopt;
     }
-    if (auto img = pack_image_(rec, *sub, cam_key)) {
-      obs.images.push_back(std::move(*img));
-    }
+    obs.images.push_back(std::move(*img));
   }
 
   return obs;
@@ -774,16 +854,20 @@ std::optional<Observation::Image> PolicyClient::pack_image_(
     const std::shared_ptr<data::RecordBase>& rec,
     const configuration::PolicyClientSubscriptionConfig& sub,
     const std::string& camera_key) {
-  auto img_ptr = std::dynamic_pointer_cast<data::ImageRecord>(rec);
+  auto img_ptr = rec ? std::dynamic_pointer_cast<data::ImageRecord>(rec)
+                     : nullptr;
   if (!img_ptr || img_ptr->image.empty()) {
-    warn_once_("unsupported_image:" + sub.record_id,
-               "record '" + sub.record_id +
-               "' is not a non-empty ImageRecord; skipping camera '" +
-               camera_key + "'");
-    if (sub.resize.has_value()) {
-      return zero_image_(camera_key, sub.resize->first, sub.resize->second);
-    }
-    return std::nullopt;
+    // Missing / wrong-type / empty record. Substitute a same-shaped zero frame
+    // so the observation's image set stays stable regardless of which cameras
+    // delivered this cycle (see F7).
+    warn_once_(
+      "missing_image:" + sub.record_id,
+      rec ? ("record '" + sub.record_id +
+             "' is not a non-empty ImageRecord; substituting zero frame for "
+             "camera '" + camera_key + "'")
+          : ("no image record yet for '" + sub.record_id +
+             "'; substituting zero frame for camera '" + camera_key + "'"));
+    return substitute_image_(sub, camera_key);
   }
   const auto& img = *img_ptr;
 
@@ -801,21 +885,38 @@ std::optional<Observation::Image> PolicyClient::pack_image_(
     resized = img.image;
   }
 
-  // The neutral Observation contract is TRUE RGB, always. Producers deliver
-  // either rgb8 (camera-native, pass through) or bgr8 (already converted by
-  // the producer; convert back). Any model-specific channel quirk (openpi's
-  // BGR training convention) is applied inside that transport, never here.
+  // The neutral Observation contract is TRUE RGB, always. Derive the channel
+  // count from the actual Mat, NOT the encoding string: a mono8 (1-channel)
+  // frame has cols bytes/row, so copying cols*3 bytes/row would over-read the
+  // heap. mono8 is expanded to RGB; bgr8 is converted; rgb8 (and any other
+  // 3-channel frame) passes through. A channel count that cannot map to RGB
+  // is rejected via the same zero-substitute path as a missing frame. Any
+  // model-specific channel quirk (openpi's BGR training convention) is applied
+  // inside that transport, never here.
   cv::Mat rgb;
-  if (img.encoding == "bgr8") {
-    cv::cvtColor(resized, rgb, cv::COLOR_BGR2RGB);
+  const int channels = resized.channels();
+  if (channels == 1) {
+    cv::cvtColor(resized, rgb, cv::COLOR_GRAY2RGB);
+  } else if (channels == 3) {
+    if (img.encoding == "bgr8") {
+      cv::cvtColor(resized, rgb, cv::COLOR_BGR2RGB);
+    } else {
+      rgb = resized;  // rgb8 (camera-native) passes through
+    }
   } else {
-    rgb = resized;
+    warn_once_("unsupported_image_channels:" + sub.record_id,
+               "record '" + sub.record_id + "' image has " +
+               std::to_string(channels) +
+               " channels, which cannot map to RGB; substituting zero frame "
+               "for camera '" + camera_key + "'");
+    return substitute_image_(sub, camera_key);
   }
 
   Observation::Image out;
   out.camera = camera_key;
   out.width = rgb.cols;
   out.height = rgb.rows;
+  // rgb now has exactly 3 channels, so cols*3 bytes/row is valid.
   const std::size_t row_bytes = static_cast<std::size_t>(rgb.cols) * 3;
   out.rgb.resize(static_cast<std::size_t>(rgb.rows) * row_bytes);
   // Row-wise copy: cv::Mat rows may be padded (non-continuous), e.g. for
@@ -824,7 +925,34 @@ std::optional<Observation::Image> PolicyClient::pack_image_(
     std::memcpy(out.rgb.data() + static_cast<std::size_t>(y) * row_bytes,
                 rgb.ptr<uint8_t>(y), row_bytes);
   }
+  // Remember the shape so a later missing/unmappable frame for this camera can
+  // still be substituted with a correctly-sized zero frame even when no resize
+  // is configured. Inference-thread only, so no lock needed.
+  last_image_dims_[camera_key] = {out.width, out.height};
   return out;
+}
+
+std::optional<Observation::Image> PolicyClient::substitute_image_(
+    const configuration::PolicyClientSubscriptionConfig& sub,
+    const std::string& camera_key) {
+  int w = 0;
+  int h = 0;
+  if (sub.resize.has_value()) {
+    w = sub.resize->first;
+    h = sub.resize->second;
+  } else {
+    auto it = last_image_dims_.find(camera_key);
+    if (it != last_image_dims_.end()) {
+      w = it->second.first;
+      h = it->second.second;
+    }
+  }
+  if (w > 0 && h > 0) {
+    return zero_image_(camera_key, w, h);
+  }
+  // No resize and no prior frame: we cannot size a placeholder. The caller
+  // fails the whole observation rather than shipping a diverging image set.
+  return std::nullopt;
 }
 
 Observation::Image PolicyClient::zero_image_(
@@ -845,12 +973,34 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
   // which also stamped chunk_seq (per-connection) and received_at. The
   // client's own gate is the one fact the transport cannot know: the chunk
   // width must match the configured joint layout.
-  if (chunk_in.N != total_n_) {
+  const int total_n = shared_->total_n.load(std::memory_order_acquire);
+  if (chunk_in.N != total_n) {
     warn_once_("chunk_n_mismatch",
                "policy reply actions N=" + std::to_string(chunk_in.N) +
-               " does not match sum(joint_count)=" + std::to_string(total_n_) +
+               " does not match sum(joint_count)=" + std::to_string(total_n) +
                "; ignoring chunk (hold-last-action)");
+    chunks_rejected_.fetch_add(1, std::memory_order_relaxed);
     return;
+  }
+
+  // Safety gate: this chunk is about to drive physical arms. A single
+  // non-finite action (NaN/Inf from a diverged or malfunctioning server) would
+  // command a garbage pose. Scan the whole [T x N] buffer and reject the WHOLE
+  // chunk on the first non-finite element — never publish a partially
+  // sanitized chunk. Rejection is hold-last-action: the slot keeps playing the
+  // chunk it already has (or its last row). Throttled (not warn_once_) so a
+  // persistently bad server keeps surfacing rather than warning only once.
+  // NOTE: per-joint range/limit clamping is a fast-follow — this branch has no
+  // per-joint bounds surface to check against yet, so only finiteness is gated.
+  for (float v : chunk_in.data) {
+    if (!std::isfinite(v)) {
+      warn_throttled_("chunk_non_finite",
+                      "policy reply chunk contains a non-finite action "
+                      "(NaN/Inf); rejecting the whole chunk (hold-last-action)",
+                      std::chrono::milliseconds(1000));
+      chunks_rejected_.fetch_add(1, std::memory_order_relaxed);
+      return;
+    }
   }
 
   auto chunk = std::make_shared<const ActionChunk>(std::move(chunk_in));
@@ -871,7 +1021,7 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
 
   log_response_(request_seq, chunk->received_at, rt_ms, chunk);
 
-  const double rate = control_rate_hz_.load(std::memory_order_acquire);
+  const double rate = shared_->control_rate_hz.load(std::memory_order_acquire);
 
   // Async-overlap path (drain threshold θ>0): the chunk was inferred while the
   // previous one still plays, so it takes over immediately, aligned to the
@@ -880,11 +1030,27 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
   if (cfg_.drain_threshold > 0.0 && rate > 0.0 && chunk->T > 0 &&
       inference_epoch_.time_since_epoch().count() != 0) {
     const auto now = std::chrono::steady_clock::now();
-    const int64_t start_row = current_timestep_(now) - chunk->base_timestep;
+    const int64_t ts_now = current_timestep_(now);
+    const int64_t start_row = ts_now - chunk->base_timestep;
     if (start_row >= chunk->T) {
       warn_once_("chunk_all_past",
                  "policy reply chunk is already fully in the past "
                  "(base_timestep behind the timestep clock); discarding");
+      chunks_rejected_.fetch_add(1, std::memory_order_relaxed);
+      return;  // hold-last-action; keep the chunk currently playing
+    }
+    // Symmetric forward bound: a far-future base_timestep (server clock ahead,
+    // or a corrupt/garbage value) makes start_row strongly negative, so the
+    // all-past guard above passes, yet aligned_start / the fire target land far
+    // ahead — the arm would stall on hold-last for a long time. Reject any
+    // chunk claiming to start more than a full chunk's worth of ticks ahead of
+    // the timestep clock.
+    if (chunk->base_timestep - ts_now > chunk->T) {
+      warn_once_("chunk_far_future",
+                 "policy reply chunk starts more than a full chunk ahead of "
+                 "the timestep clock (base_timestep far in the future); "
+                 "discarding (hold-last-action)");
+      chunks_rejected_.fetch_add(1, std::memory_order_relaxed);
       return;  // hold-last-action; keep the chunk currently playing
     }
     const auto tick_ns = [rate](int64_t ticks) {
@@ -899,19 +1065,21 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
     next_chunk_fire_target_ = aligned_start + std::chrono::nanoseconds(
       static_cast<int64_t>(play_fraction * static_cast<double>(chunk->T) /
                            rate * 1e9));
-    chunk_slot_.swap_in_aligned(chunk, aligned_start, now);
+    shared_->chunk_slot.swap_in_aligned(chunk, aligned_start, now);
     chunks_published_.fetch_add(1, std::memory_order_relaxed);
     return;
   }
 
-  // Consume-fully path (openpi θ=0 cadence) — unchanged.
-  // Compute the freshly-applied chunk's expected exhaust BEFORE moving it
-  // into the slot — once swap_in runs we no longer own the pointer.
-  // The new chunk's playback_start_ inside the slot will be
-  // max(received_at, prev_chunk_exhaust) (the slot promotes pending → latest
-  // only when the previous chunk has played to its last row). Mirror that
-  // here so the next cycle's wait gates on the right instant regardless of
-  // whether the previous chunk was still playing when this one arrived.
+  // Consume-fully path (openpi θ=0 cadence). The two members set below are
+  // scheduling ESTIMATES the client uses to time the next cycle's fire point;
+  // they are not the slot's actual playback anchor. The slot itself parks this
+  // chunk in its pending_ slot (when one is already playing) and, on the sample
+  // tick where the current chunk exhausts (t_idx >= T), promotes it and
+  // re-anchors playback_start_ = now (that sample instant). We compute the
+  // estimate BEFORE moving the chunk into the slot — once swap_in runs we no
+  // longer own the pointer — using max(received_at, previous exhaust estimate)
+  // as the base so the next cycle's wait gates on roughly the right instant
+  // whether or not the previous chunk was still playing when this one arrived.
   if (rate > 0.0 && chunk->T > 0) {
     const auto duration_ns = std::chrono::nanoseconds(
       static_cast<int64_t>(
@@ -928,7 +1096,7 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
                            rate * 1e9));
   }
 
-  chunk_slot_.swap_in(std::move(chunk));
+  shared_->chunk_slot.swap_in(std::move(chunk));
   chunks_published_.fetch_add(1, std::memory_order_relaxed);
 }
 
@@ -1013,13 +1181,13 @@ void PolicyClient::open_log_file_(const std::string& log_path) {
         return;
       }
     }
-    log_file_.open(resolved, std::ios::out | std::ios::app);
-    if (!log_file_) {
+    shared_->log_file.open(resolved, std::ios::out | std::ios::app);
+    if (!shared_->log_file) {
       std::cerr << "[policy_client:" << name()
                 << "] failed to open log file '" << resolved << "'\n";
       return;
     }
-    log_t0_ = std::chrono::steady_clock::now();
+    shared_->log_t0 = std::chrono::steady_clock::now();
     std::cerr << "[policy_client:" << name()
               << "] JSONL log → " << resolved << "\n";
   } catch (const std::exception& e) {
@@ -1032,9 +1200,9 @@ void PolicyClient::log_request_(uint64_t seq,
                                 std::chrono::steady_clock::time_point t_send,
                                 const Observation& obs,
                                 const ObservationDiagnostics& diag) {
-  if (!log_file_.is_open()) return;
+  if (!shared_->log_file.is_open()) return;
   try {
-    const auto ts = render_timestamps(t_send, log_t0_);
+    const auto ts = render_timestamps(t_send, shared_->log_t0);
 
     nlohmann::json line;
     line["event"] = "request";
@@ -1086,9 +1254,9 @@ void PolicyClient::log_request_(uint64_t seq,
 
     line["prompt"] = obs.task;
     {
-      std::lock_guard<std::mutex> lk(log_mu_);
-      log_file_ << line.dump() << '\n';
-      log_file_.flush();
+      std::lock_guard<std::mutex> lk(shared_->log_mu);
+      shared_->log_file << line.dump() << '\n';
+      shared_->log_file.flush();
     }
   } catch (...) {
     // Logging is best-effort.
@@ -1100,9 +1268,9 @@ void PolicyClient::log_response_(
     std::chrono::steady_clock::time_point t_recv,
     double rt_ms,
     const std::shared_ptr<const ActionChunk>& chunk) {
-  if (!log_file_.is_open() || !chunk) return;
+  if (!shared_->log_file.is_open() || !chunk) return;
   try {
-    const auto ts = render_timestamps(t_recv, log_t0_);
+    const auto ts = render_timestamps(t_recv, shared_->log_t0);
     nlohmann::json line;
     line["event"] = "response";
     line["seq"] = seq;
@@ -1202,25 +1370,25 @@ void PolicyClient::log_response_(
     }
 
     {
-      std::lock_guard<std::mutex> lk(log_mu_);
-      log_file_ << line.dump() << '\n';
-      log_file_.flush();
+      std::lock_guard<std::mutex> lk(shared_->log_mu);
+      shared_->log_file << line.dump() << '\n';
+      shared_->log_file.flush();
     }
   } catch (...) {
     // Logging is best-effort.
   }
 }
 
-void PolicyClient::log_tick_(
+void PolicyClient::SharedState::log_tick(
     const std::string& face_id,
     std::chrono::steady_clock::time_point t,
     const std::vector<float>& action,
-    const ChunkSlot::SampleInfo* info_ptr) {
+    const ChunkSlot::SampleInfo* info_ptr) noexcept {
   // Cheap guard before any allocation: tick logging is best-effort and
   // must add minimal overhead to the real-time face.read() path.
-  if (!log_file_.is_open()) return;
+  if (!log_file.is_open()) return;
   try {
-    const auto ts = render_timestamps(t, log_t0_);
+    const auto ts = render_timestamps(t, log_t0);
     nlohmann::json line;
     line["event"] = "tick";
     line["t_mono_s"] = ts.mono_s;
@@ -1235,8 +1403,8 @@ void PolicyClient::log_tick_(
       line["blend_active"] = info_ptr->blend_active;
     }
     {
-      std::lock_guard<std::mutex> lk(log_mu_);
-      log_file_ << line.dump() << '\n';
+      std::lock_guard<std::mutex> lk(log_mu);
+      log_file << line.dump() << '\n';
       // No flush per tick — 60 lines/s × flush() would dominate CPU.
       // The file stream's internal buffer flushes on overflow; the
       // request/response paths flush(), which also flushes any buffered
@@ -1266,22 +1434,98 @@ void PolicyClient::warn_once_(const std::string& key, const std::string& message
   }
 }
 
+void PolicyClient::warn_throttled_(const std::string& key,
+                                   const std::string& message,
+                                   std::chrono::milliseconds interval_ms) {
+  const auto now = std::chrono::steady_clock::now();
+  bool should_log = false;
+  {
+    std::lock_guard<std::mutex> lk(warn_mu_);
+    auto it = warn_throttle_at_.find(key);
+    if (it == warn_throttle_at_.end() || (now - it->second) >= interval_ms) {
+      warn_throttle_at_[key] = now;
+      should_log = true;
+    }
+  }
+  if (!should_log) {
+    return;
+  }
+  try {
+    std::cerr << "[policy_client:" << name() << "] " << message << "\n";
+  } catch (...) {
+    // Logging failures are not propagated.
+  }
+}
+
 // ── PolicyClient::Face ───────────────────────────────────────────────────────
 
-PolicyClient::Face::Face(PolicyClient* owner, std::string id,
+PolicyClient::Face::Face(std::shared_ptr<SharedState> state, std::string id,
                          int joint_offset, int joint_count)
   : HardwareComponent(std::move(id)),
-    owner_(owner),
+    state_(std::move(state)),
     joint_offset_(joint_offset),
     joint_count_(joint_count) {}
+
+void PolicyClient::Face::apply_output_ema(std::vector<float>& out,
+                                          std::vector<float>& prev,
+                                          double alpha_arm,
+                                          double alpha_gripper) noexcept {
+  // EMA smoothing: layered on top of the arm's write_moving_time_s controller
+  // filter to reject per-row chunk noise. Two alphas — one for the arm joints
+  // and a separate one for the last joint (gripper by convention). The gripper
+  // alpha defaults to 1.0 (pass-through) because gripper open/close is a fast
+  // transient that must reach full extent within a few rows; filtering it like
+  // the arm joints causes incomplete grasps. α=1.0 is a no-op on either side;
+  // the filter activates only when at least one channel needs it.
+  const bool filter_arm = (alpha_arm > 0.0 && alpha_arm < 1.0);
+  const bool filter_grip = (alpha_gripper > 0.0 && alpha_gripper < 1.0);
+  if (!(filter_arm || filter_grip)) {
+    return;  // pure pass-through; do not even seed history
+  }
+  if (prev.size() == out.size()) {
+    const float a_arm = static_cast<float>(alpha_arm);
+    const float a_grip = static_cast<float>(alpha_gripper);
+    const std::size_t grip_idx =
+      out.empty() ? 0 : out.size() - 1;  // last joint of the slice
+    for (std::size_t i = 0; i < out.size(); ++i) {
+      const bool is_grip = (i == grip_idx);
+      const float a = is_grip ? a_grip : a_arm;
+      // Skip the blend entirely on channels whose alpha is 1.0 — that
+      // preserves bit-for-bit pass-through and avoids needless float rounding
+      // when only one of the two filters is active.
+      if (a >= 1.0f) continue;
+      const float prev_v = prev[i];
+      // A non-finite history term would latch forever: NaN/Inf propagate
+      // through out_t = a·row + (1-a)·prev to every future output. Pass the
+      // current row value through instead of blending against a poisoned
+      // previous output, so the filter self-heals on the next finite row.
+      if (!std::isfinite(prev_v)) continue;
+      out[i] = a * out[i] + (1.0f - a) * prev_v;
+    }
+  }
+  // Write-back guard: cache only finite values, per channel. One non-finite
+  // output must never become next tick's history term (which would latch);
+  // a channel that is non-finite this tick keeps its last finite cached value.
+  // On the first tick (or after reset) prev is empty, so seed it to the right
+  // width first — this reproduces the original "seed from the first read"
+  // behavior while dropping any non-finite element.
+  if (prev.size() != out.size()) {
+    prev.assign(out.size(), 0.0f);
+  }
+  for (std::size_t i = 0; i < out.size(); ++i) {
+    if (std::isfinite(out[i])) {
+      prev[i] = out[i];
+    }
+  }
+}
 
 std::vector<float> PolicyClient::Face::read() noexcept {
   try {
     const auto now = std::chrono::steady_clock::now();
-    const auto info = owner_->chunk_slot_.sample_with_info(
+    const auto info = state_->chunk_slot.sample_with_info(
       now,
-      owner_->total_n_,
-      owner_->control_rate_hz_.load(std::memory_order_acquire));
+      state_->total_n.load(std::memory_order_acquire),
+      state_->control_rate_hz.load(std::memory_order_acquire));
 
     std::vector<float> out(static_cast<std::size_t>(joint_count_), 0.0f);
     const int avail = static_cast<int>(info.row.size());
@@ -1290,54 +1534,31 @@ std::vector<float> PolicyClient::Face::read() noexcept {
     if (end > begin) {
       std::copy(info.row.begin() + begin, info.row.begin() + end, out.begin());
     }
-    // EMA smoothing: layered on top of the arm's write_moving_time_s
-    // controller filter to reject per-row chunk noise. Two alphas — one
-    // for the arm joints and a separate one for the last joint (gripper
-    // by convention). The gripper alpha defaults to 1.0 (pass-through)
-    // because gripper open/close is a fast transient that needs to
-    // reach full extent within a few rows; filtering it like the arm
-    // joints causes incomplete grasps. α=1.0 is a no-op on either side;
-    // the filter activates only when at least one channel needs it.
-    // prev_out_ seeds itself from the first non-trivial read so we never
-    // blend against zeros on the first tick.
-    const double alpha_arm = owner_->cfg_.output_ema_alpha;
-    const double alpha_grip = owner_->cfg_.output_ema_alpha_gripper;
-    const bool filter_arm = (alpha_arm > 0.0 && alpha_arm < 1.0);
-    const bool filter_grip = (alpha_grip > 0.0 && alpha_grip < 1.0);
-    if (filter_arm || filter_grip) {
-      if (prev_out_.size() == out.size()) {
-        const float a_arm = static_cast<float>(alpha_arm);
-        const float a_grip = static_cast<float>(alpha_grip);
-        const std::size_t grip_idx =
-          out.empty() ? 0 : out.size() - 1;  // last joint of the slice
-        for (std::size_t i = 0; i < out.size(); ++i) {
-          const bool is_grip = (i == grip_idx);
-          const float a = is_grip ? a_grip : a_arm;
-          // Skip the blend entirely on channels whose alpha is 1.0 — that
-          // preserves bit-for-bit pass-through and avoids needless float
-          // rounding when only one of the two filters is active.
-          if (a >= 1.0f) continue;
-          const float one_minus = 1.0f - a;
-          out[i] = a * out[i] + one_minus * prev_out_[i];
-        }
-      }
-      // Cache for next tick whether or not any channel was filtered.
-      prev_out_ = out;
-    }
-    // Per-tick action log. log_tick_ early-exits when no log file is open,
-    // so this is essentially free in non-diagnostic runs.
+    apply_output_ema(out, prev_out_,
+                     state_->output_ema_alpha.load(std::memory_order_acquire),
+                     state_->output_ema_alpha_gripper.load(
+                       std::memory_order_acquire));
+    // Per-tick action log. log_tick early-exits when no log file is open, so
+    // this is essentially free in non-diagnostic runs. It reads the shared log
+    // sink, never the client, so it is safe even if the client is gone.
     try {
-      owner_->log_tick_(get_identifier(), now, out, &info);
+      state_->log_tick(get_identifier(), now, out, &info);
     } catch (...) {
       // Logging must never propagate into the real-time control loop.
     }
     return out;
   } catch (...) {
+    // Hold-last-action: NEVER command every joint to zero (a large, dangerous
+    // motion). Return the last emitted output when we have one; otherwise an
+    // empty vector, which the teleop loop treats as "no command this tick".
     try {
-      return std::vector<float>(static_cast<std::size_t>(joint_count_), 0.0f);
+      if (!prev_out_.empty()) {
+        return prev_out_;
+      }
     } catch (...) {
-      return std::vector<float>{};
+      // fall through to the empty vector
     }
+    return std::vector<float>{};
   }
 }
 

--- a/src/hw/policy/policy_client.cpp
+++ b/src/hw/policy/policy_client.cpp
@@ -457,11 +457,11 @@ void PolicyClient::inference_loop_() {
       }
     }
 
-    // Gate observation packing on the drain-threshold firing instant. At θ=0
+    // Gate observation packing on the drain-threshold firing instant. At theta=0
     // this is chunk exhaustion (openpi semantics): packing waits until the
     // current chunk is about to exhaust so the observation captures the arm at
     // its end-of-chunk pose, avoiding the mid-chunk wall-clock schedule that
-    // made the policy return chunks computed for a stale pose. At θ>0 it fires
+    // made the policy return chunks computed for a stale pose. At theta>0 it fires
     // earlier, overlapping inference with playback. Skipped on the first cycle
     // (no chunk yet) and after a pause-driven slot clear.
     wait_for_fire_point_();
@@ -527,7 +527,7 @@ void PolicyClient::inference_loop_() {
 
       transport_->push_observation(*obs);
 
-      // Poll for the reply chunk (θ=0 cadence: the cycle re-synchronizes on
+      // Poll for the reply chunk (theta=0 cadence: the cycle re-synchronizes on
       // arrival, exactly like the old blocking round_trip). The 1 ms tick is
       // noise against ~1 s inference, and using inference_cv_ keeps the wait
       // shutdown-interruptible. Exits: chunk, shutdown, or transport gone
@@ -614,7 +614,7 @@ void PolicyClient::wait_for_fire_point_() {
   // only swapped to N+1 by the next face sample(), which happens up to one
   // face period later. Reading the slot at the top of cycle N+2 therefore
   // sees chunk N's already-expired time and the wait short-circuits. We
-  // instead wait for the *applied* chunk's firing instant (θ point).
+  // instead wait for the *applied* chunk's firing instant (theta point).
   const auto target = next_chunk_fire_target_;
   // Default-constructed (epoch zero) signals "no chunk applied yet" — first
   // cycle of an active window or just after a pause clear. Proceed
@@ -782,8 +782,8 @@ std::optional<Observation> PolicyClient::pack_observation_(
   obs.timestep = current_timestep_(obs.captured_at);
   // must_go: the action buffer is empty — no chunk applied yet, or the last
   // applied chunk has played past its final row by now. The server prioritizes
-  // such observations. At θ>0 the fire point precedes exhaustion (overlap), so
-  // must_go marks the exceptional stall/slow-server case; at θ=0 the buffer
+  // such observations. At theta>0 the fire point precedes exhaustion (overlap), so
+  // must_go marks the exceptional stall/slow-server case; at theta=0 the buffer
   // empties every cycle by design, so it is set each time.
   obs.must_go = (next_chunk_exhaust_target_.time_since_epoch().count() == 0) ||
                 (obs.captured_at >= next_chunk_exhaust_target_);
@@ -1027,13 +1027,13 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
 
   const double rate = shared_->control_rate_hz.load(std::memory_order_acquire);
 
-  // Async-overlap path (drain threshold θ>0): the chunk was inferred while the
+  // Async-overlap path (drain threshold theta>0): the chunk was inferred while the
   // previous one still plays, so it takes over immediately, aligned to the
   // Timestep Clock. Row 0 anchors at epoch + base_timestep/rate; rows already
   // in the past are skipped by sample(), and an all-past chunk is discarded.
   // The base_timestep sanity guards (all-past / far-future) live here because
   // base_timestep is load-bearing only for this alignment. The consume-fully
-  // path (θ=0, openpi's default) ignores base_timestep entirely — it re-anchors
+  // path (theta=0, openpi's default) ignores base_timestep entirely — it re-anchors
   // playback_start_ = now on promotion — so it needs no such guard.
   if (cfg_.drain_threshold > 0.0 && rate > 0.0 && chunk->T > 0 &&
       inference_epoch_.time_since_epoch().count() != 0) {
@@ -1068,7 +1068,7 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
     const auto aligned_start = inference_epoch_ + tick_ns(chunk->base_timestep);
     next_chunk_exhaust_target_ = aligned_start + tick_ns(chunk->T);
     // Fire the next observation when the remaining playable fraction drops to
-    // θ: at (1-θ)·T ticks into this chunk.
+    // theta: at (1-theta)·T ticks into this chunk.
     const double play_fraction = 1.0 - cfg_.drain_threshold;
     next_chunk_fire_target_ = aligned_start + std::chrono::nanoseconds(
       static_cast<int64_t>(play_fraction * static_cast<double>(chunk->T) /
@@ -1078,7 +1078,7 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
     return;
   }
 
-  // Consume-fully path (openpi θ=0 cadence). The two members set below are
+  // Consume-fully path (openpi theta=0 cadence). The two members set below are
   // scheduling ESTIMATES the client uses to time the next cycle's fire point;
   // they are not the slot's actual playback anchor. The slot itself parks this
   // chunk in its pending_ slot (when one is already playing) and, on the sample
@@ -1096,8 +1096,8 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
       ? next_chunk_exhaust_target_   // previous chunk hadn't exhausted yet
       : chunk->received_at;           // previous chunk done; we play from now
     next_chunk_exhaust_target_ = base + duration_ns;
-    // θ=0 on this path (θ>0 takes the aligned branch above), so the fire point
-    // coincides with exhaustion. Compute it via the same θ rule for clarity.
+    // theta=0 on this path (theta>0 takes the aligned branch above), so the fire point
+    // coincides with exhaustion. Compute it via the same theta rule for clarity.
     const double play_fraction = 1.0 - cfg_.drain_threshold;
     next_chunk_fire_target_ = base + std::chrono::nanoseconds(
       static_cast<int64_t>(play_fraction * static_cast<double>(chunk->T) /

--- a/src/hw/policy/policy_client.cpp
+++ b/src/hw/policy/policy_client.cpp
@@ -838,10 +838,14 @@ std::optional<Observation> PolicyClient::pack_observation_(
       (it != snapshot.end()) ? it->second : nullptr;
     auto img = pack_image_(rec, *sub, cam_key);
     if (!img) {
-      warn_once_("camera_unrepresentable:" + cam_key,
-                 "cannot represent configured camera '" + cam_key +
-                 "' (no valid frame and no resize/last-known dimensions to "
-                 "synthesize a placeholder); skipping this observation");
+      // Throttled (not warn-once): returning nullopt every cycle here freezes
+      // inference indefinitely (no observation is ever published), so this is
+      // an ongoing hazard that must keep surfacing, like the non-finite reject.
+      warn_throttled_("camera_unrepresentable:" + cam_key,
+                      "cannot represent configured camera '" + cam_key +
+                      "' (no valid frame and no resize/last-known dimensions to "
+                      "synthesize a placeholder); skipping this observation",
+                      std::chrono::milliseconds(1000));
       return std::nullopt;
     }
     obs.images.push_back(std::move(*img));
@@ -1027,6 +1031,10 @@ void PolicyClient::apply_chunk_(ActionChunk chunk_in,
   // previous one still plays, so it takes over immediately, aligned to the
   // Timestep Clock. Row 0 anchors at epoch + base_timestep/rate; rows already
   // in the past are skipped by sample(), and an all-past chunk is discarded.
+  // The base_timestep sanity guards (all-past / far-future) live here because
+  // base_timestep is load-bearing only for this alignment. The consume-fully
+  // path (θ=0, openpi's default) ignores base_timestep entirely — it re-anchors
+  // playback_start_ = now on promotion — so it needs no such guard.
   if (cfg_.drain_threshold > 0.0 && rate > 0.0 && chunk->T > 0 &&
       inference_epoch_.time_since_epoch().count() != 0) {
     const auto now = std::chrono::steady_clock::now();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,9 @@ if(TROSSEN_SDK_ENABLE_POLICY_CLIENT)
   target_link_libraries(test_openpi_websocket_transport PRIVATE
     trossen_sdk GTest::gtest_main msgpack-cxx ixwebsocket::ixwebsocket)
 
+  add_executable(test_policy_client test_policy_client.cpp)
+  target_link_libraries(test_policy_client PRIVATE trossen_sdk GTest::gtest_main)
+
   # Drives LerobotGrpcTransport against a gmock MockAsyncInferenceStub (no real
   # channel/server, so no gRPC teardown race). Needs the generated proto + mock
   # headers, gmock, and a direct gRPC/protobuf link (PRIVATE on trossen_sdk).
@@ -180,4 +183,5 @@ if(TROSSEN_SDK_ENABLE_POLICY_CLIENT)
   gtest_discover_tests(test_lerobot_codec)
   gtest_discover_tests(test_openpi_websocket_transport)
   gtest_discover_tests(test_lerobot_grpc_transport)
+  gtest_discover_tests(test_policy_client)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,9 @@ target_link_libraries(test_backend_registry PRIVATE trossen_sdk GTest::gtest_mai
 add_executable(test_trossen_mcap_backend test_trossen_mcap_backend.cpp)
 target_link_libraries(test_trossen_mcap_backend PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_active_hardware_registry test_active_hardware_registry.cpp)
+target_link_libraries(test_active_hardware_registry PRIVATE trossen_sdk GTest::gtest_main)
+
 add_executable(test_push_producer_registry test_push_producer_registry.cpp)
 target_link_libraries(test_push_producer_registry PRIVATE trossen_sdk GTest::gtest_main)
 
@@ -149,6 +152,7 @@ gtest_discover_tests(test_record)
 gtest_discover_tests(test_null_backend)
 gtest_discover_tests(test_backend_registry)
 gtest_discover_tests(test_trossen_mcap_backend)
+gtest_discover_tests(test_active_hardware_registry)
 gtest_discover_tests(test_push_producer_registry)
 gtest_discover_tests(test_push_producer_base)
 gtest_discover_tests(test_session_manager_push_producer)

--- a/tests/test_active_hardware_registry.cpp
+++ b/tests/test_active_hardware_registry.cpp
@@ -1,0 +1,76 @@
+/**
+ * @file test_active_hardware_registry.cpp
+ * @brief Unit tests for the ActiveHardwareRegistry singleton.
+ */
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+
+namespace {
+
+using trossen::hw::ActiveHardwareRegistry;
+using trossen::hw::HardwareComponent;
+
+class StubComponent : public HardwareComponent {
+ public:
+  explicit StubComponent(const std::string& id) : HardwareComponent(id) {}
+  void configure(const nlohmann::json&) override {}
+  std::string get_type() const override { return "stub"; }
+};
+
+class ActiveHardwareRegistryTest : public ::testing::Test {
+ protected:
+  void SetUp() override { ActiveHardwareRegistry::clear(); }
+  void TearDown() override { ActiveHardwareRegistry::clear(); }
+};
+
+TEST_F(ActiveHardwareRegistryTest, RegisterAndGet) {
+  auto c = std::make_shared<StubComponent>("a");
+  ActiveHardwareRegistry::register_active("a", c);
+  EXPECT_TRUE(ActiveHardwareRegistry::is_registered("a"));
+  EXPECT_EQ(ActiveHardwareRegistry::get("a"), c);
+}
+
+TEST_F(ActiveHardwareRegistryTest, DuplicateRegistrationThrows) {
+  ActiveHardwareRegistry::register_active(
+    "a", std::make_shared<StubComponent>("a"));
+  EXPECT_THROW(
+    ActiveHardwareRegistry::register_active(
+      "a", std::make_shared<StubComponent>("a")),
+    std::runtime_error);
+}
+
+TEST_F(ActiveHardwareRegistryTest, UnregisterRemovesEntry) {
+  ActiveHardwareRegistry::register_active(
+    "a", std::make_shared<StubComponent>("a"));
+  ActiveHardwareRegistry::register_active(
+    "b", std::make_shared<StubComponent>("b"));
+  EXPECT_EQ(ActiveHardwareRegistry::count(), 2u);
+
+  EXPECT_TRUE(ActiveHardwareRegistry::unregister("a"));
+  EXPECT_FALSE(ActiveHardwareRegistry::is_registered("a"));
+  EXPECT_TRUE(ActiveHardwareRegistry::is_registered("b"));
+  EXPECT_EQ(ActiveHardwareRegistry::count(), 1u);
+}
+
+TEST_F(ActiveHardwareRegistryTest, UnregisterUnknownIdReturnsFalse) {
+  EXPECT_FALSE(ActiveHardwareRegistry::unregister("missing"));
+}
+
+TEST_F(ActiveHardwareRegistryTest, UnregisterFollowedByReregister) {
+  ActiveHardwareRegistry::register_active(
+    "a", std::make_shared<StubComponent>("a"));
+  EXPECT_TRUE(ActiveHardwareRegistry::unregister("a"));
+  EXPECT_NO_THROW(
+    ActiveHardwareRegistry::register_active(
+      "a", std::make_shared<StubComponent>("a")));
+}
+
+}  // namespace

--- a/tests/test_policy_client.cpp
+++ b/tests/test_policy_client.cpp
@@ -672,7 +672,7 @@ TEST_F(PolicyClientTest, ObservationMatchesNeutralContract) {
 
   EXPECT_EQ(obs.task, "test");
   // L5: timestep is stamped from the Timestep Clock (non-negative ticks since
-  // the active-window epoch). At the default θ=0 cadence each observation is
+  // the active-window epoch). At the default theta=0 cadence each observation is
   // packed at end-of-chunk, so the action buffer is empty and must_go is set.
   EXPECT_GE(obs.timestep, 0);
   EXPECT_TRUE(obs.must_go);
@@ -880,12 +880,12 @@ TEST_F(PolicyClientTest, InferenceFiringIsGatedByChunkExhaustion) {
 }
 
 TEST_F(PolicyClientTest, DrainThresholdFiresMidChunkAndClearsMustGo) {
-  // θ=0.5: fire the next observation halfway through each chunk (async
-  // overlap), so the cadence is ~2x the θ=0 end-of-chunk rate and the buffer
+  // theta=0.5: fire the next observation halfway through each chunk (async
+  // overlap), so the cadence is ~2x the theta=0 end-of-chunk rate and the buffer
   // is not empty at the fire point (must_go clears).
   auto fake_owned = std::make_unique<FakeTransport>();
   FakeTransport* fake = fake_owned.get();
-  // T=10 rows at 100 Hz → 100 ms/chunk; θ=0.5 fires at 50 ms.
+  // T=10 rows at 100 Hz → 100 ms/chunk; theta=0.5 fires at 50 ms.
   fake->set_canned_chunk(10, 2, std::vector<float>(20, 0.5f));
 
   auto cfg = make_config("pc1",
@@ -925,9 +925,9 @@ TEST_F(PolicyClientTest, DrainThresholdFiresMidChunkAndClearsMustGo) {
   const auto obs = fake->last_observation();
   client.stop();
 
-  // ~450 ms / 50 ms ≈ 9 fires + initial; faster than the θ=0 cadence (~5) but
+  // ~450 ms / 50 ms ≈ 9 fires + initial; faster than the theta=0 cadence (~5) but
   // still gated well below the 200 Hz × 0.45 s = 90 free-run cap.
-  EXPECT_GE(trips, 6u) << "θ=0.5 should fire roughly twice the θ=0 cadence";
+  EXPECT_GE(trips, 6u) << "theta=0.5 should fire roughly twice the theta=0 cadence";
   EXPECT_LE(trips, 20u) << "drain firing should still gate the loop";
   // Steady-state fires happen mid-chunk, so the buffer is not empty.
   EXPECT_FALSE(obs.must_go) << "mid-chunk fire should not flag starvation";

--- a/tests/test_policy_client.cpp
+++ b/tests/test_policy_client.cpp
@@ -4,9 +4,11 @@
  */
 
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <filesystem>
+#include <limits>
 #include <fstream>
 #include <memory>
 #include <mutex>
@@ -128,6 +130,11 @@ class FakeTransport : public PolicyTransport {
     if (state_ != TransportStatus::State::kConnected || !pending_) {
       return std::nullopt;
     }
+    // Half-open server simulation: stay connected but never deliver a chunk.
+    // The client's inference deadline must break the poll loop on its own.
+    if (never_reply_) {
+      return std::nullopt;
+    }
     const auto now = std::chrono::steady_clock::now();
     if (now < ready_at_) {
       return std::nullopt;  // reply still "in flight"
@@ -138,8 +145,10 @@ class FakeTransport : public PolicyTransport {
     chunk.received_at = now;
     // Mirror the real transports: row 0 is the timestep of the observation
     // that produced this chunk (openpi stamps obs.timestep). Needed by the
-    // drain-threshold aligned take-over path.
-    chunk.base_timestep = last_obs_.timestep;
+    // drain-threshold aligned take-over path. A forced value lets tests drive
+    // the client's alignment guards (all-past / far-future).
+    chunk.base_timestep =
+      forced_base_timestep_.value_or(last_obs_.timestep);
     return chunk;
   }
 
@@ -171,6 +180,14 @@ class FakeTransport : public PolicyTransport {
     std::lock_guard<std::mutex> lk(mu_);
     reply_delay_ = d;
   }
+  void set_never_reply(bool v) {
+    std::lock_guard<std::mutex> lk(mu_);
+    never_reply_ = v;
+  }
+  void set_base_timestep(int64_t ts) {
+    std::lock_guard<std::mutex> lk(mu_);
+    forced_base_timestep_ = ts;
+  }
 
   uint64_t request_count() const noexcept {
     std::lock_guard<std::mutex> lk(mu_);
@@ -192,6 +209,8 @@ class FakeTransport : public PolicyTransport {
   TransportStatus::State state_{TransportStatus::State::kDisconnected};
   bool connect_throws_{false};
   bool fail_requests_{false};
+  bool never_reply_{false};
+  std::optional<int64_t> forced_base_timestep_;
   std::chrono::milliseconds reply_delay_{0};
   uint64_t requests_{0};
   uint64_t failure_count_{0};
@@ -1250,6 +1269,409 @@ TEST_F(PolicyClientTest, DestructorUnregistersFaces) {
     EXPECT_TRUE(ActiveHardwareRegistry::is_registered("policy_left"));
   }
   EXPECT_FALSE(ActiveHardwareRegistry::is_registered("policy_left"));
+}
+
+// PR253-F1: a chunk carrying any non-finite action must be rejected whole
+// (never partially applied) and the slot must keep playing the prior chunk.
+TEST_F(PolicyClientTest, NonFiniteChunkIsRejectedAndHeldLast) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(1, 2, {5.0f, 6.0f});  // valid first chunk
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+  client.set_control_rate_hz(30.0);
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.0f, 0.0f};
+
+  ASSERT_TRUE(client.start());
+  const auto first_deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < first_deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+  // Latch the good row as the last commanded action.
+  auto good = client.faces()[0]->read();
+  ASSERT_EQ(good.size(), 2u);
+  EXPECT_FLOAT_EQ(good[0], 5.0f);
+  EXPECT_FLOAT_EQ(good[1], 6.0f);
+
+  // Now serve a chunk with a NaN element — it must be rejected wholesale.
+  const float nan_v = std::numeric_limits<float>::quiet_NaN();
+  fake->set_canned_chunk(1, 2, {nan_v, 2.0f});
+  const auto rejects_before = client.chunks_rejected();
+  const auto pubs_before = client.chunks_published();
+  const auto rej_deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_rejected() == rejects_before &&
+         std::chrono::steady_clock::now() < rej_deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  EXPECT_GT(client.chunks_rejected(), rejects_before);
+  EXPECT_EQ(client.chunks_published(), pubs_before)
+    << "a non-finite chunk must not publish";
+
+  // Hold-last-action: the Face still yields the prior (finite) row.
+  auto held = client.faces()[0]->read();
+  ASSERT_EQ(held.size(), 2u);
+  EXPECT_FLOAT_EQ(held[0], 5.0f);
+  EXPECT_FLOAT_EQ(held[1], 6.0f);
+  client.stop();
+}
+
+// PR253-F2: the output EMA must not latch a non-finite value. A poisoned
+// history term is passed through (not blended against), and a non-finite
+// output is never cached as next tick's history.
+TEST(PolicyClientFaceEmaTest, GuardsAgainstNonFiniteHistory) {
+  using Face = trossen::hw::policy::PolicyClient::Face;
+  const float nan_v = std::numeric_limits<float>::quiet_NaN();
+
+  // Channel 0's history is poisoned; channel 1 (gripper by last-index) is fine.
+  std::vector<float> out = {10.0f, 20.0f};
+  std::vector<float> prev = {nan_v, 5.0f};
+  Face::apply_output_ema(out, prev, /*alpha_arm=*/0.5, /*alpha_gripper=*/0.5);
+  // ch0: non-finite prev → pass current row through; ch1: 0.5*20 + 0.5*5.
+  EXPECT_FLOAT_EQ(out[0], 10.0f);
+  EXPECT_FLOAT_EQ(out[1], 12.5f);
+  // History is re-seeded to finite values, so tracking resumes next tick.
+  ASSERT_EQ(prev.size(), 2u);
+  EXPECT_TRUE(std::isfinite(prev[0]));
+  EXPECT_FLOAT_EQ(prev[0], 10.0f);
+  EXPECT_FLOAT_EQ(prev[1], 12.5f);
+
+  std::vector<float> out2 = {10.0f, 20.0f};
+  Face::apply_output_ema(out2, prev, 0.5, 0.5);
+  EXPECT_TRUE(std::isfinite(out2[0]));
+  EXPECT_TRUE(std::isfinite(out2[1]));
+  EXPECT_FLOAT_EQ(out2[0], 10.0f);        // 0.5*10 + 0.5*10
+  EXPECT_FLOAT_EQ(out2[1], 16.25f);       // 0.5*20 + 0.5*12.5
+
+  // Write-back guard: a non-finite OUTPUT must not overwrite finite history.
+  std::vector<float> out3 = {nan_v, 3.0f};
+  std::vector<float> prev3 = {1.0f, 2.0f};
+  Face::apply_output_ema(out3, prev3, 0.5, 0.5);
+  EXPECT_FLOAT_EQ(prev3[0], 1.0f)         // stayed finite, not poisoned
+    << "a non-finite output must not become next tick's history";
+  EXPECT_FLOAT_EQ(prev3[1], 2.5f);        // 0.5*3 + 0.5*2 cached normally
+}
+
+// PR253-F3: a half-open server (stays connected, never returns a chunk) must
+// not spin the poll loop forever. The inference deadline breaks the wait and
+// the next cycle re-observes, so the request count keeps advancing.
+TEST_F(PolicyClientTest, InferenceDeadlineBreaksPollLoop) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(1, 2, {1.0f, 2.0f});
+  fake->set_never_reply(true);  // connected, but no chunk ever arrives
+
+  auto cfg = make_config("pc1",
+                         {make_joint_sub("follower_left", "state.left", 200.0)},
+                         {make_layout("policy_left", 0, 2)},
+                         /*inference_hz=*/200.0);
+  cfg.inference_timeout_ms = 40.0;   // short deadline so the test is quick
+  cfg.freshness_timeout_ms = 20.0;   // do not stall on the freshness barrier
+  PolicyClient client(std::move(cfg), std::move(fake_owned));
+  client.set_control_rate_hz(1000.0);
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.1f, 0.2f};
+
+  ASSERT_TRUE(client.start());
+  // Without the deadline the loop would push exactly once and spin forever;
+  // with it, each abandoned round-trip is followed by a fresh push.
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (fake->request_count() < 2 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  EXPECT_GE(fake->request_count(), 2u)
+    << "inference deadline should abandon the stalled request and re-observe";
+  EXPECT_EQ(client.chunks_published(), 0u);
+  client.stop();
+}
+
+// PR253-F4: a chunk whose base_timestep is far in the future (server clock
+// ahead / corrupt value) must be discarded rather than stalling the arm on
+// hold-last for a long time while the aligned start sits far ahead.
+TEST_F(PolicyClientTest, FarFutureBaseTimestepIsDiscarded) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(10, 2, std::vector<float>(20, 0.5f));  // T=10
+  fake->set_base_timestep(1'000'000);  // absurdly far ahead of the clock
+
+  auto cfg = make_config("pc1",
+                         {make_joint_sub("follower_left", "state.left", 200.0)},
+                         {make_layout("policy_left", 0, 2)},
+                         /*inference_hz=*/200.0);
+  cfg.drain_threshold = 0.5;  // exercise the aligned take-over path
+  PolicyClient client(std::move(cfg), std::move(fake_owned));
+  client.set_control_rate_hz(100.0);
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.1f, 0.2f};
+
+  ASSERT_TRUE(client.start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_rejected() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  EXPECT_GT(fake->request_count(), 0u);
+  EXPECT_GT(client.chunks_rejected(), 0u)
+    << "a far-future base_timestep must be discarded";
+  EXPECT_EQ(client.chunks_published(), 0u);
+  client.stop();
+}
+
+// PR253-F5: a Face retained past its PolicyClient's destruction must still be
+// safe to read (no use-after-free) and must hold last / yield no command.
+// Run under AddressSanitizer to prove the UAF is gone.
+TEST_F(PolicyClientTest, FaceOutlivingClientHoldsLastSafely) {
+  std::shared_ptr<trossen::hw::policy::PolicyClient::Face> face;
+  {
+    auto fake = std::make_unique<FakeTransport>();
+    fake->set_canned_chunk(1, 2, {3.0f, 4.0f});
+    PolicyClient client(
+      make_config("pc1",
+                  {make_joint_sub("follower_left", "state.left", 200.0)},
+                  {make_layout("policy_left", 0, 2)},
+                  /*inference_hz=*/200.0),
+      std::move(fake));
+    client.set_control_rate_hz(30.0);
+    face = client.faces()[0];  // retain the Face beyond the client's lifetime
+
+    auto rec = std::make_shared<JointStateRecord>();
+    rec->id = "follower_left";
+    rec->positions = {0.0f, 0.0f};
+    ASSERT_TRUE(client.start());
+    const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (client.chunks_published() == 0 &&
+           std::chrono::steady_clock::now() < deadline) {
+      client.offer(rec);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_GT(client.chunks_published(), 0u);
+    (void)face->read();  // latch a last commanded row
+    client.stop();
+  }  // client destroyed here; `face` (and its shared state) survive
+
+  auto cmd = face->read();
+  EXPECT_TRUE(cmd.size() == 2u || cmd.empty())
+    << "a surviving Face must hold-last (sized) or yield no command (empty)";
+  for (float v : cmd) {
+    EXPECT_TRUE(std::isfinite(v));
+  }
+  auto cmd2 = face->read();  // repeated reads must stay safe
+  EXPECT_TRUE(cmd2.size() == 2u || cmd2.empty());
+}
+
+// PR253-F6: a 1-channel (mono8) frame must be expanded to a correctly sized
+// 3-channel RGB image, not memcpy'd as if it had 3 channels (heap over-read).
+// Run under AddressSanitizer to prove the over-read is gone.
+TEST_F(PolicyClientTest, Mono8ImagePacksAsThreeChannelRgb) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(1, 14, std::vector<float>(14, 0.0f));
+
+  PolicyClientSubscriptionConfig cam_sub;
+  cam_sub.record_id = "cam_high/color";
+  cam_sub.obs_key = "images.cam_high";
+  cam_sub.throttle_hz = 200.0;
+  cam_sub.resize = std::make_pair(4, 4);
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left",  "state.left",  200.0),
+                 make_joint_sub("follower_right", "state.right", 200.0),
+                 cam_sub},
+                {make_layout("policy_left",  0, 7),
+                 make_layout("policy_right", 7, 7)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+
+  auto left = std::make_shared<JointStateRecord>();
+  left->id = "follower_left";
+  left->positions = std::vector<float>(7, 0.0f);
+  auto right = std::make_shared<JointStateRecord>();
+  right->id = "follower_right";
+  right->positions = std::vector<float>(7, 0.0f);
+
+  // Single-channel (mono8) 8x8 image, uniform gray = 123.
+  auto img_rec = std::make_shared<trossen::data::ImageRecord>();
+  img_rec->id = "cam_high/color";
+  img_rec->encoding = "mono8";
+  img_rec->image = cv::Mat(8, 8, CV_8UC1, cv::Scalar(123));
+
+  ASSERT_TRUE(client.start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(left);
+    client.offer(right);
+    client.offer(img_rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+  client.stop();
+
+  const auto obs = fake->last_observation();
+  ASSERT_EQ(obs.images.size(), 1u);
+  const auto& img = obs.images[0];
+  EXPECT_EQ(img.camera, "cam_high");
+  EXPECT_EQ(img.width, 4);
+  EXPECT_EQ(img.height, 4);
+  ASSERT_EQ(img.rgb.size(), 4u * 4u * 3u);  // exactly 3 channels, no over-read
+  for (int p = 0; p < 16; ++p) {
+    EXPECT_EQ(static_cast<int>(img.rgb[p * 3 + 0]), 123);
+    EXPECT_EQ(static_cast<int>(img.rgb[p * 3 + 1]), 123);
+    EXPECT_EQ(static_cast<int>(img.rgb[p * 3 + 2]), 123);
+  }
+}
+
+// PR253-F7: a missing camera WITH a configured resize is substituted with a
+// same-shaped zero frame, so the observation's image set never depends on
+// which cameras happened to deliver this cycle.
+TEST_F(PolicyClientTest, MissingCameraWithResizeShipsZeroFrame) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(1, 14, std::vector<float>(14, 0.0f));
+
+  PolicyClientSubscriptionConfig cam_high;
+  cam_high.record_id = "cam_high/color";
+  cam_high.obs_key = "images.cam_high";
+  cam_high.throttle_hz = 200.0;
+  cam_high.resize = std::make_pair(4, 4);
+  PolicyClientSubscriptionConfig cam_low;  // never delivered
+  cam_low.record_id = "cam_low/color";
+  cam_low.obs_key = "images.cam_low";
+  cam_low.throttle_hz = 200.0;
+  cam_low.resize = std::make_pair(4, 4);
+
+  auto cfg = make_config("pc1",
+                         {make_joint_sub("follower_left",  "state.left",  200.0),
+                          make_joint_sub("follower_right", "state.right", 200.0),
+                          cam_high, cam_low},
+                         {make_layout("policy_left",  0, 7),
+                          make_layout("policy_right", 7, 7)},
+                         /*inference_hz=*/200.0);
+  cfg.freshness_timeout_ms = 20.0;  // cam_low never arrives; don't block long
+  PolicyClient client(std::move(cfg), std::move(fake_owned));
+  client.set_control_rate_hz(30.0);
+
+  auto left = std::make_shared<JointStateRecord>();
+  left->id = "follower_left";
+  left->positions = std::vector<float>(7, 0.0f);
+  auto right = std::make_shared<JointStateRecord>();
+  right->id = "follower_right";
+  right->positions = std::vector<float>(7, 0.0f);
+  auto img_rec = std::make_shared<trossen::data::ImageRecord>();
+  img_rec->id = "cam_high/color";
+  img_rec->encoding = "bgr8";
+  img_rec->image = cv::Mat(4, 4, CV_8UC3, cv::Scalar(10, 20, 30));
+
+  ASSERT_TRUE(client.start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(left);
+    client.offer(right);
+    client.offer(img_rec);  // cam_low deliberately never offered
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+  client.stop();
+
+  const auto obs = fake->last_observation();
+  // BOTH configured cameras are present (stable image set), cam_low zero-filled.
+  ASSERT_EQ(obs.images.size(), 2u);
+  const trossen::hw::policy::Observation::Image* low = nullptr;
+  for (const auto& im : obs.images) {
+    if (im.camera == "cam_low") low = &im;
+  }
+  ASSERT_NE(low, nullptr);
+  EXPECT_EQ(low->width, 4);
+  EXPECT_EQ(low->height, 4);
+  ASSERT_EQ(low->rgb.size(), 4u * 4u * 3u);
+  for (uint8_t b : low->rgb) {
+    EXPECT_EQ(static_cast<int>(b), 0);  // black placeholder
+  }
+}
+
+// PR253-F7: a missing camera WITHOUT a resize (and never seen, so no
+// last-known dimensions) cannot be represented; the whole observation is
+// skipped rather than shipped with a diverging image set. So the transport
+// never receives an observation — the same-shape-or-nothing contract.
+TEST_F(PolicyClientTest, MissingCameraWithoutResizeFailsObservation) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(1, 14, std::vector<float>(14, 0.0f));
+
+  PolicyClientSubscriptionConfig cam_high;
+  cam_high.record_id = "cam_high/color";
+  cam_high.obs_key = "images.cam_high";
+  cam_high.throttle_hz = 200.0;
+  cam_high.resize = std::make_pair(4, 4);
+  PolicyClientSubscriptionConfig cam_low;  // never delivered, NO resize
+  cam_low.record_id = "cam_low/color";
+  cam_low.obs_key = "images.cam_low";
+  cam_low.throttle_hz = 200.0;
+
+  auto cfg = make_config("pc1",
+                         {make_joint_sub("follower_left",  "state.left",  200.0),
+                          make_joint_sub("follower_right", "state.right", 200.0),
+                          cam_high, cam_low},
+                         {make_layout("policy_left",  0, 7),
+                          make_layout("policy_right", 7, 7)},
+                         /*inference_hz=*/200.0);
+  cfg.freshness_timeout_ms = 20.0;
+  PolicyClient client(std::move(cfg), std::move(fake_owned));
+  client.set_control_rate_hz(30.0);
+
+  auto left = std::make_shared<JointStateRecord>();
+  left->id = "follower_left";
+  left->positions = std::vector<float>(7, 0.0f);
+  auto right = std::make_shared<JointStateRecord>();
+  right->id = "follower_right";
+  right->positions = std::vector<float>(7, 0.0f);
+  auto img_rec = std::make_shared<trossen::data::ImageRecord>();
+  img_rec->id = "cam_high/color";
+  img_rec->encoding = "bgr8";
+  img_rec->image = cv::Mat(4, 4, CV_8UC3, cv::Scalar(10, 20, 30));
+
+  ASSERT_TRUE(client.start());
+  const auto until = std::chrono::steady_clock::now() +
+                     std::chrono::milliseconds(400);
+  while (std::chrono::steady_clock::now() < until) {
+    client.offer(left);
+    client.offer(right);
+    client.offer(img_rec);  // cam_low never offered
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  client.stop();
+
+  // No representable observation was ever produced, so none was pushed and no
+  // chunk was published — never a 1-image (diverging) observation.
+  EXPECT_EQ(client.chunks_published(), 0u);
+  EXPECT_EQ(fake->request_count(), 0u);
 }
 
 }  // namespace

--- a/tests/test_policy_client.cpp
+++ b/tests/test_policy_client.cpp
@@ -1,0 +1,1255 @@
+/**
+ * @file test_policy_client.cpp
+ * @brief Unit tests for PolicyClient and PolicyClient::Face with a FakeTransport.
+ */
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+#include "opencv2/core.hpp"
+
+#include "trossen_sdk/configuration/types/hardware/policy_client_config.hpp"
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/policy/policy_client.hpp"
+#include "trossen_sdk/hw/policy/policy_transport.hpp"
+
+namespace {
+
+using trossen::configuration::PolicyClientConfig;
+using trossen::configuration::PolicyClientJointLayoutEntry;
+using trossen::configuration::PolicyClientSubscriptionConfig;
+using trossen::data::JointStateRecord;
+using trossen::hw::ActiveHardwareRegistry;
+using trossen::hw::policy::PolicyClient;
+using trossen::hw::policy::PolicyTransport;
+
+PolicyClientConfig make_config(
+    const std::string& id,
+    std::vector<PolicyClientSubscriptionConfig> subs,
+    std::vector<PolicyClientJointLayoutEntry> layout,
+    double inference_hz = 100.0) {
+  PolicyClientConfig c;
+  c.id = id;
+  c.server_url = "ws://127.0.0.1:1";
+  c.inference_hz = inference_hz;
+  c.prompt = "test";
+  c.subscriptions = std::move(subs);
+  c.joint_layout = std::move(layout);
+  return c;
+}
+
+PolicyClientSubscriptionConfig make_joint_sub(const std::string& record_id,
+                                              const std::string& obs_key,
+                                              double throttle_hz = 100.0) {
+  PolicyClientSubscriptionConfig s;
+  s.record_id = record_id;
+  s.obs_key = obs_key;
+  s.throttle_hz = throttle_hz;
+  return s;
+}
+
+PolicyClientJointLayoutEntry make_layout(
+    const std::string& leader_id, int offset, int count,
+    std::vector<std::string> joint_names = {}) {
+  PolicyClientJointLayoutEntry e;
+  e.leader_id = leader_id;
+  e.joint_offset = offset;
+  e.joint_count = count;
+  e.joint_names = std::move(joint_names);
+  return e;
+}
+
+/**
+ * @brief Test transport implementing the push/poll contract.
+ *
+ * A push records the neutral observation and schedules the canned chunk for
+ * delivery (pollable) after an optional reply delay. Failure mode mirrors the
+ * real openpi transport's die-on-disconnect reporting: the failing request
+ * bumps failure_count and flips the state to kDisconnected; later pushes drop
+ * silently per the interface contract. Nothing here blocks, so close() has
+ * nothing to interrupt — one mutex over plain members suffices.
+ */
+class FakeTransport : public PolicyTransport {
+ public:
+  FakeTransport() = default;
+
+  void connect() override {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (connect_throws_) {
+      throw std::runtime_error("FakeTransport: connect failed");
+    }
+    state_ = TransportStatus::State::kConnected;
+  }
+
+  void close() noexcept override {
+    std::lock_guard<std::mutex> lk(mu_);
+    state_ = TransportStatus::State::kDisconnected;
+    pending_ = false;
+  }
+
+  const nlohmann::json& server_metadata() const override { return metadata_; }
+
+  void push_observation(const trossen::hw::policy::Observation& obs)
+      noexcept override {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (state_ != TransportStatus::State::kConnected) {
+      return;  // contract: silent drop while unhealthy
+    }
+    last_obs_ = obs;
+    ++requests_;
+    if (fail_requests_) {
+      ++failure_count_;
+      last_error_ = "FakeTransport: request failed";
+      state_ = TransportStatus::State::kDisconnected;
+      return;
+    }
+    ready_at_ = std::chrono::steady_clock::now() + reply_delay_;
+    pending_ = true;
+  }
+
+  std::optional<trossen::hw::policy::ActionChunk> try_poll_chunk()
+      noexcept override {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (state_ != TransportStatus::State::kConnected || !pending_) {
+      return std::nullopt;
+    }
+    const auto now = std::chrono::steady_clock::now();
+    if (now < ready_at_) {
+      return std::nullopt;  // reply still "in flight"
+    }
+    pending_ = false;
+    trossen::hw::policy::ActionChunk chunk = canned_chunk_;
+    chunk.chunk_seq = ++chunk_seq_;
+    chunk.received_at = now;
+    // Mirror the real transports: row 0 is the timestep of the observation
+    // that produced this chunk (openpi stamps obs.timestep). Needed by the
+    // drain-threshold aligned take-over path.
+    chunk.base_timestep = last_obs_.timestep;
+    return chunk;
+  }
+
+  trossen::hw::policy::TransportStatus status() const noexcept override {
+    std::lock_guard<std::mutex> lk(mu_);
+    trossen::hw::policy::TransportStatus s;
+    s.state = state_;
+    s.failure_count = failure_count_;
+    s.last_error = last_error_;
+    return s;
+  }
+
+  void set_canned_chunk(int T, int N, const std::vector<float>& flat) {
+    std::lock_guard<std::mutex> lk(mu_);
+    canned_chunk_.T = T;
+    canned_chunk_.N = N;
+    canned_chunk_.data = flat;
+  }
+
+  void set_connect_throws(bool v) {
+    std::lock_guard<std::mutex> lk(mu_);
+    connect_throws_ = v;
+  }
+  void set_fail_requests(bool v) {
+    std::lock_guard<std::mutex> lk(mu_);
+    fail_requests_ = v;
+  }
+  void set_reply_delay(std::chrono::milliseconds d) {
+    std::lock_guard<std::mutex> lk(mu_);
+    reply_delay_ = d;
+  }
+
+  uint64_t request_count() const noexcept {
+    std::lock_guard<std::mutex> lk(mu_);
+    return requests_;
+  }
+  bool is_connected() const noexcept {
+    std::lock_guard<std::mutex> lk(mu_);
+    return state_ == TransportStatus::State::kConnected;
+  }
+  trossen::hw::policy::Observation last_observation() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return last_obs_;
+  }
+
+ private:
+  using TransportStatus = trossen::hw::policy::TransportStatus;
+
+  mutable std::mutex mu_;
+  TransportStatus::State state_{TransportStatus::State::kDisconnected};
+  bool connect_throws_{false};
+  bool fail_requests_{false};
+  std::chrono::milliseconds reply_delay_{0};
+  uint64_t requests_{0};
+  uint64_t failure_count_{0};
+  uint64_t chunk_seq_{0};
+  std::string last_error_;
+
+  bool pending_{false};
+  std::chrono::steady_clock::time_point ready_at_{};
+  trossen::hw::policy::ActionChunk canned_chunk_;
+  nlohmann::json metadata_ = nlohmann::json::object();
+  trossen::hw::policy::Observation last_obs_;
+};
+
+class PolicyClientTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    ActiveHardwareRegistry::clear();
+  }
+};
+
+TEST_F(PolicyClientTest, ConstructorRegistersFacesAndComputesTotalN) {
+  auto fake = std::make_unique<FakeTransport>();
+  FakeTransport* fake_ptr = fake.get();
+  (void)fake_ptr;
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left"),
+                 make_joint_sub("follower_right", "state.right")},
+                {make_layout("policy_left", 0, 7),
+                 make_layout("policy_right", 7, 7)}),
+    std::move(fake));
+
+  EXPECT_EQ(client.total_joint_count(), 14);
+  ASSERT_EQ(client.faces().size(), 2u);
+  EXPECT_EQ(client.faces()[0]->get_identifier(), "policy_left");
+  EXPECT_EQ(client.faces()[0]->joint_offset(), 0);
+  EXPECT_EQ(client.faces()[0]->joint_count(), 7);
+  EXPECT_EQ(client.faces()[1]->get_identifier(), "policy_right");
+  EXPECT_EQ(client.faces()[1]->joint_offset(), 7);
+  EXPECT_EQ(client.faces()[1]->joint_count(), 7);
+  EXPECT_TRUE(ActiveHardwareRegistry::is_registered("policy_left"));
+  EXPECT_TRUE(ActiveHardwareRegistry::is_registered("policy_right"));
+}
+
+TEST_F(PolicyClientTest, ConstructorThrowsOnNullTransport) {
+  EXPECT_THROW(
+    PolicyClient(
+      make_config("pc1",
+                  {make_joint_sub("follower_left", "state.left")},
+                  {make_layout("policy_left", 0, 7)}),
+      nullptr),
+    std::invalid_argument);
+}
+
+TEST_F(PolicyClientTest, SubscriptionHandlerPopulatesCache) {
+  auto fake = std::make_unique<FakeTransport>();
+  fake->set_canned_chunk(2, 2, {1.0f, 2.0f, 3.0f, 4.0f});
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2)},
+                /*inference_hz=*/50.0),
+    std::move(fake));
+
+  ASSERT_TRUE(client.start());
+  client.set_control_rate_hz(30.0);
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.5f, 0.6f};
+
+  // Offer until the handler has run and the inference loop has shipped a chunk.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  EXPECT_GT(client.chunks_published(), 0u);
+  client.stop();
+}
+
+TEST_F(PolicyClientTest, InferenceTicksAtConfiguredRate) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(2, 2, {1.0f, 2.0f, 3.0f, 4.0f});
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+
+  // High control rate so the fire-point wait completes in ~2ms
+  // (T=2 / 1000 Hz). Without this, the inference loop would be gated by
+  // chunk consumption at the default 30 Hz × T=2 = 67 ms per chunk,
+  // which the assertion below — that aims to validate the configured
+  // inference_hz, not playback timing — would otherwise fail.
+  client.set_control_rate_hz(1000.0);
+
+  // Seed the cache so pack_observation_ has something to ship.
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.1f, 0.2f};
+
+  ASSERT_TRUE(client.start());
+  // Push some records so the subscription cache stays populated.
+  for (int i = 0; i < 10; ++i) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  client.stop();
+
+  // 200 Hz over ~200 ms should give us many round-trips; assert a conservative
+  // lower bound that tolerates startup jitter and scheduler noise.
+  EXPECT_GE(fake->request_count(), 5u);
+}
+
+TEST_F(PolicyClientTest, PauseResumeUnderLoadIsRaceFree) {
+  // Toggle set_inference_active from a separate thread while the inference loop
+  // runs and Faces are polled, exercising the per-episode pause/resume path
+  // (the chunk-timing target/epoch state must stay inference-thread-owned).
+  // This is a liveness/no-crash check; run under ThreadSanitizer to also catch
+  // data races on that state.
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(2, 2, {1.0f, 2.0f, 3.0f, 4.0f});
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+  client.set_control_rate_hz(1000.0);
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.1f, 0.2f};
+
+  ASSERT_TRUE(client.start());
+
+  std::atomic<bool> stop{false};
+  std::thread feeder([&] {
+    while (!stop.load()) {
+      client.offer(rec);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  });
+  std::thread reader([&] {
+    while (!stop.load()) {
+      (void)client.faces()[0]->read();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  });
+
+  // Hammer pause/resume from this (episode) thread for ~200 ms.
+  for (int i = 0; i < 100; ++i) {
+    client.set_inference_active(i % 2 == 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  client.set_inference_active(true);
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  stop.store(true);
+  feeder.join();
+  reader.join();
+  client.stop();
+
+  // Survived the toggling and still made progress.
+  EXPECT_GT(fake->request_count(), 0u);
+}
+
+TEST_F(PolicyClientTest, ChunkNMismatchIsRejectedAndHeldLast) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  // Server returns 3 cols but layout wants 2 — must be ignored.
+  fake->set_canned_chunk(2, 3, {1, 2, 3, 4, 5, 6});
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.0f, 0.0f};
+  client.set_control_rate_hz(30.0);
+
+  ASSERT_TRUE(client.start());
+  for (int i = 0; i < 10; ++i) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  // Round-trips happened, but no chunk was published.
+  EXPECT_GT(fake->request_count(), 0u);
+  EXPECT_EQ(client.chunks_published(), 0u);
+
+  // Faces still produce a non-empty zero vector (hold-last-action).
+  auto face_cmd = client.faces()[0]->read();
+  EXPECT_EQ(face_cmd.size(), 2u);
+  EXPECT_FLOAT_EQ(face_cmd[0], 0.0f);
+  EXPECT_FLOAT_EQ(face_cmd[1], 0.0f);
+
+  client.stop();
+}
+
+TEST_F(PolicyClientTest, FacesSliceCommandedRow) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  // Single-row chunk so we know exactly which row will be sampled.
+  const std::vector<float> row = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f,
+                                  1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f};
+  fake->set_canned_chunk(1, 14, row);
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0),
+                 make_joint_sub("follower_right", "state.right", 200.0)},
+                {make_layout("policy_left", 0, 7),
+                 make_layout("policy_right", 7, 7)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+
+  client.set_control_rate_hz(30.0);
+
+  // prime_observation_cache_ blocks the inference thread until each
+  // subscription has received at least one record, so we must offer for both
+  // arms (not just follower_left).
+  auto left_rec = std::make_shared<JointStateRecord>();
+  left_rec->id = "follower_left";
+  left_rec->positions = {0.0f, 0.0f};
+  auto right_rec = std::make_shared<JointStateRecord>();
+  right_rec->id = "follower_right";
+  right_rec->positions = {0.0f, 0.0f};
+
+  ASSERT_TRUE(client.start());
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(left_rec);
+    client.offer(right_rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+
+  auto left = client.faces()[0]->read();
+  auto right = client.faces()[1]->read();
+  ASSERT_EQ(left.size(), 7u);
+  ASSERT_EQ(right.size(), 7u);
+  for (int i = 0; i < 7; ++i) {
+    EXPECT_FLOAT_EQ(left[i], row[i]);
+    EXPECT_FLOAT_EQ(right[i], row[7 + i]);
+  }
+
+  client.stop();
+  (void)fake;
+}
+
+TEST_F(PolicyClientTest, RequestFailureKeepsThreadAliveAndPreservesLastAction) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  const std::vector<float> row = {5.0f, 6.0f};
+  fake->set_canned_chunk(1, 2, row);
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+  client.set_control_rate_hz(30.0);
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.1f, 0.2f};
+
+  ASSERT_TRUE(client.start());
+  // Land one good chunk.
+  const auto first_deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < first_deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+
+  // Flip the transport to failing mode; the inference loop must survive.
+  // The failing request bumps failure_count and the fake (mirroring the real
+  // openpi transport) goes kDisconnected, so expect exactly one increment —
+  // later pushes drop silently per the transport contract. The freshness
+  // barrier blocks the inference thread until each subscription has delivered
+  // a new record this cycle, so keep offering through the observation window.
+  fake->set_fail_requests(true);
+  const auto before = client.transport_status().failure_count;
+  const auto fail_deadline =
+    std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+  while (client.transport_status().failure_count == before &&
+         std::chrono::steady_clock::now() < fail_deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  EXPECT_GT(client.transport_status().failure_count, before);
+  EXPECT_EQ(client.transport_status().state,
+            trossen::hw::policy::TransportStatus::State::kDisconnected);
+
+  // The Face still sees the previously commanded row (hold-last-action).
+  auto cmd = client.faces()[0]->read();
+  ASSERT_EQ(cmd.size(), 2u);
+  EXPECT_FLOAT_EQ(cmd[0], 5.0f);
+  EXPECT_FLOAT_EQ(cmd[1], 6.0f);
+
+  client.stop();
+}
+
+TEST_F(PolicyClientTest, StopJoinsCleanlyWithInFlightRequest) {
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(1, 2, {1.0f, 2.0f});
+  fake->set_reply_delay(std::chrono::milliseconds(500));
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2)},
+                /*inference_hz=*/100.0),
+    std::move(fake_owned));
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.0f, 0.0f};
+
+  ASSERT_TRUE(client.start());
+  // Let the inference thread push and enter its chunk-poll wait, then stop.
+  client.offer(rec);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  const auto t0 = std::chrono::steady_clock::now();
+  client.stop();
+  const auto elapsed = std::chrono::steady_clock::now() - t0;
+
+  // stop() must not wait out the 500 ms reply delay — the poll wait exits on
+  // inference_running_, independent of when the transport would deliver.
+  EXPECT_LT(elapsed, std::chrono::milliseconds(400));
+}
+
+TEST_F(PolicyClientTest, OnStartFailureMarksObserverDead) {
+  auto fake = std::make_unique<FakeTransport>();
+  fake->set_connect_throws(true);
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2)}),
+    std::move(fake));
+
+  EXPECT_FALSE(client.start());
+  // A failed on_start latches the observer stopped (one-shot; no restart).
+  EXPECT_TRUE(client.is_stopped());
+  EXPECT_FALSE(client.is_running());
+}
+
+TEST_F(PolicyClientTest, FaceReadIsNeverEmptyBeforeFirstChunk) {
+  auto fake = std::make_unique<FakeTransport>();
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 5)}),
+    std::move(fake));
+
+  // No start() and no chunk: the slot is empty, but the Face must still return
+  // a joint_count-sized zero vector.
+  auto cmd = client.faces()[0]->read();
+  ASSERT_EQ(cmd.size(), 5u);
+  for (float v : cmd) {
+    EXPECT_FLOAT_EQ(v, 0.0f);
+  }
+}
+
+TEST_F(PolicyClientTest, ObservationMatchesNeutralContract) {
+  // The client packs the transport-agnostic Observation; the openpi wire
+  // format (flattened state ndarray, CHW images, BGR quirk) is pinned in
+  // test_openpi_websocket_transport.cpp where it is now produced.
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(1, 14, std::vector<float>(14, 0.0f));
+
+  PolicyClientSubscriptionConfig cam_sub;
+  cam_sub.record_id = "cam_high/color";
+  cam_sub.obs_key = "images.cam_high";
+  cam_sub.throttle_hz = 200.0;
+  cam_sub.resize = std::make_pair(16, 16);
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left",  "state.left",  200.0),
+                 make_joint_sub("follower_right", "state.right", 200.0),
+                 cam_sub},
+                {make_layout("policy_left",  0, 7),
+                 make_layout("policy_right", 7, 7)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+
+  auto left_rec = std::make_shared<JointStateRecord>();
+  left_rec->id = "follower_left";
+  left_rec->positions = std::vector<float>(7, 0.5f);
+
+  auto right_rec = std::make_shared<JointStateRecord>();
+  right_rec->id = "follower_right";
+  right_rec->positions = std::vector<float>(7, 0.25f);
+
+  auto img_rec = std::make_shared<trossen::data::ImageRecord>();
+  img_rec->id = "cam_high/color";
+  img_rec->encoding = "bgr8";
+  img_rec->image = cv::Mat(8, 8, CV_8UC3, cv::Scalar(10, 20, 30));
+
+  ASSERT_TRUE(client.start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(left_rec);
+    client.offer(right_rec);
+    client.offer(img_rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+  client.stop();
+
+  const auto obs = fake->last_observation();
+
+  // state: one named group per joint_layout entry, in layout order, padded
+  // to the layout's declared joint_count.
+  ASSERT_EQ(obs.state.size(), 2u);
+  EXPECT_EQ(obs.state[0].name, "policy_left");
+  EXPECT_EQ(obs.state[1].name, "policy_right");
+  ASSERT_EQ(obs.state[0].values.size(), 7u);
+  ASSERT_EQ(obs.state[1].values.size(), 7u);
+  for (float v : obs.state[0].values) EXPECT_FLOAT_EQ(v, 0.5f);
+  for (float v : obs.state[1].values) EXPECT_FLOAT_EQ(v, 0.25f);
+  // joint_names: deliberately empty in L2 (no config/record source yet).
+  EXPECT_TRUE(obs.state[0].joint_names.empty());
+
+  // images: the configured camera, resized per the subscription, HWC RGB.
+  ASSERT_EQ(obs.images.size(), 1u);
+  EXPECT_EQ(obs.images[0].camera, "cam_high");
+  EXPECT_EQ(obs.images[0].width, 16);
+  EXPECT_EQ(obs.images[0].height, 16);
+  EXPECT_EQ(obs.images[0].rgb.size(), 16u * 16u * 3u);
+
+  EXPECT_EQ(obs.task, "test");
+  // L5: timestep is stamped from the Timestep Clock (non-negative ticks since
+  // the active-window epoch). At the default θ=0 cadence each observation is
+  // packed at end-of-chunk, so the action buffer is empty and must_go is set.
+  EXPECT_GE(obs.timestep, 0);
+  EXPECT_TRUE(obs.must_go);
+  // captured_at is stamped at packing time (epoch zero means "never set").
+  EXPECT_NE(obs.captured_at.time_since_epoch().count(), 0);
+}
+
+TEST_F(PolicyClientTest, ConfiguredJointNamesPropagateToStateGroups) {
+  // joint_names from the layout config must reach the neutral StateGroup so
+  // name-keyed transports (LeRobot's "<name>.pos") can use them.
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(1, 2, std::vector<float>(2, 0.0f));
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2, {"waist", "gripper"})},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.1f, 0.2f};
+
+  ASSERT_TRUE(client.start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+  client.stop();
+
+  const auto obs = fake->last_observation();
+  ASSERT_EQ(obs.state.size(), 1u);
+  ASSERT_EQ(obs.state[0].joint_names.size(), 2u);
+  EXPECT_EQ(obs.state[0].joint_names[0], "waist");
+  EXPECT_EQ(obs.state[0].joint_names[1], "gripper");
+}
+
+TEST_F(PolicyClientTest, LerobotConfigDerivesStateNamesFromJointNames) {
+  // End-to-end config chain: joint_names -> injected motor_names -> the
+  // lerobot_grpc transport's observation.state feature names. configure()
+  // builds the transport (running parse_policy_config) but does NOT connect.
+  const char* kJson = R"({
+    "id": "l7_client",
+    "transport": "lerobot_grpc",
+    "server_url": "127.0.0.1:8000",
+    "inference_hz": 10.0,
+    "prompt": "demo",
+    "subscriptions": [
+      { "record_id": "fl", "throttle_hz": 30.0, "obs_key": "state.left" },
+      { "record_id": "fr", "throttle_hz": 30.0, "obs_key": "state.right" },
+      { "record_id": "ch", "throttle_hz": 30.0, "obs_key": "images.cam_high" }
+    ],
+    "joint_layout": [
+      { "leader_id": "l7_left",  "joint_offset": 0, "joint_count": 2,
+        "joint_names": ["left_joint_0", "left_joint_1"] },
+      { "leader_id": "l7_right", "joint_offset": 2, "joint_count": 2,
+        "joint_names": ["right_joint_0", "right_joint_1"] }
+    ],
+    "transport_config": {
+      "policy_type": "pi05",
+      "pretrained_name_or_path": "org/model",
+      "actions_per_chunk": 50,
+      "lerobot_features": {
+        "observation.state": { "dtype": "float32", "shape": [4] },
+        "observation.images.cam_high": { "dtype": "image", "shape": [480, 640, 3] }
+      }
+    }
+  })";
+
+  // observation.state names are derived from joint_names (4 == shape[0]), so
+  // configure succeeds without listing them explicitly.
+  PolicyClient client("l7_client");
+  EXPECT_NO_THROW(client.configure(nlohmann::json::parse(kJson)));
+
+  // Without joint_names (and no explicit feature names), the state feature has
+  // no component names and the transport factory must reject the config.
+  auto j = nlohmann::json::parse(kJson);
+  j["id"] = "l7_client_bad";
+  j["joint_layout"][0].erase("joint_names");
+  j["joint_layout"][1].erase("joint_names");
+  PolicyClient bad("l7_client_bad");
+  EXPECT_THROW(bad.configure(j), std::runtime_error);
+}
+
+TEST_F(PolicyClientTest, RejectsUnsupportedCameraKey) {
+  PolicyClientSubscriptionConfig bad_cam;
+  bad_cam.record_id = "bogus/color";
+  bad_cam.obs_key = "images.bogus";
+  bad_cam.throttle_hz = 200.0;
+
+  EXPECT_THROW(
+    PolicyClient(
+      make_config("pc1",
+                  {make_joint_sub("follower_left", "state.left", 200.0), bad_cam},
+                  {make_layout("policy_left", 0, 7)}),
+      std::make_unique<FakeTransport>()),
+    std::runtime_error);
+}
+
+TEST_F(PolicyClientTest, RejectsStateJointLayoutCountMismatch) {
+  EXPECT_THROW(
+    PolicyClient(
+      make_config("pc1",
+                  {make_joint_sub("follower_left", "state.left", 200.0)},
+                  {make_layout("policy_left", 0, 7),
+                   make_layout("policy_right", 7, 7)}),
+      std::make_unique<FakeTransport>()),
+    std::runtime_error);
+}
+
+TEST_F(PolicyClientTest, ConstructorRollsBackPartialRegistrationOnCollision) {
+  // Pre-register policy_right so the second Face would collide.
+  class StubFace : public trossen::hw::HardwareComponent {
+   public:
+    explicit StubFace(const std::string& id)
+      : trossen::hw::HardwareComponent(id) {}
+    void configure(const nlohmann::json&) override {}
+    std::string get_type() const override { return "stub"; }
+  };
+  ActiveHardwareRegistry::register_active(
+    "policy_right", std::make_shared<StubFace>("policy_right"));
+
+  EXPECT_THROW(
+    PolicyClient(
+      make_config("pc1",
+                  {make_joint_sub("follower_left",  "state.left",  200.0),
+                   make_joint_sub("follower_right", "state.right", 200.0)},
+                  {make_layout("policy_left",  0, 7),
+                   make_layout("policy_right", 7, 7)}),
+      std::make_unique<FakeTransport>()),
+    std::runtime_error);
+
+  // policy_left must not have been left behind in the registry.
+  EXPECT_FALSE(ActiveHardwareRegistry::is_registered("policy_left"));
+  EXPECT_TRUE(ActiveHardwareRegistry::is_registered("policy_right"));
+}
+
+TEST_F(PolicyClientTest, InferenceFiringIsGatedByChunkExhaustion) {
+  // The inference loop must hold off the next round-trip until the
+  // currently-playing chunk reaches its expected exhaustion instant. This
+  // mirrors openpi's synchronous "request after chunk consumed" semantics
+  // and removes the "policy commands arm backward at chunk boundary"
+  // artifact caused by mid-chunk observation packing.
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  // T=10 rows; at control_rate=100 Hz, each chunk plays for 100 ms.
+  // inference_hz=200 (period=5 ms) would *want* to fire much faster, but
+  // the chunk-exhaust wait should pin the round-trip cadence near 100 ms.
+  fake->set_canned_chunk(10, 2, std::vector<float>(20, 0.5f));
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left", 200.0)},
+                {make_layout("policy_left", 0, 2)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+  client.set_control_rate_hz(100.0);
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.1f, 0.2f};
+
+  ASSERT_TRUE(client.start());
+
+  // Simulate the teleop_controller polling the face at control_rate_hz so
+  // ChunkSlot::sample() can promote pending → latest as chunks exhaust.
+  // Without this the slot stays anchored to the first chunk and the
+  // exhaustion time never advances — the wait would return immediately
+  // after one chunk worth of elapsed time and the loop would free-run.
+  std::atomic<bool> poll_active{true};
+  std::thread poll_thread([&]() {
+    while (poll_active.load(std::memory_order_acquire)) {
+      (void)client.faces()[0]->read();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  });
+
+  const auto start = std::chrono::steady_clock::now();
+  // Run for 450 ms with the cache continuously fed.
+  while (std::chrono::steady_clock::now() - start <
+         std::chrono::milliseconds(450)) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  const auto trips = fake->request_count();
+  poll_active.store(false, std::memory_order_release);
+  poll_thread.join();
+  client.stop();
+
+  // Expected: roughly 1 (initial) + 4 (one per 100 ms chunk exhaustion)
+  // = ~5 round-trips in 450 ms. Allow a generous window for jitter, but
+  // assert that we're nowhere near the 200 Hz × 0.45 s = 90 cap that a
+  // broken (un-gated) implementation would produce.
+  EXPECT_GE(trips, 3u) << "chunk-exhaust wait should not deadlock";
+  EXPECT_LE(trips, 12u)
+    << "chunk-exhaust wait should be holding off the inference loop; "
+       "got " << trips << " round-trips in 450 ms — implementation "
+       "regression?";
+}
+
+TEST_F(PolicyClientTest, DrainThresholdFiresMidChunkAndClearsMustGo) {
+  // θ=0.5: fire the next observation halfway through each chunk (async
+  // overlap), so the cadence is ~2x the θ=0 end-of-chunk rate and the buffer
+  // is not empty at the fire point (must_go clears).
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  // T=10 rows at 100 Hz → 100 ms/chunk; θ=0.5 fires at 50 ms.
+  fake->set_canned_chunk(10, 2, std::vector<float>(20, 0.5f));
+
+  auto cfg = make_config("pc1",
+                         {make_joint_sub("follower_left", "state.left", 200.0)},
+                         {make_layout("policy_left", 0, 2)},
+                         /*inference_hz=*/200.0);
+  cfg.drain_threshold = 0.5;
+  PolicyClient client(std::move(cfg), std::move(fake_owned));
+  client.set_control_rate_hz(100.0);
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.1f, 0.2f};
+
+  ASSERT_TRUE(client.start());
+
+  // Poll the face so the slot's playback advances (and the timestep clock the
+  // alignment depends on tracks real elapsed time).
+  std::atomic<bool> poll_active{true};
+  std::thread poll_thread([&]() {
+    while (poll_active.load(std::memory_order_acquire)) {
+      (void)client.faces()[0]->read();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  });
+
+  const auto start = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() - start <
+         std::chrono::milliseconds(450)) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  const auto trips = fake->request_count();
+  poll_active.store(false, std::memory_order_release);
+  poll_thread.join();
+
+  const auto obs = fake->last_observation();
+  client.stop();
+
+  // ~450 ms / 50 ms ≈ 9 fires + initial; faster than the θ=0 cadence (~5) but
+  // still gated well below the 200 Hz × 0.45 s = 90 free-run cap.
+  EXPECT_GE(trips, 6u) << "θ=0.5 should fire roughly twice the θ=0 cadence";
+  EXPECT_LE(trips, 20u) << "drain firing should still gate the loop";
+  // Steady-state fires happen mid-chunk, so the buffer is not empty.
+  EXPECT_FALSE(obs.must_go) << "mid-chunk fire should not flag starvation";
+}
+
+TEST_F(PolicyClientTest, OutputEmaPassesGripperThroughByDefault) {
+  // Gripper open/close is a fast transient; smoothing it like the arm
+  // joints causes the gripper to reach only ~70% of commanded extent.
+  // Default contract: arm joints filter, last joint (gripper by
+  // convention) passes through unchanged.
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  // 3-joint slice: cols 0,1 = arm; col 2 = "gripper".
+  fake->set_canned_chunk(1, 3, {10.0f, 20.0f, 0.05f});
+
+  auto cfg = make_config(
+    "pc1",
+    {make_joint_sub("follower_left", "state.left", 200.0)},
+    {make_layout("policy_left", 0, 3)},
+    /*inference_hz=*/200.0);
+  cfg.output_ema_alpha = 0.5;
+  // output_ema_alpha_gripper stays at default 1.0.
+
+  PolicyClient client(cfg, std::move(fake_owned));
+  client.set_control_rate_hz(1000.0);
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.0f, 0.0f, 0.0f};
+
+  ASSERT_TRUE(client.start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+
+  auto& face = client.faces()[0];
+  face->reset_output_filter();
+
+  // Seed: first read passes through.
+  auto r1 = face->read();
+  ASSERT_EQ(r1.size(), 3u);
+  EXPECT_FLOAT_EQ(r1[0], 10.0f);
+  EXPECT_FLOAT_EQ(r1[1], 20.0f);
+  EXPECT_FLOAT_EQ(r1[2], 0.05f);  // gripper
+
+  // Reseed with a row that jumps every joint, then read.
+  fake->set_canned_chunk(1, 3, {20.0f, 40.0f, 0.10f});
+  const auto step_deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  const auto pubs_before = client.chunks_published();
+  while (client.chunks_published() == pubs_before &&
+         std::chrono::steady_clock::now() < step_deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), pubs_before);
+
+  // Single read should show: arm joints blended (0.5*new + 0.5*prev),
+  // gripper at the raw chunk value (pass-through).
+  auto r2 = face->read();
+  EXPECT_NEAR(r2[0], 15.0f, 1e-4);    // 0.5*20 + 0.5*10
+  EXPECT_NEAR(r2[1], 30.0f, 1e-4);    // 0.5*40 + 0.5*20
+  EXPECT_NEAR(r2[2], 0.10f, 1e-6);    // gripper: full new value
+  client.stop();
+  (void)fake;
+}
+
+TEST_F(PolicyClientTest, OutputEmaFiltersFaceReadAcrossTicks) {
+  // EMA contract: out_t = α·row + (1-α)·prev_out_t-1, applied per Face.
+  // First read passes the row through unchanged (no prev_out yet). Second
+  // read blends. α=1.0 is a no-op. Reset clears the history.
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  // Single-row chunk: row=[10,20]. Faces always see this exact row.
+  fake->set_canned_chunk(1, 2, {10.0f, 20.0f});
+
+  auto cfg = make_config(
+    "pc1",
+    {make_joint_sub("follower_left", "state.left", 200.0)},
+    {make_layout("policy_left", 0, 2)},
+    /*inference_hz=*/200.0);
+  cfg.output_ema_alpha = 0.5;  // half-blend each tick
+  // The slice here is only 2 joints, so joint 1 *is* the "gripper" by
+  // last-index convention. Force the gripper coefficient to match the arm
+  // coefficient so this test exercises the EMA math on both channels.
+  cfg.output_ema_alpha_gripper = 0.5;
+
+  PolicyClient client(cfg, std::move(fake_owned));
+  client.set_control_rate_hz(1000.0);  // chunks exhaust fast in tests
+
+  auto rec = std::make_shared<JointStateRecord>();
+  rec->id = "follower_left";
+  rec->positions = {0.0f, 0.0f};
+
+  ASSERT_TRUE(client.start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+
+  auto& face = client.faces()[0];
+
+  // Reset history so the next read is the documented first-tick path.
+  face->reset_output_filter();
+
+  // First read: pass-through. prev_out_ was empty.
+  auto r1 = face->read();
+  ASSERT_EQ(r1.size(), 2u);
+  EXPECT_FLOAT_EQ(r1[0], 10.0f);
+  EXPECT_FLOAT_EQ(r1[1], 20.0f);
+
+  // Second read: out = 0.5*[10,20] + 0.5*[10,20] = [10,20]. Same row, so
+  // value is unchanged but the filter ran (would show on a changing row).
+  auto r2 = face->read();
+  EXPECT_FLOAT_EQ(r2[0], 10.0f);
+  EXPECT_FLOAT_EQ(r2[1], 20.0f);
+
+  // Simulate a row jump to [20,40] by reseeding with a new chunk, then
+  // verify the EMA smooths the transition rather than stepping.
+  fake->set_canned_chunk(1, 2, {20.0f, 40.0f});
+  // Force a new chunk through by waiting for inference to fire again.
+  const auto step_deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  const auto pubs_before = client.chunks_published();
+  while (client.chunks_published() == pubs_before &&
+         std::chrono::steady_clock::now() < step_deadline) {
+    client.offer(rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), pubs_before);
+
+  // Now read three times — each one should be halfway between prev_out
+  // and the new row.
+  auto s1 = face->read();   // prev=[10,20], new=[20,40] → [15,30]
+  auto s2 = face->read();   // prev=[15,30], new=[20,40] → [17.5,35]
+  auto s3 = face->read();   // prev=[17.5,35], new=[20,40] → [18.75,37.5]
+  EXPECT_NEAR(s1[0], 15.0f, 1e-4);
+  EXPECT_NEAR(s1[1], 30.0f, 1e-4);
+  EXPECT_NEAR(s2[0], 17.5f, 1e-4);
+  EXPECT_NEAR(s2[1], 35.0f, 1e-4);
+  EXPECT_NEAR(s3[0], 18.75f, 1e-4);
+  EXPECT_NEAR(s3[1], 37.5f, 1e-4);
+
+  client.stop();
+  (void)fake;
+}
+
+TEST_F(PolicyClientTest, ObservationCarriesTrueRgbRegardlessOfRecordEncoding) {
+  // The neutral Observation contract is TRUE RGB, always: a bgr8 record must
+  // be converted by the client, so every transport starts from the same
+  // bytes. openpi's BGR-as-RGB training quirk is applied inside that
+  // transport and pinned in test_openpi_websocket_transport.cpp — if THIS
+  // test sees swapped channels, the client is leaking a wire convention.
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  fake->set_canned_chunk(1, 14, std::vector<float>(14, 0.0f));
+
+  PolicyClientSubscriptionConfig cam_sub;
+  cam_sub.record_id = "cam_high/color";
+  cam_sub.obs_key = "images.cam_high";
+  cam_sub.throttle_hz = 200.0;
+  cam_sub.resize = std::make_pair(4, 4);
+
+  PolicyClient client(
+    make_config("pc1",
+                {make_joint_sub("follower_left",  "state.left",  200.0),
+                 make_joint_sub("follower_right", "state.right", 200.0),
+                 cam_sub},
+                {make_layout("policy_left",  0, 7),
+                 make_layout("policy_right", 7, 7)},
+                /*inference_hz=*/200.0),
+    std::move(fake_owned));
+
+  auto left_rec = std::make_shared<JointStateRecord>();
+  left_rec->id = "follower_left";
+  left_rec->positions = std::vector<float>(7, 0.0f);
+  auto right_rec = std::make_shared<JointStateRecord>();
+  right_rec->id = "follower_right";
+  right_rec->positions = std::vector<float>(7, 0.0f);
+
+  // Construct a uniform-color image in BGR memory order:
+  //   B=100, G=150, R=200 at every pixel.
+  // cv::Scalar for a 3-channel image follows OpenCV's BGR convention.
+  auto img_rec = std::make_shared<trossen::data::ImageRecord>();
+  img_rec->id = "cam_high/color";
+  img_rec->encoding = "bgr8";
+  img_rec->image = cv::Mat(4, 4, CV_8UC3, cv::Scalar(100, 150, 200));
+
+  ASSERT_TRUE(client.start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client.offer(left_rec);
+    client.offer(right_rec);
+    client.offer(img_rec);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+  client.stop();
+
+  const auto obs = fake->last_observation();
+  ASSERT_EQ(obs.images.size(), 1u);
+  const auto& img = obs.images[0];
+  EXPECT_EQ(img.camera, "cam_high");
+  // HWC interleaved: 4x4 pixels x 3 channels, 48 bytes total.
+  ASSERT_EQ(img.rgb.size(), 48u);
+  // The bgr8 record carried B=100, G=150, R=200 per pixel; the neutral image
+  // must be TRUE RGB: every pixel is [R=200, G=150, B=100].
+  for (int p = 0; p < 16; ++p) {
+    EXPECT_EQ(static_cast<int>(img.rgb[p * 3]), 200)
+      << "pixel " << p << " channel R expected scene_R=200";
+    EXPECT_EQ(static_cast<int>(img.rgb[p * 3 + 1]), 150)
+      << "pixel " << p << " channel G expected scene_G=150";
+    EXPECT_EQ(static_cast<int>(img.rgb[p * 3 + 2]), 100)
+      << "pixel " << p << " channel B expected scene_B=100";
+  }
+  (void)fake;
+}
+
+TEST_F(PolicyClientTest, JsonlLogEmitsDiagnosticFields) {
+  // Diagnostic schema regression: every new field added for openpi/SDK
+  // side-by-side comparison must appear on every request/response line.
+  // Failure of this test means the diff_runs.py invariants will break.
+  const auto log_path =
+    std::filesystem::temp_directory_path() /
+    "test_policy_client_diag_log.jsonl";
+  std::error_code ec;
+  std::filesystem::remove(log_path, ec);
+
+  auto fake_owned = std::make_unique<FakeTransport>();
+  FakeTransport* fake = fake_owned.get();
+  // Chunk with T=4, N=14 so col_l1 / row_l1_samples / gripper_traj have data.
+  std::vector<float> chunk(4 * 14);
+  for (int t = 0; t < 4; ++t) {
+    for (int n = 0; n < 14; ++n) {
+      chunk[t * 14 + n] = static_cast<float>(0.01 * (t + 1) * (n + 1));
+    }
+  }
+  fake->set_canned_chunk(4, 14, chunk);
+
+  auto cfg = make_config(
+    "pc1",
+    {make_joint_sub("follower_left",  "state.left",  200.0),
+     make_joint_sub("follower_right", "state.right", 200.0)},
+    {make_layout("policy_left",  0, 7),
+     make_layout("policy_right", 7, 7)},
+    /*inference_hz=*/200.0);
+  cfg.log_path = log_path.string();
+
+  PolicyClient client(cfg, std::move(fake_owned));
+  client.set_control_rate_hz(30.0);
+
+  auto left = std::make_shared<JointStateRecord>();
+  left->id = "follower_left";
+  left->positions = std::vector<float>(7, 0.5f);
+  // Stamp the records so age computation has something non-zero to subtract.
+  // now_mono() returns steady_clock ns, matching what the inference thread
+  // uses, so age = (now - rec.ts) is well-defined.
+  left->ts.monotonic = trossen::data::now_mono();
+
+  auto right = std::make_shared<JointStateRecord>();
+  right->id = "follower_right";
+  right->positions = std::vector<float>(7, -0.5f);
+  right->ts.monotonic = trossen::data::now_mono();
+
+  ASSERT_TRUE(client.start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client.chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    // Refresh timestamps so each delivery looks fresh; otherwise repeated
+    // offers of the same record would carry an ever-aging ts.
+    left->ts.monotonic = trossen::data::now_mono();
+    right->ts.monotonic = trossen::data::now_mono();
+    client.offer(left);
+    client.offer(right);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client.chunks_published(), 0u);
+  client.stop();
+
+  std::ifstream in(log_path);
+  ASSERT_TRUE(in.is_open());
+
+  nlohmann::json first_req;
+  nlohmann::json first_resp;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (line.empty()) continue;
+    auto j = nlohmann::json::parse(line);
+    if (j["event"] == "request" && first_req.is_null()) first_req = j;
+    if (j["event"] == "response" && first_resp.is_null()) first_resp = j;
+    if (!first_req.is_null() && !first_resp.is_null()) break;
+  }
+  std::filesystem::remove(log_path, ec);
+  ASSERT_FALSE(first_req.is_null());
+  ASSERT_FALSE(first_resp.is_null());
+
+  // Request schema: all diagnostic fields must be present.
+  EXPECT_TRUE(first_req.contains("obs_collect_ms"));
+  EXPECT_TRUE(first_req.contains("cycle_interval_ms"));
+  EXPECT_TRUE(first_req.contains("obs_ages_ms"));
+  EXPECT_TRUE(first_req.contains("obs_skew_ms"));
+  ASSERT_TRUE(first_req["obs_ages_ms"].is_object());
+  EXPECT_TRUE(first_req["obs_ages_ms"].contains("follower_left"));
+  EXPECT_TRUE(first_req["obs_ages_ms"].contains("follower_right"));
+
+  // Response schema: chunk shape diagnostics must be present.
+  EXPECT_TRUE(first_resp.contains("col_l1"));
+  EXPECT_TRUE(first_resp.contains("row_l1_samples"));
+  EXPECT_TRUE(first_resp.contains("gripper_traj_per_arm"));
+  ASSERT_TRUE(first_resp["col_l1"].is_array());
+  EXPECT_EQ(first_resp["col_l1"].size(), 14u);
+  ASSERT_TRUE(first_resp["row_l1_samples"].is_array());
+  EXPECT_EQ(first_resp["row_l1_samples"].size(), 5u);
+  ASSERT_TRUE(first_resp["gripper_traj_per_arm"].is_object());
+  EXPECT_TRUE(first_resp["gripper_traj_per_arm"].contains("policy_left"));
+  EXPECT_TRUE(first_resp["gripper_traj_per_arm"].contains("policy_right"));
+  EXPECT_EQ(first_resp["gripper_traj_per_arm"]["policy_left"].size(), 4u);
+}
+
+TEST_F(PolicyClientTest, DestructorUnregistersFaces) {
+  {
+    PolicyClient client(
+      make_config("pc1",
+                  {make_joint_sub("follower_left", "state.left", 200.0)},
+                  {make_layout("policy_left", 0, 7)}),
+      std::make_unique<FakeTransport>());
+    EXPECT_TRUE(ActiveHardwareRegistry::is_registered("policy_left"));
+  }
+  EXPECT_FALSE(ActiveHardwareRegistry::is_registered("policy_left"));
+}
+
+}  // namespace

--- a/tests/test_policy_client.cpp
+++ b/tests/test_policy_client.cpp
@@ -660,7 +660,7 @@ TEST_F(PolicyClientTest, ObservationMatchesNeutralContract) {
   ASSERT_EQ(obs.state[1].values.size(), 7u);
   for (float v : obs.state[0].values) EXPECT_FLOAT_EQ(v, 0.5f);
   for (float v : obs.state[1].values) EXPECT_FLOAT_EQ(v, 0.25f);
-  // joint_names: deliberately empty in L2 (no config/record source yet).
+  // joint_names: deliberately empty (no config/record source in this path).
   EXPECT_TRUE(obs.state[0].joint_names.empty());
 
   // images: the configured camera, resized per the subscription, HWC RGB.
@@ -671,7 +671,7 @@ TEST_F(PolicyClientTest, ObservationMatchesNeutralContract) {
   EXPECT_EQ(obs.images[0].rgb.size(), 16u * 16u * 3u);
 
   EXPECT_EQ(obs.task, "test");
-  // L5: timestep is stamped from the Timestep Clock (non-negative ticks since
+  // timestep is stamped from the Timestep Clock (non-negative ticks since
   // the active-window epoch). At the default theta=0 cadence each observation is
   // packed at end-of-chunk, so the action buffer is empty and must_go is set.
   EXPECT_GE(obs.timestep, 0);


### PR DESCRIPTION
## Summary

Adds **`PolicyClient`** — the hardware/observer bridge that packs neutral `Observation`s, drives one `PolicyTransport` over the async push/poll contract, and presents per-arm action slices through `Face` adapters to the existing teleop machinery. This is the chunk-timing core of the subsystem.

> **Stack:** PolicyClient stack, based on #248. Review bottom-up (#252 → here).

## Changes

- In `include/trossen_sdk/hw/policy/policy_client.hpp` + `src/hw/policy/policy_client.cpp`: `PolicyClient` (multi-inherits `HardwareComponent` + `ObserverBase`) and its per-arm `Face`. Implements the inference loop and its timing model:
  - **timestep clock** (`⌊(now − epoch)·rate⌋`) stamped on every observation and paired with the chunk's `base_timestep` on the return path;
  - **drain-threshold θ** firing gate — at θ=0 it packs at chunk exhaustion (openpi cadence, end-of-chunk pose); at θ>0 it fires early to overlap inference with playback;
  - **freshness barrier** so every observation snapshot is co-temporal (bounds cross-camera skew);
  - **`must_go`** starvation flag for queueing servers;
  - **hold-last-action** under any failure (`Face::read()` never throws), plus per-arm EMA output smoothing.
- In `tests/test_policy_client.cpp` + `tests/CMakeLists.txt`: drives the client against a `FakeTransport` (the two-arg constructor) — chunk apply/publish, hold-last-action, pause/resume, width-mismatch rejection.
- In `cmake/policy_client.cmake`: add `policy_client.cpp` to the gated sources.

## Test Plan

- [x] Builds cleanly with `-DTROSSEN_SDK_ENABLE_POLICY_CLIENT=ON`
- [x] Tests pass — `test_policy_client`
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Hardware — chunk-timing validated end-to-end via the live pi05 integration (see #255)

## Breaking Changes

None. New gated sources behind `TROSSEN_SDK_ENABLE_POLICY_CLIENT` (default OFF).

## Related

Based on #248. Stacked on #252; followed by #254–#255.
