### PR TITLE
vr: add VrBaseComponent base-velocity teleop leader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ if(TROSSEN_ENABLE_VR)
   target_sources(trossen_sdk PRIVATE
     src/hw/vr/vr_session.cpp
     src/hw/vr/vr_arm_component.cpp
+    src/hw/vr/vr_base_component.cpp
   )
   target_compile_definitions(trossen_sdk PRIVATE TROSSEN_ENABLE_VR)
 

--- a/include/trossen_sdk/hw/vr/vr_base_component.hpp
+++ b/include/trossen_sdk/hw/vr/vr_base_component.hpp
@@ -1,0 +1,114 @@
+/**
+ * @file vr_base_component.hpp
+ * @brief VR thumbstick as a base-velocity (linear, angular) teleop leader.
+ */
+
+#ifndef TROSSEN_SDK__HW__VR__VR_BASE_COMPONENT_HPP_
+#define TROSSEN_SDK__HW__VR__VR_BASE_COMPONENT_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+
+namespace trossen::hw::vr {
+
+/**
+ * @brief Base-velocity teleop leader driven by VR controller thumbstick(s).
+ *
+ * Each `read()` samples the configured thumbstick axis/axes and returns
+ * `[linear_mps, angular_rps]`. Values below `deadzone` are zeroed; above
+ * it they are rescaled to span the full range and then multiplied by
+ * `max_linear_mps` / `max_angular_rps`. `write()` is a no-op (leader only).
+ * Shares the process-wide `VrSession` with all other VR hardware components.
+ *
+ * The two axes can come from the same or different controllers (split mode).
+ * In split mode the component claims the thumbstick input on both sides.
+ */
+class VrBaseComponent : public HardwareComponent,
+                                public teleop::BaseSpaceTeleop {
+public:
+  explicit VrBaseComponent(std::string identifier)
+      : HardwareComponent(std::move(identifier)) {}
+
+  ~VrBaseComponent() override;
+
+  VrBaseComponent(const VrBaseComponent&)            = delete;
+  VrBaseComponent& operator=(const VrBaseComponent&) = delete;
+  VrBaseComponent(VrBaseComponent&&)                 = delete;
+  VrBaseComponent& operator=(VrBaseComponent&&)      = delete;
+
+  /**
+   * @brief Configure from JSON.
+   *
+   * Required (one of):
+   *   - `controller_type` : "left" or "right" — single-hand mode. Both the
+   *                    linear and angular axes come from this controller's
+   *                    thumbstick (Y-axis → forward/backward, X-axis → yaw).
+   *   - `linear_controller_type` and/or `angular_controller_type` : per-axis
+   *                    split mode. Either may be given independently; a missing
+   *                    axis falls back to `controller_type` if present, else
+   *                    "left". Each is "left" or "right". The two axes may use
+   *                    the same controller (equivalent to single-hand mode) or
+   *                    different ones — e.g. right thumbstick for driving
+   *                    forward, left thumbstick for turning.
+   *
+   * Output of `read()` is always `[linear_mps, angular_rps]`:
+   *   - `linear_mps`  : forward velocity (positive = forward). Driven by the
+   *                    Y-axis of `linear_controller_type`'s thumbstick.
+   *   - `angular_rps` : yaw rate (positive = left/CCW, right-hand rule about
+   *                    the vertical axis). Driven by the X-axis of
+   *                    `angular_controller_type`'s thumbstick with sign
+   *                    negated so pushing left → positive yaw.
+   *
+   * Optional:
+   *   - `vr_port`              : network port (default 9000).
+   *   - `max_linear_mps`       : Speed at full stick deflection (default 0.5 m/s).
+   *   - `max_angular_rps`      : Yaw rate at full stick deflection (default 1.0 rad/s).
+   *   - `deadzone`             : Stick magnitude below which output is zero,
+   *                             applied to the raw −1..1 range (default 0.1).
+   *                             Above the deadzone the output is rescaled so
+   *                             full deflection always reaches ±max.
+   *   - `connection_timeout_s` : How long `prepare_for_teleop()` waits for the
+   *                             headset to connect before throwing (default 10 s).
+   *
+   * @throws std::runtime_error if required fields are missing or invalid.
+   */
+  void configure(const nlohmann::json& config) override;
+
+  std::string    get_type() const override { return "vr_base_component"; }
+  nlohmann::json get_info() const override;
+
+  // ── teleop::BaseSpaceTeleop: IO contract ─────────────────────────────────
+
+  /// Sample the thumbstick and return `[linear_mps, angular_rps]`. Returns
+  /// zeros while the headset is disconnected or no frame has arrived.
+  std::vector<float> read() override;
+
+  /// Leader role: no-op.
+  void write(const std::vector<float>& cmd) override;
+
+  // ── teleop::TeleopCapable: lifecycle ────────────────────────────────────
+
+  void prepare_for_teleop() override;
+  void end_teleop() override;
+
+private:
+  /// Config — per-axis controller-type assignment.
+  std::string   linear_controller_type_{"left"};
+  std::string   angular_controller_type_{"left"};
+  std::uint16_t vr_port_{9000};
+  double        max_linear_mps_{0.5};
+  double        max_angular_rps_{1.0};
+  double        deadzone_{0.1};
+  std::chrono::milliseconds connection_timeout_{std::chrono::seconds{10}};
+
+  bool session_held_{false};
+};
+
+}  // namespace trossen::hw::vr
+
+#endif  // TROSSEN_SDK__HW__VR__VR_BASE_COMPONENT_HPP_

