### PR TITLE
hw: make SlateBaseComponent a base-velocity teleop follower

### DIFF
--- a/include/trossen_sdk/hw/base/slate_base_component.hpp
+++ b/include/trossen_sdk/hw/base/slate_base_component.hpp
@@ -72,17 +72,16 @@ public:
 
   // ── teleop::BaseSpaceTeleop: IO contract ─────────────────────────────────
 
-  /// Return the base's current body-frame velocity as `[linear_mps,
-  /// angular_rps]`. Used by the teleop controller to seed leader alignment.
+  /// Refresh state and return the base's current velocity `[linear_mps,
+  /// angular_rps]`. Returns an empty vector (and logs) if the driver is unset.
   std::vector<float> read() override;
 
-  /// Apply a `[linear_mps, angular_rps]` velocity command to the base
-  /// (follower role). Forwards the two velocity scalars to the SLATE driver,
-  /// which applies its own velocity limits. Commands with fewer than two
-  /// elements are ignored.
+  /// Apply a `[linear_mps, angular_rps]` velocity command (follower role).
+  /// No-op that logs if the driver is unset, `cmd` has < 2 elements, or the
+  /// driver rejects the command.
   void write(const std::vector<float>& cmd) override;
 
-  /// Stop the base by commanding zero velocity. Idempotent.
+  /// Stop the base by commanding zero velocity. Idempotent; logs on failure.
   void end_teleop() override;
 
 private:

--- a/include/trossen_sdk/hw/base/slate_base_component.hpp
+++ b/include/trossen_sdk/hw/base/slate_base_component.hpp
@@ -8,8 +8,10 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
 #include "trossen_slate/trossen_slate.hpp"
 
 namespace trossen::hw::base {
@@ -17,9 +19,13 @@ namespace trossen::hw::base {
 /**
  * @brief Hardware component for SLATE mobile base
  *
- * Wraps TrossenSlate driver and provides JSON configuration.
+ * Wraps the TrossenSlate driver and provides JSON configuration. Implements
+ * `teleop::BaseSpaceTeleop` so the base can act as a teleop follower: any
+ * base-space leader sends `[linear_mps, angular_rps]` velocity commands that
+ * are forwarded to the wheels.
  */
-class SlateBaseComponent : public HardwareComponent {
+class SlateBaseComponent : public HardwareComponent,
+                           public teleop::BaseSpaceTeleop {
 public:
   /**
    * @brief Constructor
@@ -63,6 +69,21 @@ public:
    * @return Shared pointer to driver
    */
   std::shared_ptr<trossen_slate::TrossenSlate> get_driver() const { return driver_; }
+
+  // ── teleop::BaseSpaceTeleop: IO contract ─────────────────────────────────
+
+  /// Return the base's current body-frame velocity as `[linear_mps,
+  /// angular_rps]`. Used by the teleop controller to seed leader alignment.
+  std::vector<float> read() override;
+
+  /// Apply a `[linear_mps, angular_rps]` velocity command to the base
+  /// (follower role). Forwards the two velocity scalars to the SLATE driver,
+  /// which applies its own velocity limits. Commands with fewer than two
+  /// elements are ignored.
+  void write(const std::vector<float>& cmd) override;
+
+  /// Stop the base by commanding zero velocity. Idempotent.
+  void end_teleop() override;
 
 private:
   std::shared_ptr<trossen_slate::TrossenSlate> driver_;

--- a/src/hw/base/slate_base_component.cpp
+++ b/src/hw/base/slate_base_component.cpp
@@ -60,6 +60,23 @@ nlohmann::json SlateBaseComponent::get_info() const {
   return info;
 }
 
+std::vector<float> SlateBaseComponent::read() {
+  if (!driver_) return {0.0f, 0.0f};
+  const auto vel = driver_->get_vel();  // [linear_mps, angular_rps]
+  return {vel[0], vel[1]};
+}
+
+void SlateBaseComponent::write(const std::vector<float>& cmd) {
+  if (!driver_ || cmd.size() < 2) return;
+  driver_->set_cmd_vel(cmd[0], cmd[1]);
+}
+
+void SlateBaseComponent::end_teleop() {
+  if (driver_) {
+    driver_->set_cmd_vel(0.0f, 0.0f);
+  }
+}
+
 // Register the hardware component with the hardware registry
 REGISTER_HARDWARE(SlateBaseComponent, "slate_base")
 

--- a/src/hw/base/slate_base_component.cpp
+++ b/src/hw/base/slate_base_component.cpp
@@ -61,19 +61,36 @@ nlohmann::json SlateBaseComponent::get_info() const {
 }
 
 std::vector<float> SlateBaseComponent::read() {
-  if (!driver_) return {0.0f, 0.0f};
+  if (!driver_) {
+    std::cerr << "SlateBaseComponent::read: driver not initialized" << std::endl;
+    return {};
+  }
+  // Refresh state so the returned velocity is current, not the last poll.
+  if (!driver_->update_state()) {
+    std::cerr << "SlateBaseComponent::read: update_state() failed" << std::endl;
+  }
   const auto vel = driver_->get_vel();  // [linear_mps, angular_rps]
   return {vel[0], vel[1]};
 }
 
 void SlateBaseComponent::write(const std::vector<float>& cmd) {
-  if (!driver_ || cmd.size() < 2) return;
-  driver_->set_cmd_vel(cmd[0], cmd[1]);
+  if (!driver_) {
+    std::cerr << "SlateBaseComponent::write: driver not initialized" << std::endl;
+    return;
+  }
+  if (cmd.size() < 2) {
+    std::cerr << "SlateBaseComponent::write: expected 2 elements "
+                 "[linear_mps, angular_rps], got " << cmd.size() << std::endl;
+    return;
+  }
+  if (!driver_->set_cmd_vel(cmd[0], cmd[1])) {
+    std::cerr << "SlateBaseComponent::write: set_cmd_vel failed" << std::endl;
+  }
 }
 
 void SlateBaseComponent::end_teleop() {
-  if (driver_) {
-    driver_->set_cmd_vel(0.0f, 0.0f);
+  if (driver_ && !driver_->set_cmd_vel(0.0f, 0.0f)) {
+    std::cerr << "SlateBaseComponent::end_teleop: failed to stop the base" << std::endl;
   }
 }
 


### PR DESCRIPTION
## Summary

Implements `teleop::BaseSpaceTeleop` on `SlateBaseComponent` so the SLATE mobile base can be driven as a teleop **follower** by any base-space leader. Without this, a base teleop pair silently runs leader-only and the base never moves.

## Changes

- `write([linear_mps, angular_rps])` forwards the command to `TrossenSlate::set_cmd_vel()`; the driver applies its own velocity limits.
- `read()` returns the base's current body-frame velocity, used once by the teleop controller to seed leader alignment.
- `end_teleop()` commands zero velocity so the base halts on shutdown (idempotent).
- Commands with fewer than two elements are ignored.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [ ] Tested on hardware

## Breaking Changes

None. Purely additive — the base only acts as a follower when a teleop pair targets it with `"space": "base"`; flows that record the base as a producer are unaffected.

## Related Issues

N/A — part of the VR teleoperation feature stack.
