### PR TITLE
policy_client: producer + hardware-registry integration

### DIFF
--- a/cmake/policy_client.cmake
+++ b/cmake/policy_client.cmake
@@ -83,6 +83,7 @@ target_sources(trossen_sdk PRIVATE
   src/hw/policy/msgpack_ndarray.cpp
   src/hw/policy/openpi_websocket_transport.cpp
   src/hw/policy/policy_client.cpp
+  src/hw/policy/policy_client_producer.cpp
   src/hw/policy/transport_registry.cpp
   ${_lerobot_proto_out}/lerobot_transport_services.pb.cc
   ${_lerobot_proto_out}/lerobot_transport_services.grpc.pb.cc

--- a/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
@@ -55,10 +55,17 @@ struct ArmConfig {
   bool episode_lifecycle_enabled{false};
 
   /// @brief Per-tick trajectory time (seconds) passed to set_all_positions in
-  /// write_joint(). Zero applies the goal immediately (libtrossen_arm treats
-  /// goal_time < 0.001s as no-interpolation); non-zero smooths the per-tick
-  /// motion between successive writes. Used by the policy-client playback path
-  /// on top of its own EMA output filter.
+  /// TrossenArmComponent::write_joint(). Applies to every write on this arm,
+  /// regardless of who issues it (teleop, replay, or policy playback), not just
+  /// the policy-client path. Zero applies the goal immediately (libtrossen_arm
+  /// treats goal_time < 0.001s as no-interpolation); non-zero smooths the
+  /// per-tick motion between successive writes. Opt-in; defaults to 0.0 to
+  /// preserve prior immediate-apply behavior byte-for-byte. Validated as
+  /// non-negative and finite by TrossenArmComponent::configure().
+  /// Tuning trap: keep this below the session's control period. A per-tick
+  /// trajectory time longer than the interval to the next write means each goal
+  /// is superseded before it is reached, so the arm perpetually chases a moving
+  /// target and never settles.
   float write_moving_time_s{0.0f};
 
   static ArmConfig from_json(const nlohmann::json& j) {

--- a/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
@@ -23,7 +23,8 @@ namespace trossen::configuration {
  *   "end_effector": "wxai_v0_leader",
  *   "staged_position": [0.0, 1.04, 0.52, 0.63, 0.0, 0.0, 0.0],  // optional
  *   "staging_time_s": 2.0,                                // optional
- *   "episode_lifecycle_enabled": true                     // optional, default false
+ *   "episode_lifecycle_enabled": true,                    // optional, default false
+ *   "write_moving_time_s": 0.1                            // optional, default 0.0
  * }
  */
 struct ArmConfig {
@@ -53,6 +54,13 @@ struct ArmConfig {
   /// false so an arm is only re-homed between episodes when explicitly enabled.
   bool episode_lifecycle_enabled{false};
 
+  /// @brief Per-tick trajectory time (seconds) passed to set_all_positions in
+  /// write_joint(). Zero applies the goal immediately (libtrossen_arm treats
+  /// goal_time < 0.001s as no-interpolation); non-zero smooths the per-tick
+  /// motion between successive writes. Used by the policy-client playback path
+  /// on top of its own EMA output filter.
+  float write_moving_time_s{0.0f};
+
   static ArmConfig from_json(const nlohmann::json& j) {
     ArmConfig c;
     if (j.contains("ip_address")) j.at("ip_address").get_to(c.ip_address);
@@ -67,6 +75,9 @@ struct ArmConfig {
     if (j.contains("episode_lifecycle_enabled")) {
       j.at("episode_lifecycle_enabled").get_to(c.episode_lifecycle_enabled);
     }
+    if (j.contains("write_moving_time_s")) {
+      j.at("write_moving_time_s").get_to(c.write_moving_time_s);
+    }
     return c;
   }
 
@@ -76,7 +87,8 @@ struct ArmConfig {
       {"model", model},
       {"end_effector", end_effector},
       {"staging_time_s", staging_time_s},
-      {"episode_lifecycle_enabled", episode_lifecycle_enabled}
+      {"episode_lifecycle_enabled", episode_lifecycle_enabled},
+      {"write_moving_time_s", write_moving_time_s}
     };
     // Emit staging only when configured. TrossenArmComponent::configure()
     // rejects a present-but-wrong-length staged_position, so an empty array

--- a/include/trossen_sdk/configuration/types/producers/producer_config.hpp
+++ b/include/trossen_sdk/configuration/types/producers/producer_config.hpp
@@ -37,6 +37,7 @@ namespace trossen::configuration {
  *  - "realsense_camera" - RealSense image producer
  *  - "opencv_camera"    - OpenCV/V4L2 image producer
  *  - "slate_base"       - SLATE mobile base velocity producer
+ *  - "policy_client"    - polls a PolicyClient hardware entry; emits JointStateRecord
  */
 struct ProducerConfig {
   /// @brief Producer/hardware registry key (e.g. "trossen_arm", "realsense_camera")

--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -53,7 +53,8 @@ public:
    *   "model": "wxai_v0",
    *   "end_effector": "wxai_v0_follower",
    *   "staged_position": [0, 1.0, 0.5, 0.6, 0, 0, 0],  // optional, joint-space
-   *   "staging_time_s": 2.0           // optional, default 2.0
+   *   "staging_time_s": 2.0,       // optional, default 2.0 (stage / rest move)
+   *   "write_moving_time_s": 0.1   // optional, default 0.0 (per-tick smoothing)
    * }
    *
    * @param config JSON configuration object
@@ -165,6 +166,12 @@ private:
   /// Whether this arm participates in the per-episode lifecycle (staging before
   /// each episode). Opt-in; parsed from "episode_lifecycle_enabled" in configure().
   bool episode_lifecycle_enabled_{false};
+
+  /// Per-write trajectory time passed to set_all_positions in write_joint().
+  /// Zero means apply the goal immediately (libtrossen_arm interprets
+  /// goal_time < 0.001s as no-interpolation). Non-zero values smooth the
+  /// per-tick motion between successive write_joint() calls.
+  float write_moving_time_s_{0.0f};
 };
 
 }  // namespace trossen::hw::arm

--- a/include/trossen_sdk/hw/policy/policy_client_producer.hpp
+++ b/include/trossen_sdk/hw/policy/policy_client_producer.hpp
@@ -1,0 +1,108 @@
+/**
+ * @file policy_client_producer.hpp
+ * @brief Polled producer that emits the PolicyClient's currently commanded action row.
+ */
+
+#ifndef TROSSEN_SDK__HW__POLICY__POLICY_CLIENT_PRODUCER_HPP_
+#define TROSSEN_SDK__HW__POLICY__POLICY_CLIENT_PRODUCER_HPP_
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/policy/policy_client.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::hw::policy {
+
+/**
+ * @brief Producer that samples the latest commanded action from a PolicyClient.
+ *
+ * Constructed by the ProducerRegistry factory with a HardwareComponent shared_ptr
+ * (must downcast to PolicyClient) and a JSON config object containing ``stream_id``.
+ * On each poll, calls ``PolicyClient::current_command()`` and emits a
+ * ``JointStateRecord`` with that vector under the configured ``stream_id``.
+ */
+class PolicyClientProducer : public hw::PolledProducer {
+public:
+  /**
+   * @brief Per-producer configuration parsed from the JSON entry.
+   */
+  struct Config {
+    /// Stream identifier written to backend records (e.g. ``"policy_action"``).
+    std::string stream_id{"policy_action"};
+
+    /// When true, stamp emitted records with the latest action chunk's
+    /// ``received_at`` (steady-clock nanoseconds since epoch). When false, or
+    /// when no chunk has been published yet, use the wall-clock monotonic now.
+    bool use_device_time{false};
+  };
+
+  /**
+   * @brief Metadata for PolicyClientProducer: feature shape derived from joint count.
+   */
+  struct PolicyClientProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// Total number of joints in the commanded action row.
+    int joint_count{0};
+
+    /// Synthesized joint names (``joint_0`` .. ``joint_{N-1}``).
+    std::vector<std::string> joint_names;
+
+    nlohmann::ordered_json get_info() const override {
+      nlohmann::ordered_json features;
+      features["action"]["dtype"] = "float32";
+      features["action"]["shape"] = nlohmann::json::array({joint_count});
+      features["action"]["names"] = joint_names;
+      return features;
+    }
+
+    nlohmann::ordered_json get_stream_info() const override {
+      nlohmann::ordered_json info;
+      info["streams"][id]["joint_names"] = joint_names;
+      return info;
+    }
+  };
+
+  /**
+   * @brief Construct from a PolicyClient hardware component and a JSON config.
+   *
+   * @param hardware Hardware component; must be a ``PolicyClient``.
+   * @param config   JSON object with optional ``stream_id`` (default ``policy_action``)
+   *                 and ``use_device_time`` (default false) fields.
+   *
+   * @throws std::invalid_argument if @p hardware is null or not a ``PolicyClient``.
+   */
+  PolicyClientProducer(
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config);
+
+  ~PolicyClientProducer() override = default;
+
+  /**
+   * @brief Sample the client's current command and emit a JointStateRecord.
+   *
+   * @param emit Callback invoked with the produced record.
+   */
+  void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<PolicyClientProducerMetadata>(pc_metadata_);
+  }
+
+private:
+  std::shared_ptr<PolicyClient> client_;
+  Config cfg_;
+  // Named distinctly from the base PolledProducer's protected `metadata_` so it
+  // does not shadow it; this producer's metadata is the richer subtype and the
+  // base member is intentionally unused here.
+  PolicyClientProducerMetadata pc_metadata_;
+};
+
+}  // namespace trossen::hw::policy
+
+#endif  // TROSSEN_SDK__HW__POLICY__POLICY_CLIENT_PRODUCER_HPP_

--- a/include/trossen_sdk/hw/policy/policy_client_producer.hpp
+++ b/include/trossen_sdk/hw/policy/policy_client_producer.hpp
@@ -40,6 +40,10 @@ public:
     /// When true, stamp emitted records with the latest action chunk's
     /// ``received_at`` (steady-clock nanoseconds since epoch). When false, or
     /// when no chunk has been published yet, use the wall-clock monotonic now.
+    /// Known limitation: every action row sourced from a single chunk shares
+    /// that chunk's ``received_at``, so a multi-row chunk yields repeated
+    /// timestamps until the next chunk arrives. Correct per-row timing is a
+    /// deferred follow-up requiring a new PolicyClient accessor.
     bool use_device_time{false};
   };
 

--- a/src/hw/arm/trossen_arm_component.cpp
+++ b/src/hw/arm/trossen_arm_component.cpp
@@ -79,6 +79,13 @@ void TrossenArmComponent::configure(const nlohmann::json& config) {
   if (config.contains("episode_lifecycle_enabled")) {
     episode_lifecycle_enabled_ = config.at("episode_lifecycle_enabled").get<bool>();
   }
+  if (config.contains("write_moving_time_s")) {
+    write_moving_time_s_ = config.at("write_moving_time_s").get<float>();
+    if (write_moving_time_s_ < 0.0f || !std::isfinite(write_moving_time_s_)) {
+      throw std::runtime_error(
+        "TrossenArmComponent: 'write_moving_time_s' must be non-negative and finite");
+    }
+  }
 
   // TODO(lukeschmitt-tr): Can do other configuration like joint characteristics here if needed
 }
@@ -111,7 +118,7 @@ void TrossenArmComponent::write_joint(const std::vector<float>& cmd) {
       std::to_string(cmd.size()));
   }
   std::vector<double> pos_d(cmd.begin(), cmd.end());
-  driver_->set_all_positions(pos_d, 0.0, false);
+  driver_->set_all_positions(pos_d, write_moving_time_s_, false);
 }
 
 std::vector<float> TrossenArmComponent::read_cartesian() {

--- a/src/hw/policy/policy_client_producer.cpp
+++ b/src/hw/policy/policy_client_producer.cpp
@@ -1,0 +1,103 @@
+/**
+ * @file policy_client_producer.cpp
+ * @brief Implementation of PolicyClientProducer plus PolicyClient + producer registrations.
+ */
+
+#include "trossen_sdk/hw/policy/policy_client_producer.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/policy/action_chunk.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+
+namespace trossen::hw::policy {
+
+PolicyClientProducer::PolicyClientProducer(
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config) {
+  if (!hardware) {
+    throw std::invalid_argument(
+      "PolicyClientProducer: hardware component cannot be null");
+  }
+
+  client_ = std::dynamic_pointer_cast<PolicyClient>(hardware);
+  if (!client_) {
+    throw std::invalid_argument(
+      "PolicyClientProducer: hardware must be PolicyClient, got: " +
+      hardware->get_type());
+  }
+
+  if (config.contains("stream_id") && config.at("stream_id").is_string()) {
+    config.at("stream_id").get_to(cfg_.stream_id);
+  }
+  if (config.contains("use_device_time") && config.at("use_device_time").is_boolean()) {
+    config.at("use_device_time").get_to(cfg_.use_device_time);
+  }
+
+  // total_joint_count() is the sum of the PolicyClient's joint_layout, set when
+  // the client is configured. It is captured once here, so the producer must be
+  // created only after the client is configured; otherwise the metadata would
+  // advertise a zero-width row while the emitted rows are hold-last-action
+  // vectors. Fail loudly rather than record a mismatched dataset.
+  const int n = client_->total_joint_count();
+  if (n <= 0) {
+    throw std::runtime_error(
+      "PolicyClientProducer: backing PolicyClient must be configured before the "
+      "producer is created (total_joint_count() is " + std::to_string(n) + ")");
+  }
+  pc_metadata_.type = "policy_client";
+  pc_metadata_.id = cfg_.stream_id;
+  pc_metadata_.name = "Policy Client Producer";
+  pc_metadata_.description = "Emits the policy server's currently commanded action row";
+  pc_metadata_.joint_count = n;
+  pc_metadata_.joint_names.reserve(static_cast<std::size_t>(n));
+  for (int i = 0; i < n; ++i) {
+    pc_metadata_.joint_names.push_back("joint_" + std::to_string(i));
+  }
+}
+
+void PolicyClientProducer::poll(
+    const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {
+  if (!client_) {
+    return;
+  }
+
+  std::vector<float> cmd = client_->current_command();
+
+  data::Timestamp ts;
+  // Fall back to wall-clock when no chunk has arrived yet regardless of flag.
+  std::shared_ptr<const ActionChunk> chunk =
+    cfg_.use_device_time ? client_->latest_chunk() : nullptr;
+  if (chunk) {
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      chunk->received_at.time_since_epoch()).count();
+    ts.monotonic = data::Timespec::from_ns(static_cast<uint64_t>(ns));
+  } else {
+    ts.monotonic = data::now_mono();
+  }
+  ts.realtime = data::now_real();
+
+  auto rec = std::make_shared<data::JointStateRecord>();
+  rec->ts = ts;
+  rec->seq = seq_++;
+  rec->id = cfg_.stream_id;
+  rec->positions = std::move(cmd);
+
+  emit(rec);
+  ++stats_.produced;
+}
+
+REGISTER_PRODUCER(PolicyClientProducer, "policy_client")
+
+REGISTER_HARDWARE(PolicyClient, "policy_client")
+
+}  // namespace trossen::hw::policy

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,25 +103,12 @@ if(TROSSEN_ENABLE_RERUN_OBSERVER)
   target_link_libraries(test_rerun_observer PRIVATE trossen_sdk rerun_sdk GTest::gtest_main)
 endif()
 
-# PolicyClient config parsing — header-only schema, no transport deps, so it
-# builds regardless of TROSSEN_SDK_ENABLE_POLICY_CLIENT.
 add_executable(test_policy_client_config test_policy_client_config.cpp)
 target_link_libraries(test_policy_client_config PRIVATE trossen_sdk GTest::gtest_main)
-
-# Neutral types (Observation / ActionChunk / ChunkSlot / TransportStatus) are
-# header-only, so the chunk-slot test is ungated too.
-add_executable(test_action_chunk test_action_chunk.cpp)
-target_link_libraries(test_action_chunk PRIVATE trossen_sdk GTest::gtest_main)
 
 if(TROSSEN_SDK_ENABLE_POLICY_CLIENT)
   add_executable(test_msgpack_ndarray test_msgpack_ndarray.cpp)
   target_link_libraries(test_msgpack_ndarray PRIVATE trossen_sdk GTest::gtest_main msgpack-cxx)
-
-  add_executable(test_lerobot_codec test_lerobot_codec.cpp)
-  target_link_libraries(test_lerobot_codec PRIVATE trossen_sdk GTest::gtest_main)
-  # Absolute fixture path baked in: the test must pass regardless of ctest's cwd.
-  target_compile_definitions(test_lerobot_codec PRIVATE
-    LEROBOT_CODEC_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/lerobot_codec")
 
   add_executable(test_openpi_websocket_transport test_openpi_websocket_transport.cpp)
   target_link_libraries(test_openpi_websocket_transport PRIVATE
@@ -129,6 +116,15 @@ if(TROSSEN_SDK_ENABLE_POLICY_CLIENT)
 
   add_executable(test_policy_client test_policy_client.cpp)
   target_link_libraries(test_policy_client PRIVATE trossen_sdk GTest::gtest_main)
+
+  add_executable(test_policy_client_producer test_policy_client_producer.cpp)
+  target_link_libraries(test_policy_client_producer PRIVATE trossen_sdk GTest::gtest_main)
+
+  add_executable(test_lerobot_codec test_lerobot_codec.cpp)
+  target_link_libraries(test_lerobot_codec PRIVATE trossen_sdk GTest::gtest_main)
+  # Absolute fixture path baked in: the test must pass regardless of ctest's cwd.
+  target_compile_definitions(test_lerobot_codec PRIVATE
+    LEROBOT_CODEC_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/lerobot_codec")
 
   # Drives LerobotGrpcTransport against a gmock MockAsyncInferenceStub (no real
   # channel/server, so no gRPC teardown race). Needs the generated proto + mock
@@ -144,6 +140,12 @@ if(TROSSEN_SDK_ENABLE_POLICY_CLIENT)
   target_compile_definitions(test_lerobot_grpc_transport PRIVATE
     LEROBOT_CODEC_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/lerobot_codec")
 endif()
+
+add_executable(test_action_chunk test_action_chunk.cpp)
+target_link_libraries(test_action_chunk PRIVATE trossen_sdk GTest::gtest_main)
+
+add_executable(test_active_hardware_registry test_active_hardware_registry.cpp)
+target_link_libraries(test_active_hardware_registry PRIVATE trossen_sdk GTest::gtest_main)
 
 # Enable CTest integration
 include(GoogleTest)
@@ -182,10 +184,10 @@ if(TROSSEN_ENABLE_RERUN_OBSERVER)
 endif()
 gtest_discover_tests(test_policy_client_config)
 gtest_discover_tests(test_action_chunk)
+gtest_discover_tests(test_active_hardware_registry)
 if(TROSSEN_SDK_ENABLE_POLICY_CLIENT)
-  gtest_discover_tests(test_msgpack_ndarray)
-  gtest_discover_tests(test_lerobot_codec)
-  gtest_discover_tests(test_openpi_websocket_transport)
-  gtest_discover_tests(test_lerobot_grpc_transport)
   gtest_discover_tests(test_policy_client)
+  gtest_discover_tests(test_policy_client_producer)
+  gtest_discover_tests(test_lerobot_codec)
+  gtest_discover_tests(test_lerobot_grpc_transport)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,9 +144,6 @@ endif()
 add_executable(test_action_chunk test_action_chunk.cpp)
 target_link_libraries(test_action_chunk PRIVATE trossen_sdk GTest::gtest_main)
 
-add_executable(test_active_hardware_registry test_active_hardware_registry.cpp)
-target_link_libraries(test_active_hardware_registry PRIVATE trossen_sdk GTest::gtest_main)
-
 # Enable CTest integration
 include(GoogleTest)
 gtest_discover_tests(test_timestamp)
@@ -184,8 +181,13 @@ if(TROSSEN_ENABLE_RERUN_OBSERVER)
 endif()
 gtest_discover_tests(test_policy_client_config)
 gtest_discover_tests(test_action_chunk)
-gtest_discover_tests(test_active_hardware_registry)
 if(TROSSEN_SDK_ENABLE_POLICY_CLIENT)
+  # Every add_executable() under the TROSSEN_SDK_ENABLE_POLICY_CLIENT guard must
+  # have a matching gtest_discover_tests() line here: without it the target still
+  # compiles but ctest never runs it (test_msgpack_ndarray and
+  # test_openpi_websocket_transport were silently undiscovered this way).
+  gtest_discover_tests(test_msgpack_ndarray)
+  gtest_discover_tests(test_openpi_websocket_transport)
   gtest_discover_tests(test_policy_client)
   gtest_discover_tests(test_policy_client_producer)
   gtest_discover_tests(test_lerobot_codec)

--- a/tests/test_policy_client_producer.cpp
+++ b/tests/test_policy_client_producer.cpp
@@ -1,0 +1,359 @@
+/**
+ * @file test_policy_client_producer.cpp
+ * @brief Unit tests for PolicyClientProducer driven by a FakeTransport-backed PolicyClient.
+ */
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/configuration/types/hardware/policy_client_config.hpp"
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/policy/policy_client.hpp"
+#include "trossen_sdk/hw/policy/policy_client_producer.hpp"
+#include "trossen_sdk/hw/policy/policy_transport.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+
+namespace {
+
+using trossen::configuration::PolicyClientConfig;
+using trossen::configuration::PolicyClientJointLayoutEntry;
+using trossen::configuration::PolicyClientSubscriptionConfig;
+using trossen::data::JointStateRecord;
+using trossen::data::RecordBase;
+using trossen::hw::ActiveHardwareRegistry;
+using trossen::hw::HardwareRegistry;
+using trossen::hw::policy::ActionChunk;
+using trossen::hw::policy::Observation;
+using trossen::hw::policy::PolicyClient;
+using trossen::hw::policy::PolicyClientProducer;
+using trossen::hw::policy::PolicyTransport;
+using trossen::hw::policy::TransportStatus;
+using trossen::runtime::ProducerRegistry;
+
+PolicyClientSubscriptionConfig make_joint_sub(const std::string& record_id,
+                                              const std::string& obs_key,
+                                              double throttle_hz = 200.0) {
+  PolicyClientSubscriptionConfig s;
+  s.record_id = record_id;
+  s.obs_key = obs_key;
+  s.throttle_hz = throttle_hz;
+  return s;
+}
+
+PolicyClientJointLayoutEntry make_layout(const std::string& leader_id,
+                                         int offset, int count) {
+  PolicyClientJointLayoutEntry e;
+  e.leader_id = leader_id;
+  e.joint_offset = offset;
+  e.joint_count = count;
+  return e;
+}
+
+PolicyClientConfig make_config(
+    const std::string& id,
+    std::vector<PolicyClientSubscriptionConfig> subs,
+    std::vector<PolicyClientJointLayoutEntry> layout,
+    double inference_hz = 200.0) {
+  PolicyClientConfig c;
+  c.id = id;
+  c.server_url = "ws://127.0.0.1:1";
+  c.inference_hz = inference_hz;
+  c.prompt = "test";
+  c.subscriptions = std::move(subs);
+  c.joint_layout = std::move(layout);
+  return c;
+}
+
+// Minimal push/poll transport: every accepted push makes the canned chunk
+// pollable immediately. No failure or latency knobs — the producer tests only
+// need a steady chunk supply.
+class FakeTransport : public PolicyTransport {
+ public:
+  FakeTransport() = default;
+
+  void connect() override {
+    std::lock_guard<std::mutex> lk(mu_);
+    connected_ = true;
+  }
+
+  void close() noexcept override {
+    std::lock_guard<std::mutex> lk(mu_);
+    connected_ = false;
+    pending_ = false;
+  }
+
+  const nlohmann::json& server_metadata() const override { return metadata_; }
+
+  void push_observation(const Observation& obs) noexcept override {
+    (void)obs;
+    std::lock_guard<std::mutex> lk(mu_);
+    if (!connected_) return;  // contract: silent drop while unhealthy
+    pending_ = true;
+  }
+
+  std::optional<ActionChunk> try_poll_chunk() noexcept override {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (!connected_ || !pending_) return std::nullopt;
+    pending_ = false;
+    ActionChunk chunk = canned_chunk_;
+    chunk.chunk_seq = ++chunk_seq_;
+    chunk.received_at = std::chrono::steady_clock::now();
+    return chunk;
+  }
+
+  TransportStatus status() const noexcept override {
+    std::lock_guard<std::mutex> lk(mu_);
+    TransportStatus s;
+    s.state = connected_ ? TransportStatus::State::kConnected
+                         : TransportStatus::State::kDisconnected;
+    return s;
+  }
+
+  void set_canned_chunk(int T, int N, const std::vector<float>& flat) {
+    std::lock_guard<std::mutex> lk(mu_);
+    canned_chunk_.T = T;
+    canned_chunk_.N = N;
+    canned_chunk_.data = flat;
+  }
+
+ private:
+  mutable std::mutex mu_;
+  bool connected_{false};
+  bool pending_{false};
+  uint64_t chunk_seq_{0};
+  ActionChunk canned_chunk_;
+  nlohmann::json metadata_ = nlohmann::json::object();
+};
+
+class PolicyClientProducerTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    ActiveHardwareRegistry::clear();
+  }
+};
+
+TEST_F(PolicyClientProducerTest, ConstructorRejectsNullHardware) {
+  EXPECT_THROW(
+    PolicyClientProducer(nullptr, nlohmann::json::object()),
+    std::invalid_argument);
+}
+
+TEST_F(PolicyClientProducerTest, ConstructorRejectsNonPolicyClientHardware) {
+  class StubComponent : public trossen::hw::HardwareComponent {
+   public:
+    StubComponent() : trossen::hw::HardwareComponent("stub") {}
+    void configure(const nlohmann::json&) override {}
+    std::string get_type() const override { return "stub"; }
+  };
+  auto stub = std::make_shared<StubComponent>();
+  EXPECT_THROW(
+    PolicyClientProducer(stub, nlohmann::json::object()),
+    std::invalid_argument);
+}
+
+TEST_F(PolicyClientProducerTest, PollEmitsJointStateRecordMatchingCurrentCommand) {
+  auto fake = std::make_unique<FakeTransport>();
+  const std::vector<float> row = {0.1f, 0.2f, 0.3f, 0.4f};
+  fake->set_canned_chunk(1, 4, row);
+
+  auto client = std::make_shared<PolicyClient>(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left"),
+                 make_joint_sub("follower_right", "state.right")},
+                {make_layout("policy_left", 0, 2),
+                 make_layout("policy_right", 2, 2)}),
+    std::move(fake));
+  client->set_control_rate_hz(30.0);
+
+  nlohmann::json prod_cfg = {
+    {"stream_id", "policy_action"},
+    {"use_device_time", false}};
+  PolicyClientProducer producer(client, prod_cfg);
+
+  auto seed = std::make_shared<JointStateRecord>();
+  seed->id = "follower_left";
+  seed->positions = {0.0f, 0.0f};
+  ASSERT_TRUE(client->start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client->chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client->offer(seed);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client->chunks_published(), 0u);
+
+  std::shared_ptr<RecordBase> emitted;
+  producer.poll([&](std::shared_ptr<RecordBase> rec) { emitted = std::move(rec); });
+  client->stop();
+
+  ASSERT_NE(emitted, nullptr);
+  auto js = std::dynamic_pointer_cast<JointStateRecord>(emitted);
+  ASSERT_NE(js, nullptr);
+  EXPECT_EQ(js->id, "policy_action");
+  ASSERT_EQ(js->positions.size(), 4u);
+  for (std::size_t i = 0; i < row.size(); ++i) {
+    EXPECT_FLOAT_EQ(js->positions[i], row[i]);
+  }
+}
+
+TEST_F(PolicyClientProducerTest, UseDeviceTimeStampsFromChunkReceivedAt) {
+  auto fake = std::make_unique<FakeTransport>();
+  fake->set_canned_chunk(1, 4, {0.1f, 0.2f, 0.3f, 0.4f});
+
+  auto client = std::make_shared<PolicyClient>(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left"),
+                 make_joint_sub("follower_right", "state.right")},
+                {make_layout("policy_left", 0, 2),
+                 make_layout("policy_right", 2, 2)}),
+    std::move(fake));
+  client->set_control_rate_hz(30.0);
+
+  nlohmann::json prod_cfg = {
+    {"stream_id", "policy_action"},
+    {"use_device_time", true}};
+  PolicyClientProducer producer(client, prod_cfg);
+
+  auto seed = std::make_shared<JointStateRecord>();
+  seed->id = "follower_left";
+  seed->positions = {0.0f, 0.0f};
+  ASSERT_TRUE(client->start());
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (client->chunks_published() == 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    client->offer(seed);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_GT(client->chunks_published(), 0u);
+
+  auto chunk = client->latest_chunk();
+  ASSERT_NE(chunk, nullptr);
+  const uint64_t expected_ns =
+    static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+        chunk->received_at.time_since_epoch()).count());
+
+  std::shared_ptr<RecordBase> emitted;
+  producer.poll([&](std::shared_ptr<RecordBase> rec) { emitted = std::move(rec); });
+  client->stop();
+
+  ASSERT_NE(emitted, nullptr);
+  // With use_device_time, the monotonic stamp comes from the chunk's receipt
+  // instant, not wall-clock-now.
+  EXPECT_EQ(emitted->ts.monotonic.to_ns(), expected_ns);
+}
+
+TEST_F(PolicyClientProducerTest, PollBeforeFirstChunkEmitsZeroVector) {
+  auto fake = std::make_unique<FakeTransport>();
+  auto client = std::make_shared<PolicyClient>(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left")},
+                {make_layout("policy_left", 0, 5)}),
+    std::move(fake));
+
+  PolicyClientProducer producer(client, nlohmann::json::object());
+
+  std::shared_ptr<RecordBase> emitted;
+  producer.poll([&](std::shared_ptr<RecordBase> rec) { emitted = std::move(rec); });
+
+  auto js = std::dynamic_pointer_cast<JointStateRecord>(emitted);
+  ASSERT_NE(js, nullptr);
+  ASSERT_EQ(js->positions.size(), 5u);
+  for (float v : js->positions) {
+    EXPECT_FLOAT_EQ(v, 0.0f);
+  }
+}
+
+TEST_F(PolicyClientProducerTest, SeqIncrementsAcrossPolls) {
+  auto fake = std::make_unique<FakeTransport>();
+  auto client = std::make_shared<PolicyClient>(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left")},
+                {make_layout("policy_left", 0, 2)}),
+    std::move(fake));
+  PolicyClientProducer producer(client, nlohmann::json::object());
+
+  std::vector<uint64_t> seqs;
+  for (int i = 0; i < 3; ++i) {
+    producer.poll([&](std::shared_ptr<RecordBase> rec) {
+      seqs.push_back(rec->seq);
+    });
+  }
+  ASSERT_EQ(seqs.size(), 3u);
+  EXPECT_EQ(seqs[0] + 1, seqs[1]);
+  EXPECT_EQ(seqs[1] + 1, seqs[2]);
+}
+
+TEST_F(PolicyClientProducerTest, MetadataReflectsJointCount) {
+  auto fake = std::make_unique<FakeTransport>();
+  auto client = std::make_shared<PolicyClient>(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left"),
+                 make_joint_sub("follower_right", "state.right")},
+                {make_layout("policy_left", 0, 7),
+                 make_layout("policy_right", 7, 7)}),
+    std::move(fake));
+
+  nlohmann::json prod_cfg = {{"stream_id", "policy_action"}};
+  PolicyClientProducer producer(client, prod_cfg);
+
+  auto md = producer.metadata();
+  ASSERT_NE(md, nullptr);
+  auto typed =
+    std::dynamic_pointer_cast<PolicyClientProducer::PolicyClientProducerMetadata>(md);
+  ASSERT_NE(typed, nullptr);
+  EXPECT_EQ(typed->id, "policy_action");
+  EXPECT_EQ(typed->type, "policy_client");
+  EXPECT_EQ(typed->joint_count, 14);
+  ASSERT_EQ(typed->joint_names.size(), 14u);
+  EXPECT_EQ(typed->joint_names[0], "joint_0");
+  EXPECT_EQ(typed->joint_names[13], "joint_13");
+
+  const auto info = typed->get_info();
+  ASSERT_TRUE(info.contains("action"));
+  EXPECT_EQ(info["action"]["dtype"], "float32");
+  ASSERT_TRUE(info["action"]["shape"].is_array());
+  EXPECT_EQ(info["action"]["shape"][0].get<int>(), 14);
+}
+
+TEST_F(PolicyClientProducerTest, ProducerRegistryCreatesByType) {
+  ASSERT_TRUE(ProducerRegistry::is_registered("policy_client"));
+
+  auto fake = std::make_unique<FakeTransport>();
+  auto client = std::make_shared<PolicyClient>(
+    make_config("pc1",
+                {make_joint_sub("follower_left", "state.left")},
+                {make_layout("policy_left", 0, 3)}),
+    std::move(fake));
+
+  nlohmann::json prod_cfg = {{"stream_id", "policy_action_via_registry"}};
+  auto producer = ProducerRegistry::create("policy_client", client, prod_cfg);
+  ASSERT_NE(producer, nullptr);
+
+  std::shared_ptr<RecordBase> emitted;
+  producer->poll([&](std::shared_ptr<RecordBase> rec) { emitted = std::move(rec); });
+  ASSERT_NE(emitted, nullptr);
+  EXPECT_EQ(emitted->id, "policy_action_via_registry");
+}
+
+TEST_F(PolicyClientProducerTest, HardwareRegistryRegistersPolicyClient) {
+  EXPECT_TRUE(HardwareRegistry::is_registered("policy_client"));
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Wires `PolicyClient` into the SDK runtime: a `PolicyClientProducer` (so the chunk-aligned command stream is a recordable source), registry placement so it constructs from config, and the small arm change the playback path needs.

> **Stack:** PolicyClient stack, based on #248. Review bottom-up (#253 → here). This PR touches `ArmConfig`/`TrossenArmComponent`, which #248 also changes — see Related.

## Changes

- In `include/trossen_sdk/hw/policy/policy_client_producer.{hpp}` + `src/hw/policy/policy_client_producer.cpp`: `PolicyClientProducer` emitting the commanded rows (with `joint_names` in the stream metadata/features); `REGISTER_PRODUCER` / `REGISTER_HARDWARE` under `"policy_client"`.
- In `include/trossen_sdk/hw/active_hardware_registry.hpp` + `src/hw/active_hardware_registry.cpp`: registry placement so a `policy_client` hardware entry is constructed and configured from JSON.
- In `include/trossen_sdk/configuration/types/producers/producer_config.hpp`: carry the policy-client producer config.
- In `include/trossen_sdk/configuration/types/hardware/arm_config.hpp` + `include/trossen_sdk/hw/arm/trossen_arm_component.{hpp,cpp}`: add `write_moving_time_s` — the per-tick trajectory time passed to `set_all_positions()` in `write_joint()` (0 = apply immediately; non-zero smooths per-tick motion, on top of the Face EMA). Reconciled with #248's arm changes: built on #248's `slew_time_s`/`staged_position`/`episode_lifecycle_enabled`, adding only `write_moving_time_s`.
- In `tests/test_policy_client_producer.cpp`, `tests/test_active_hardware_registry.cpp`, `tests/CMakeLists.txt`: producer metadata + registry construction coverage.
- In `cmake/policy_client.cmake`: add `policy_client_producer.cpp` to the gated sources.

## Test Plan

- [x] Builds cleanly with `-DTROSSEN_SDK_ENABLE_POLICY_CLIENT=ON`
- [x] Tests pass — `test_policy_client_producer`, `test_active_hardware_registry`, `test_config`
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Hardware — exercised end-to-end via the live pi05 integration (see #255)

## Breaking Changes

None. `write_moving_time_s` is optional (defaults to 0.0 = previous behavior). New gated sources behind `TROSSEN_SDK_ENABLE_POLICY_CLIENT` (default OFF).

## Related

Based on #248. **Depends on #248's `ArmConfig` rework** — this PR's arm change is reconciled on top of `slew_time_s`/staging (adds only `write_moving_time_s`), so it must merge after #248. Stacked on #253; followed by #255.