--- a/include/trossen_sdk/hw/vr/vr_base_component.hpp
+++ b/include/trossen_sdk/hw/vr/vr_base_component.hpp
@@ -13,6 +13,7 @@
 
 #include "trossen_sdk/hw/hardware_component.hpp"
 #include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+#include "trossen_sdk/hw/vr/vr_session.hpp"
 
 namespace trossen::hw::vr {
 
@@ -34,7 +35,7 @@ public:
   explicit VrBaseComponent(std::string identifier)
       : HardwareComponent(std::move(identifier)) {}
 
-  ~VrBaseComponent() override;
+  ~VrBaseComponent() override = default;
 
   VrBaseComponent(const VrBaseComponent&)            = delete;
   VrBaseComponent& operator=(const VrBaseComponent&) = delete;
@@ -106,7 +107,9 @@ private:
   double        deadzone_{0.1};
   std::chrono::milliseconds connection_timeout_{std::chrono::seconds{10}};
 
-  bool session_held_{false};
+  /// Holds this component's reference on the shared VrSession; releases the
+  /// reference and input claims automatically on teardown.
+  VrSessionLease session_lease_;
 };
 
 }  // namespace trossen::hw::vr

--- a/src/hw/vr/vr_base_component.cpp
+++ b/src/hw/vr/vr_base_component.cpp
@@ -29,30 +29,22 @@ double apply_deadzone(double v, double deadzone) {
 
 }  // namespace
 
-VrBaseComponent::~VrBaseComponent() {
-  if (session_held_) {
-    VrSession::instance().release_claims(get_identifier());
-    VrSession::instance().release();
-    session_held_ = false;
-  }
-}
-
 void VrBaseComponent::configure(const nlohmann::json& config) {
   // Two accepted shapes:
-  //   * `controller_type` alone → both axes from that controller.
+  //   * `controller_type` alone → both axes from that one controller.
   //   * `linear_controller_type` and/or `angular_controller_type` : per-axis
   //     split mode.
   const bool has_linear  = config.contains("linear_controller_type");
   const bool has_angular = config.contains("angular_controller_type");
-  const bool has_legacy  = config.contains("controller_type");
+  const bool has_shared  = config.contains("controller_type");
 
-  if (!has_linear && !has_angular && !has_legacy) {
+  if (!has_linear && !has_angular && !has_shared) {
     throw std::runtime_error(
       "VrBaseComponent: one of 'controller_type', "
       "'linear_controller_type', or 'angular_controller_type' is required");
   }
 
-  const std::string fallback = has_legacy
+  const std::string fallback = has_shared
     ? config.at("controller_type").get<std::string>()
     : std::string{"left"};
 
@@ -98,8 +90,7 @@ void VrBaseComponent::configure(const nlohmann::json& config) {
   connection_timeout_ = std::chrono::milliseconds(
     static_cast<std::int64_t>(wait_s * 1000.0));
 
-  VrSession::instance().ensure_started(vr_port_);
-  session_held_ = true;
+  session_lease_.acquire(vr_port_, get_identifier());
 
   // Claim the thumbstick on each controller type we read from.
   VrSession::instance().claim_inputs(
@@ -134,16 +125,13 @@ void VrBaseComponent::prepare_for_teleop() {
 }
 
 void VrBaseComponent::end_teleop() {
-  if (session_held_) {
-    VrSession::instance().release_claims(get_identifier());
-    VrSession::instance().release();
-    session_held_ = false;
-  }
+  session_lease_.reset();
 }
 
 std::vector<float> VrBaseComponent::read() {
   // Hold zero velocity while the headset is disconnected so the base does not
-  // coast on a stale frame.
+  // coast on a stale frame. Note: is_vr_connected() reflects the VrSession
+  // heartbeat and can lag a real drop by up to that timeout.
   if (!VrSession::instance().is_vr_connected()) return {0.0f, 0.0f};
 
   const auto frame = VrSession::instance().latest_frame();
@@ -165,6 +153,11 @@ std::vector<float> VrBaseComponent::read() {
   // user-configured limit.
   const double linear  =  y * max_linear_mps_;
   const double angular = -x * max_angular_rps_;
+
+  // A malformed frame can yield non-finite axes; never forward that as a
+  // velocity command — stop the base instead.
+  if (!std::isfinite(linear) || !std::isfinite(angular)) return {0.0f, 0.0f};
+
   return {static_cast<float>(linear), static_cast<float>(angular)};
 }
 

--- a/src/hw/vr/vr_base_component.cpp
+++ b/src/hw/vr/vr_base_component.cpp
@@ -1,0 +1,177 @@
+/**
+ * @file vr_base_component.cpp
+ * @brief Implementation of the VR thumbstick base-velocity teleop leader.
+ */
+
+#include "trossen_sdk/hw/vr/vr_base_component.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/vr/vr_session.hpp"
+
+namespace trossen::hw::vr {
+
+namespace {
+
+/// Rescale `v` from `[-1, 1]` with a centered deadzone:
+/// returns 0 when |v| <= deadzone, otherwise linearly maps
+/// the remaining travel to the full [-1, 1] range.
+double apply_deadzone(double v, double deadzone) {
+  const double a = std::fabs(v);
+  if (a <= deadzone) return 0.0;
+  const double span = 1.0 - deadzone;
+  const double sign = (v > 0.0) ? 1.0 : -1.0;
+  return sign * std::clamp((a - deadzone) / span, 0.0, 1.0);
+}
+
+}  // namespace
+
+VrBaseComponent::~VrBaseComponent() {
+  if (session_held_) {
+    VrSession::instance().release_claims(get_identifier());
+    VrSession::instance().release();
+    session_held_ = false;
+  }
+}
+
+void VrBaseComponent::configure(const nlohmann::json& config) {
+  // Two accepted shapes:
+  //   * `controller_type` alone → both axes from that controller.
+  //   * `linear_controller_type` and/or `angular_controller_type` : per-axis
+  //     split mode.
+  const bool has_linear  = config.contains("linear_controller_type");
+  const bool has_angular = config.contains("angular_controller_type");
+  const bool has_legacy  = config.contains("controller_type");
+
+  if (!has_linear && !has_angular && !has_legacy) {
+    throw std::runtime_error(
+      "VrBaseComponent: one of 'controller_type', "
+      "'linear_controller_type', or 'angular_controller_type' is required");
+  }
+
+  const std::string fallback = has_legacy
+    ? config.at("controller_type").get<std::string>()
+    : std::string{"left"};
+
+  linear_controller_type_  = has_linear
+    ? config.at("linear_controller_type").get<std::string>()
+    : fallback;
+  angular_controller_type_ = has_angular
+    ? config.at("angular_controller_type").get<std::string>()
+    : fallback;
+
+  auto validate = [](const char* field, const std::string& v) {
+    if (v != "left" && v != "right") {
+      throw std::runtime_error(
+        std::string{"VrBaseComponent: '"} + field +
+        "' must be \"left\" or \"right\", got \"" + v + "\"");
+    }
+  };
+  validate("linear_controller_type",  linear_controller_type_);
+  validate("angular_controller_type", angular_controller_type_);
+
+  vr_port_         = config.value("vr_port",         static_cast<std::uint16_t>(9000));
+  max_linear_mps_  = config.value("max_linear_mps",  0.5);
+  max_angular_rps_ = config.value("max_angular_rps", 1.0);
+  if (!std::isfinite(max_linear_mps_) || max_linear_mps_ < 0.0) {
+    throw std::runtime_error(
+      "VrBaseComponent: 'max_linear_mps' must be a non-negative finite number");
+  }
+  if (!std::isfinite(max_angular_rps_) || max_angular_rps_ < 0.0) {
+    throw std::runtime_error(
+      "VrBaseComponent: 'max_angular_rps' must be a non-negative finite number");
+  }
+  deadzone_        = config.value("deadzone",        0.1);
+  if (deadzone_ < 0.0 || deadzone_ >= 1.0) {
+    throw std::runtime_error(
+      "VrBaseComponent: 'deadzone' must be in [0, 1)");
+  }
+
+  const double wait_s = config.value("connection_timeout_s", 10.0);
+  if (!std::isfinite(wait_s) || wait_s < 0.0) {
+    throw std::runtime_error(
+      "VrBaseComponent: 'connection_timeout_s' must be a non-negative number");
+  }
+  connection_timeout_ = std::chrono::milliseconds(
+    static_cast<std::int64_t>(wait_s * 1000.0));
+
+  VrSession::instance().ensure_started(vr_port_);
+  session_held_ = true;
+
+  // Claim the thumbstick on each controller type we read from.
+  VrSession::instance().claim_inputs(
+    linear_controller_type_, get_identifier(), {VrInput::kThumbstick});
+  if (angular_controller_type_ != linear_controller_type_) {
+    VrSession::instance().claim_inputs(
+      angular_controller_type_, get_identifier(), {VrInput::kThumbstick});
+  }
+}
+
+nlohmann::json VrBaseComponent::get_info() const {
+  return nlohmann::json{
+    {"type",                    get_type()},
+    {"identifier",              get_identifier()},
+    {"linear_controller_type",  linear_controller_type_},
+    {"angular_controller_type", angular_controller_type_},
+    {"vr_port",                 vr_port_},
+    {"max_linear_mps",          max_linear_mps_},
+    {"max_angular_rps",         max_angular_rps_},
+    {"deadzone",                deadzone_},
+    {"connected",               VrSession::instance().is_vr_connected()},
+  };
+}
+
+void VrBaseComponent::prepare_for_teleop() {
+  if (!VrSession::instance().wait_for_connection(connection_timeout_)) {
+    throw std::runtime_error(
+      "VrBaseComponent: timed out waiting for VR headset to connect "
+      "on port " + std::to_string(vr_port_) +
+      " — is the VR app running?");
+  }
+}
+
+void VrBaseComponent::end_teleop() {
+  if (session_held_) {
+    VrSession::instance().release_claims(get_identifier());
+    VrSession::instance().release();
+    session_held_ = false;
+  }
+}
+
+std::vector<float> VrBaseComponent::read() {
+  // Hold zero velocity while the headset is disconnected so the base does not
+  // coast on a stale frame.
+  if (!VrSession::instance().is_vr_connected()) return {0.0f, 0.0f};
+
+  const auto frame = VrSession::instance().latest_frame();
+  if (!frame) return {0.0f, 0.0f};
+
+  const auto& linear_stick = (linear_controller_type_ == "right")
+    ? frame->right_controller.thumbstick
+    : frame->left_controller.thumbstick;
+  const auto& angular_stick = (angular_controller_type_ == "right")
+    ? frame->right_controller.thumbstick
+    : frame->left_controller.thumbstick;
+
+  const double y = apply_deadzone(linear_stick.y_axis, deadzone_);
+  const double x = apply_deadzone(angular_stick.x_axis, deadzone_);
+
+  // Forward stick → forward velocity; left stick → positive yaw (CCW
+  // about the vertical axis), so we negate x. `max_*` caps are applied
+  // after the deadzone rescale so full-deflection matches the
+  // user-configured limit.
+  const double linear  =  y * max_linear_mps_;
+  const double angular = -x * max_angular_rps_;
+  return {static_cast<float>(linear), static_cast<float>(angular)};
+}
+
+void VrBaseComponent::write(const std::vector<float>& /*cmd*/) {
+  // Leader only.
+}
+
+REGISTER_HARDWARE(VrBaseComponent, "vr_base_component")
+
+}  // namespace trossen::hw::vr

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,9 @@ if(TROSSEN_ENABLE_VR)
 
   add_executable(test_vr_arm_component test_vr_arm_component.cpp)
   target_link_libraries(test_vr_arm_component PRIVATE trossen_sdk GTest::gtest_main)
+
+  add_executable(test_vr_base_component test_vr_base_component.cpp)
+  target_link_libraries(test_vr_base_component PRIVATE trossen_sdk GTest::gtest_main)
 endif()
 
 add_executable(test_lerobot_depth_utils test_lerobot_depth_utils.cpp)
@@ -123,6 +126,7 @@ endif()
 if(TROSSEN_ENABLE_VR)
   gtest_discover_tests(test_vr_session)
   gtest_discover_tests(test_vr_arm_component)
+  gtest_discover_tests(test_vr_base_component)
 endif()
 gtest_discover_tests(test_lerobot_depth_utils)
 gtest_discover_tests(test_record_types)

--- a/tests/test_vr_base_component.cpp
+++ b/tests/test_vr_base_component.cpp
@@ -1,0 +1,177 @@
+/**
+ * @file test_vr_base_component.cpp
+ * @brief Unit tests for the VR thumbstick base-velocity teleop leader.
+ *
+ * Drives the real VrBaseComponent with synthetic frames via the VrSession
+ * test seam — no VR hardware required. Covers config validation, the deadzone,
+ * scaling, caps, and especially the steering direction (push forward → drive
+ * forward, push left → turn left), plus the disconnect and non-finite guards.
+ */
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+#include "trossen_vr/vr_types.hpp"
+
+#include "trossen_sdk/hw/vr/vr_base_component.hpp"
+#include "trossen_sdk/hw/vr/vr_session.hpp"
+
+using trossen::hw::vr::VrBaseComponent;
+using trossen::hw::vr::VrSession;
+
+namespace {
+
+trossen_vr::VRFrame make_stick_frame(const std::string& side, float x_axis,
+                                     float y_axis) {
+  trossen_vr::VRFrame f;
+  auto& c = (side == "right") ? f.right_controller : f.left_controller;
+  c.is_tracked = 1;
+  c.thumbstick.x_axis = x_axis;
+  c.thumbstick.y_axis = y_axis;
+  return f;
+}
+
+nlohmann::json base_config() {
+  return nlohmann::json{
+    {"controller_type", "left"},
+    {"max_linear_mps", 0.5},
+    {"max_angular_rps", 1.0},
+    {"deadzone", 0.1},
+  };
+}
+
+}  // namespace
+
+// ── config validation (no frames needed) ────────────────────────────────────
+
+TEST(VrBaseConfig, MissingAllControllerTypesThrows) {
+  VrBaseComponent base("base_cfg1");
+  EXPECT_THROW(base.configure(nlohmann::json::object()), std::runtime_error);
+}
+
+TEST(VrBaseConfig, InvalidControllerTypeThrows) {
+  VrBaseComponent base("base_cfg2");
+  EXPECT_THROW(base.configure({{"controller_type", "middle"}}),
+               std::runtime_error);
+}
+
+TEST(VrBaseConfig, NegativeMaxLinearThrows) {
+  VrBaseComponent base("base_cfg3");
+  EXPECT_THROW(
+    base.configure({{"controller_type", "left"}, {"max_linear_mps", -0.5}}),
+    std::runtime_error);
+}
+
+TEST(VrBaseConfig, DeadzoneOutOfRangeThrows) {
+  VrBaseComponent base("base_cfg4");
+  EXPECT_THROW(
+    base.configure({{"controller_type", "left"}, {"deadzone", 1.0}}),
+    std::runtime_error);
+}
+
+TEST(VrBaseConfig, NegativeConnectionTimeoutThrows) {
+  VrBaseComponent base("base_cfg5");
+  EXPECT_THROW(
+    base.configure({{"controller_type", "left"},
+                    {"connection_timeout_s", -1.0}}),
+    std::runtime_error);
+}
+
+// ── velocity mapping (seam-driven) ──────────────────────────────────────────
+
+class VrBaseRead : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    VrSession::instance().set_test_frame(trossen_vr::VRFrame{});
+  }
+  void TearDown() override { VrSession::instance().clear_test_frame(); }
+};
+
+TEST_F(VrBaseRead, PushForwardDrivesForward) {
+  VrBaseComponent base("base_fwd");
+  base.configure(base_config());
+
+  VrSession::instance().set_test_frame(make_stick_frame("left", 0.0f, 1.0f));
+  const auto out = base.read();
+  ASSERT_EQ(out.size(), 2u);
+  EXPECT_GT(out[0], 0.0f);              // positive linear = forward
+  EXPECT_NEAR(out[0], 0.5f, 1e-4f);     // full deflection = max_linear
+  EXPECT_NEAR(out[1], 0.0f, 1e-4f);
+}
+
+TEST_F(VrBaseRead, PushBackwardDrivesBackward) {
+  VrBaseComponent base("base_back");
+  base.configure(base_config());
+
+  VrSession::instance().set_test_frame(make_stick_frame("left", 0.0f, -1.0f));
+  EXPECT_LT(base.read()[0], 0.0f);      // negative linear = reverse
+}
+
+TEST_F(VrBaseRead, PushLeftTurnsLeft) {
+  VrBaseComponent base("base_left");
+  base.configure(base_config());
+
+  // Stick left is x_axis < 0; the base must yaw positive (CCW / left).
+  VrSession::instance().set_test_frame(make_stick_frame("left", -1.0f, 0.0f));
+  const auto out = base.read();
+  EXPECT_GT(out[1], 0.0f);
+  EXPECT_NEAR(out[1], 1.0f, 1e-4f);     // full deflection = max_angular
+}
+
+TEST_F(VrBaseRead, PushRightTurnsRight) {
+  VrBaseComponent base("base_right");
+  base.configure(base_config());
+
+  VrSession::instance().set_test_frame(make_stick_frame("left", 1.0f, 0.0f));
+  EXPECT_LT(base.read()[1], 0.0f);      // negative yaw = CW / right
+}
+
+TEST_F(VrBaseRead, WithinDeadzoneOutputsZero) {
+  VrBaseComponent base("base_dead");
+  base.configure(base_config());
+
+  // Both axes inside the 0.1 deadzone.
+  VrSession::instance().set_test_frame(make_stick_frame("left", 0.05f, 0.05f));
+  const auto out = base.read();
+  EXPECT_NEAR(out[0], 0.0f, 1e-6f);
+  EXPECT_NEAR(out[1], 0.0f, 1e-6f);
+}
+
+TEST_F(VrBaseRead, CapsAtConfiguredMax) {
+  VrBaseComponent base("base_cap");
+  base.configure({{"controller_type", "left"},
+                  {"max_linear_mps", 0.3},
+                  {"max_angular_rps", 0.7},
+                  {"deadzone", 0.1}});
+
+  VrSession::instance().set_test_frame(make_stick_frame("left", 0.0f, 1.0f));
+  EXPECT_NEAR(base.read()[0], 0.3f, 1e-4f);
+}
+
+TEST_F(VrBaseRead, DisconnectedOutputsZero) {
+  VrBaseComponent base("base_disc");
+  base.configure(base_config());
+  VrSession::instance().set_test_frame(make_stick_frame("left", 0.0f, 1.0f));
+
+  VrSession::instance().set_test_connected(false);
+  const auto out = base.read();
+  EXPECT_NEAR(out[0], 0.0f, 1e-6f);
+  EXPECT_NEAR(out[1], 0.0f, 1e-6f);
+}
+
+TEST_F(VrBaseRead, NonFiniteAxisStopsBase) {
+  VrBaseComponent base("base_nan");
+  base.configure(base_config());
+
+  auto bad = make_stick_frame("left", 0.0f, 0.0f);
+  bad.left_controller.thumbstick.y_axis = std::nanf("");
+  VrSession::instance().set_test_frame(bad);
+
+  const auto out = base.read();
+  EXPECT_NEAR(out[0], 0.0f, 1e-6f);
+  EXPECT_NEAR(out[1], 0.0f, 1e-6f);
+}


### PR DESCRIPTION
## Summary

Adds `VrBaseComponent`, a base-velocity teleop leader driven by VR thumbstick(s) (hardware type `vr_base_component`). Pairs with the SLATE base follower.

## Changes

- `read()` samples the configured thumbstick(s) and returns `[linear_mps, angular_rps]`: forward stick → forward velocity, left stick → positive yaw. `write()` is a no-op (leader-only). Returns zeros while the headset is disconnected so the base does not coast on a stale frame.
- A centered deadzone zeroes small stick noise, then rescales the remaining travel to full range before applying `max_linear_mps` / `max_angular_rps` caps.
- Split-axis mode: linear and angular axes may come from the same or different controllers; either axis may be specified independently, with a documented fallback.
- `configure()` validates `max_linear_mps` / `max_angular_rps` (non-negative, finite).

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware

## Breaking Changes

None.

## Related Issues

N/A — part of the VR teleoperation feature stack.
