### PR TITLE
examples: add trossen_vr_solo demo

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,6 +12,13 @@ target_link_libraries(trossen_stationary_ai trossen_sdk libtrossen_arm)
 add_executable(trossen_mobile_ai trossen_mobile_ai/trossen_mobile_ai.cpp)
 target_link_libraries(trossen_mobile_ai trossen_sdk libtrossen_arm)
 
+# VR demos require the VR hardware layer (TROSSEN_ENABLE_VR).
+if(TROSSEN_ENABLE_VR)
+  # Trossen VR Solo — 1 VR controller leader + 1 follower arm + 2 cameras
+  add_executable(trossen_vr_solo trossen_vr_solo/trossen_vr_solo.cpp)
+  target_link_libraries(trossen_vr_solo trossen_sdk libtrossen_arm)
+endif()
+
 # Registry demo executable
 add_executable(backend_registry_demo backend_registry_demo.cpp)
 target_link_libraries(backend_registry_demo trossen_sdk)

--- a/examples/trossen_vr_solo/README.md
+++ b/examples/trossen_vr_solo/README.md
@@ -1,0 +1,110 @@
+# Trossen VR Solo Demo
+
+Single-arm VR teleop: one follower arm, two cameras, and one VR right controller.
+The right VR controller acts as the Cartesian-space leader — its pose and trigger
+drive the follower arm at the teleop mirror rate (`teleop.rate_hz`, default
+1000 Hz). Joint and camera data are *recorded* at their producer poll rates
+(30 Hz by default).
+
+## Hardware required
+
+- 1× Trossen arm (`wxai_v0_follower`)
+- 2× RealSense cameras (main view + wrist; update serial numbers in `config.json`)
+- VR headset running the Trossen VR app
+
+## Flow
+
+1. **Launch the demo.** The follower arm connects over TCP, both cameras
+   initialize, and the VR network receiver binds port `9000`.
+2. **Open the VR app** and connect to this host's IP address. The VR session
+   control component starts and waits for the headset.
+3. **Press A on the right controller** (or ENTER in the terminal) to start
+   the first episode. The arm's current Cartesian pose is captured as the
+   anchor point; hold the right hand-grip and the arm begins mirroring.
+4. **The hand-grip is the deadman switch.** The arm mirrors only while the hand-grip is held.
+   Releasing and re-gripping re-anchors the offset to the arm's current pose —
+   no jump on re-engagement.
+5. The episode records until `session.max_duration` seconds elapse or you stop
+   it early.
+6. **A** starts the next episode. **B** re-records the current or last episode.
+   **Ctrl+C** ends the session. Keyboard (ENTER / arrow keys) works as fallback.
+
+> **VR button bindings** (configurable under `vr.session_control.bindings`):
+> - **A** = start / advance to next episode / skip reset
+> - **B** = re-record current or last episode
+
+## Run
+
+```bash
+cd ~/trossen_sdk
+./build/examples/trossen_vr_solo
+```
+
+Override any config key on the command line:
+
+```bash
+./build/examples/trossen_vr_solo \
+  --set hardware.arms.follower.ip_address=192.168.1.5 \
+  --set hardware.cameras[0].serial_number=123456789012 \
+  --set hardware.cameras[1].serial_number=987654321098 \
+  --set session.max_duration=60
+```
+
+Print merged config without touching hardware:
+
+```bash
+./build/examples/trossen_vr_solo --dump-config
+```
+
+## Config keys
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `hardware.arms.follower.ip_address` | `192.168.1.4` | Follower arm IP |
+| `hardware.cameras[0].serial_number` | `128422271347` | Main camera serial (set to your device) |
+| `hardware.cameras[1].serial_number` | `218622270304` | Wrist camera serial (set to your device) |
+| `vr.arm_controllers.vr_right.controller_type` | `right` | Which VR controller to use |
+| `vr.arm_controllers.vr_right.vr_port` | `9000` | Port the VR app connects to |
+| `vr.arm_controllers.vr_right.gripper_max_m` | `0.04` | Gripper opening at full trigger (m) |
+| `vr.arm_controllers.vr_right.connection_timeout_s` | `120.0` | Seconds to wait for the headset |
+| `vr.session_control.connection_timeout_s` | `120.0` | Seconds to wait for the headset (session-control source) |
+| `session.max_duration` | `10` | Episode length in seconds |
+| `session.max_episodes` | `5` | Number of episodes to record |
+| `teleop.rate_hz` | `1000.0` | Mirror loop frequency |
+
+## Cartesian vector format
+
+The VR leader emits `[x, y, z, rx, ry, rz, gripper_m]` every tick:
+
+- `x, y, z` — target position in the follower's base frame (meters)
+- `rx, ry, rz` — axis-angle rotation (radians)
+- `gripper_m` — gripper opening, linearly mapped from the index trigger `[0..1]`
+  onto `[gripper_min_m, gripper_max_m]`
+
+The VR-to-robot alignment is captured once in `sync_to_state()` at the start of
+each episode so the arm tracks *relative* hand motion, not the controller's
+absolute world position.
+
+## Troubleshooting
+
+- **Timeout waiting for VR headset**: check that the VR app is running, the
+  headset is on the same network, and no firewall blocks port `9000`.
+- **Arm snaps on first tick**: `sync_to_state()` was called before the headset
+  sent a valid frame. Make sure the connection is established before starting
+  the first episode.
+- **Gripper feels wrong**: tune `vr.arm_controllers.vr_right.gripper_max_m`.
+  The `wxai_v0_follower` fully opens at approximately `0.04 m`.
+
+## Live visualization (optional)
+
+Build with `-DTROSSEN_ENABLE_RERUN_OBSERVER=ON` and start a viewer before
+launching the demo (in a separate terminal):
+
+```bash
+rerun
+```
+
+The demo connects to `rerun+http://127.0.0.1:9876/proxy` (configurable under
+`observers[0].rerun_url`). Install the viewer with `uv tool install rerun-sdk`
+(or `pip install rerun-sdk`). To silence the observer entirely, set
+`observers[0].enabled` to `false`.

--- a/examples/trossen_vr_solo/config.json
+++ b/examples/trossen_vr_solo/config.json
@@ -1,0 +1,117 @@
+{
+  "robot_name": "trossen_vr_solo",
+
+  "hardware": {
+    "arms": {
+      "follower": {
+        "ip_address":          "192.168.1.4",
+        "model":               "wxai_v0",
+        "end_effector":        "wxai_v0_follower",
+        "staged_position":     [0.0, 1.04719755, 0.523598776, 0.628318531, 0.0, 0.0, 0.0],
+        "teleop_moving_time_s": 2.0
+      }
+    },
+    "cameras": [
+      {
+        "id":            "camera_main",
+        "serial_number": "128422271347",
+        "width":         640,
+        "height":        480,
+        "fps":           30
+      },
+      {
+        "id":            "camera_wrist",
+        "serial_number": "218622270304",
+        "width":         640,
+        "height":        480,
+        "fps":           30
+      }
+    ]
+  },
+
+  "producers": [
+    {
+      "type":            "trossen_arm",
+      "hardware_id":     "follower",
+      "stream_id":       "follower",
+      "poll_rate_hz":    30.0,
+      "use_device_time": false
+    },
+    {
+      "type":            "realsense_camera",
+      "hardware_id":     "camera_main",
+      "stream_id":       "camera_main",
+      "poll_rate_hz":    30.0,
+      "encoding":        "bgr8",
+      "use_device_time": true
+    },
+    {
+      "type":            "realsense_camera",
+      "hardware_id":     "camera_wrist",
+      "stream_id":       "camera_wrist",
+      "poll_rate_hz":    30.0,
+      "encoding":        "bgr8",
+      "use_device_time": true
+    }
+  ],
+
+  "vr": {
+    "arm_controllers": {
+      "vr_right": {
+        "controller_type":      "right",
+        "vr_port":              9000,
+        "gripper_min_m":        0.0,
+        "gripper_max_m":        0.04,
+        "connection_timeout_s": 120.0
+      }
+    },
+    "session_control": {
+      "controller_type":      "right",
+      "vr_port":              9000,
+      "connection_timeout_s": 120.0,
+      "poll_interval_ms":     50,
+      "disconnect_timeout_s": 2.0,
+      "bindings": {
+        "button_a": "start",
+        "button_b": "rerecord"
+      }
+    }
+  },
+
+  "teleop": {
+    "enabled": true,
+    "rate_hz": 1000.0,
+    "pairs": [
+      { "leader": "vr_right", "follower": "follower", "space": "cartesian" }
+    ]
+  },
+
+  "session": {
+    "max_duration":   10,
+    "max_episodes":   5,
+    "backend_type":   "trossen_mcap"
+  },
+
+  "backend": {
+    "root":             "~/.trossen_sdk",
+    "dataset_id":       "vr_solo_dataset",
+    "compression":      "",
+    "chunk_size_bytes": 4194304
+  },
+
+  "observers": [
+    {
+      "type":      "rerun",
+      "id":        "live_viewer",
+      "rerun_url": "rerun+http://127.0.0.1:9876/proxy",
+      "app_id":    "trossen_vr_solo",
+      "spawn":     true,
+      "enabled":   true,
+      "subscriptions": [
+        { "record_id": "follower",     "throttle_hz": 30.0 },
+        { "record_id": "camera_main",  "throttle_hz": 15.0 },
+        { "record_id": "camera_wrist", "throttle_hz": 15.0 }
+      ]
+    }
+  ]
+}

--- a/examples/trossen_vr_solo/trossen_vr_solo.cpp
+++ b/examples/trossen_vr_solo/trossen_vr_solo.cpp
@@ -325,36 +325,18 @@ int main(int argc, char** argv) {
   const bool has_teleop = !controllers.empty();
   for (auto& ctrl : controllers) mgr.add_teleop(std::move(ctrl));
 
-  // Wire VR button callbacks to SessionManager's thread-safe signals.
-  // set_callbacks() just stores lambdas; start() spawns the reader thread.
+  // Hand the VR button source to SessionManager. attach_control() installs
+  // callbacks that only post events onto a thread-safe queue, starts the
+  // reader thread, and remembers the source so shutdown() stops it. The
+  // session is only ever mutated on the main loop thread.
   if (session_ctrl) {
-    session_ctrl->set_callbacks(
-      [&](trossen::hw::session_control::SessionControlEvent ev) {
-        using E = trossen::hw::session_control::SessionControlEvent;
-        switch (ev) {
-          case E::kStart:
-            mgr.stop_episode();
-            mgr.signal_reset_complete();
-            break;
-          case E::kRerecord:   mgr.request_rerecord();      break;
-          case E::kStopEarly:  mgr.stop_episode();          break;
-          case E::kStopSession: trossen::utils::g_stop_requested = true; break;
-          default: break;
-        }
-      },
-      [&]() {
-        // VR headset disconnected mid-session — end cleanly.
-        std::cout << "\n[vr] Headset disconnected. Ending session.\n";
-        trossen::utils::g_stop_requested = true;
-      });
-
     const double sc_timeout =
       vr_cfg_top.at("session_control").value("connection_timeout_s", 120.0);
     std::cout << "\nWaiting for VR headset on port " << vr_port
               << " (timeout " << sc_timeout
               << " s) — open the VR app and connect to this host's IP...\n";
     try {
-      session_ctrl->start();
+      mgr.attach_control(session_ctrl);
       std::cout << "VR headset connected. Button A = start, B = re-record.\n";
     } catch (const std::exception& e) {
       std::cerr << "\nError: VR headset did not connect — " << e.what() << "\n"
@@ -408,7 +390,6 @@ int main(int argc, char** argv) {
     if (initial == trossen::runtime::UserAction::kStop ||
         trossen::utils::g_stop_requested) {
       std::cout << "\nAborted before first episode.\n";
-      if (session_ctrl) session_ctrl->stop();
       mgr.shutdown();
       return 0;
     }
@@ -448,8 +429,6 @@ int main(int argc, char** argv) {
 
   // shutdown() calls stop_episode() (no-op if already stopped) then on_pre_shutdown
   mgr.shutdown();
-
-  if (session_ctrl) session_ctrl->stop();
 
   const auto final_stats = mgr.stats();
   std::vector<std::string> extra_info = {

--- a/examples/trossen_vr_solo/trossen_vr_solo.cpp
+++ b/examples/trossen_vr_solo/trossen_vr_solo.cpp
@@ -1,0 +1,465 @@
+/**
+ * @file trossen_vr_solo.cpp
+ * @brief VR-driven single-arm teleop demo — 1 VR controller leader + 1 follower arm.
+ *
+ * The right VR controller acts as a Cartesian-space leader. Its pose and trigger
+ * are mapped to the follower arm every teleop tick. Session control (start /
+ * re-record) is driven by button A/B on the right VR controller, or from the
+ * terminal keyboard as a fallback.
+ *
+ * The hand-grip (hand trigger) on the VR controller is the deadman switch: the arm
+ * mirrors only while the hand-grip is held. Releasing and re-gripping re-anchors the
+ * offset to the arm's current pose so there is no jump on re-engagement.
+ *
+ * VR button bindings (configurable in config.json under vr.session_control.bindings):
+ *   A = start episode / advance to next / skip reset
+ *   B = re-record current or last episode
+ *
+ * Usage:
+ *   ./trossen_vr_solo [OPTIONS]
+ *
+ *   --config PATH       Path to robot config JSON
+ *                       [default: examples/trossen_vr_solo/config.json]
+ *   --set KEY=VALUE     Override a config value using dot notation (repeatable)
+ *   --dump-config       Print merged config as JSON and exit
+ *   --help              Show this help and exit
+ *
+ * Examples:
+ *   ./trossen_vr_solo
+ *   ./trossen_vr_solo --set hardware.arms.follower.ip_address=192.168.1.5
+ *   ./trossen_vr_solo --set session.max_duration=60
+ *   ./trossen_vr_solo --dump-config
+ */
+
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+#include "trossen_sdk/configuration/cli_parser.hpp"
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+#include "trossen_sdk/configuration/sdk_config.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
+#include "trossen_sdk/hw/vr/vr_arm_component.hpp"
+#include "trossen_sdk/hw/vr/vr_session_control_component.hpp"
+#include "trossen_sdk/observer/observer_registry.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
+#include "trossen_sdk/utils/app_utils.hpp"
+
+static void print_usage(const char* program) {
+  std::cout <<
+    "Usage: " << program << " [OPTIONS]\n"
+    "\n"
+    "Options:\n"
+    "  --config PATH      Path to robot config JSON\n"
+    "                     [default: examples/trossen_vr_solo/config.json]\n"
+    "  --set KEY=VALUE    Override a config value using dot notation (repeatable)\n"
+    "  --dump-config      Print merged config as JSON and exit\n"
+    "  --help             Show this help and exit\n"
+    "\n"
+    "Examples:\n"
+    "  " << program << "\n"
+    "  " << program << " --set hardware.arms.follower.ip_address=192.168.1.5\n"
+    "  " << program << " --set session.max_duration=60\n"
+    "  " << program << " --dump-config\n";
+}
+
+int main(int argc, char** argv) {
+  // Flush every line immediately so progress is always visible — important
+  // for a long-running, hardware-driven recording loop.
+  std::cout << std::unitbuf;
+  trossen::configuration::CliParser cli(argc, argv);
+
+  if (cli.has_flag("help")) {
+    print_usage(argv[0]);
+    return 0;
+  }
+
+  const std::string config_path =
+    cli.get_string("config", "examples/trossen_vr_solo/config.json");
+
+  if (!std::filesystem::exists(config_path)) {
+    std::cerr << "Error: config file not found: " << config_path << "\n";
+    return 1;
+  }
+
+  // Load JSON and apply CLI overrides
+  auto j = trossen::configuration::JsonLoader::load(config_path);
+  const auto overrides = cli.get_set_overrides();
+  if (!overrides.empty()) {
+    j = trossen::configuration::merge_overrides(j, overrides);
+  }
+
+  if (cli.has_flag("dump-config")) {
+    trossen::configuration::dump_config(j, "Trossen VR Solo Config");
+    return 0;
+  }
+
+  // Parse unified robot config
+  auto cfg = trossen::configuration::SdkConfig::from_json(j);
+
+  // Populate GlobalConfig so SessionManager picks up session + backend settings
+  cfg.populate_global_config();
+
+  const std::string root = cfg.mcap_backend.root;
+
+  // Extract VR config block early — used in both the banner and hardware init.
+  const auto vr_cfg_top     = j.contains("vr") ? j.at("vr") : nlohmann::json::object();
+  const auto arm_ctrl_cfg   = vr_cfg_top.contains("arm_controllers")
+    ? vr_cfg_top.at("arm_controllers") : nlohmann::json::object();
+
+  float joint_rate_hz = 30.0f;
+  float camera_fps    = 30.0f;
+  for (const auto& p : cfg.producers) {
+    if (p.type == "trossen_arm") {
+      joint_rate_hz = p.poll_rate_hz;
+      break;
+    }
+  }
+  for (const auto& p : cfg.producers) {
+    if (p.type == "zed_camera" || p.type == "realsense_camera" ||
+        p.type == "opencv_camera") { camera_fps = p.poll_rate_hz; break; }
+  }
+
+  std::vector<std::string> config_lines = {
+    "Config file:          " + config_path,
+    "Root directory:       " + root,
+    "Backend:              " + cfg.session.backend_type,
+    "Robot name:           " + cfg.robot_name,
+  };
+  for (const auto& [id, arm] : cfg.hardware.arms) {
+    config_lines.push_back(
+      "Arm [" + id + "]:           " + arm.ip_address + " (" + arm.end_effector + ")");
+  }
+  for (const auto& cam : cfg.hardware.cameras) {
+    config_lines.push_back(
+      "Camera [" + cam.id + "]:       " + cam.serial_number + "  " +
+      std::to_string(cam.width) + "x" + std::to_string(cam.height) +
+      " @ " + std::to_string(cam.fps) + " fps");
+  }
+  for (const auto& [id, entry] : arm_ctrl_cfg.items()) {
+    config_lines.push_back(
+      "VR ctrl [" + id + "]:       " +
+      entry.value("controller_type", std::string{"right"}) + " controller, port " +
+      std::to_string(entry.value("vr_port", 9000)));
+  }
+  config_lines.push_back("Joint rate:           " + std::to_string(joint_rate_hz) + " Hz");
+  if (!cfg.hardware.cameras.empty()) {
+    config_lines.push_back("Camera rate:          " + std::to_string(camera_fps) + " fps");
+  }
+  config_lines.push_back(
+    "Teleop:               " +
+    std::string(cfg.teleop.enabled ? "enabled" : "disabled") +
+    " (" + std::to_string(cfg.teleop.pairs.size()) + " pairs)");
+
+  trossen::utils::print_config_banner("Trossen VR Solo Demo", config_lines);
+
+  trossen::utils::install_signal_handler();
+  std::filesystem::create_directories(root);
+
+  // ── Initialize arm hardware ──────────────────────────────────────────────────
+
+  std::cout << "Initializing hardware...\n";
+
+  std::unordered_map<std::string,
+    std::shared_ptr<trossen::hw::arm::TrossenArmComponent>> arm_components;
+  for (const auto& [id, arm_cfg] : cfg.hardware.arms) {
+    auto component = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", id, arm_cfg.to_json(), true);
+    arm_components[id] =
+      std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(component);
+    std::cout << "  [ok] Arm [" << id << "] configured (" << arm_cfg.ip_address << ")\n";
+  }
+
+  // ── Initialize cameras ─────────────────────────────────────────────────────
+
+  std::unordered_map<std::string,
+    std::shared_ptr<trossen::hw::HardwareComponent>> camera_components;
+  std::unordered_map<std::string,
+    const trossen::configuration::CameraConfig*> camera_cfg_map;
+  for (const auto& cam_cfg : cfg.hardware.cameras) {
+    auto cam_component = trossen::hw::HardwareRegistry::create(
+      cam_cfg.type, cam_cfg.id, cam_cfg.to_json());
+    camera_components[cam_cfg.id] = cam_component;
+    camera_cfg_map[cam_cfg.id] = &cam_cfg;
+    std::cout << "  [ok] Camera [" << cam_cfg.id << "] initialized ("
+              << cam_cfg.serial_number << ")\n";
+  }
+
+  // ── Initialize VR arm controller ────────────────────────────────────────
+  // VrArmComponent is registered into the ActiveHardwareRegistry under its
+  // configured id (e.g. "vr_right"). The teleop factory then pairs it with
+  // the follower arm using the "teleop" block from config.
+
+  const auto& arm_controllers = arm_ctrl_cfg;
+
+  std::uint16_t vr_port = 9000;
+  for (const auto& [_, entry] : arm_controllers.items()) {
+    if (entry.contains("vr_port")) {
+      vr_port = entry.at("vr_port").get<std::uint16_t>();
+      break;
+    }
+  }
+  std::cout << "  [info] VR receiver on port " << vr_port
+            << " — connect the VR app to this host's IP.\n";
+
+  std::vector<std::shared_ptr<trossen::hw::vr::VrArmComponent>> vr_components;
+  for (const auto& [id, entry] : arm_controllers.items()) {
+    auto component = trossen::hw::HardwareRegistry::create("vr_arm_component", id, entry, true);
+    vr_components.push_back(
+      std::dynamic_pointer_cast<trossen::hw::vr::VrArmComponent>(component));
+    std::cout << "  [ok] VR arm component [" << id << "] ("
+              << entry.value("controller_type", std::string{"right"}) << " controller)\n";
+  }
+
+  // ── Initialize VR session control (A/B buttons → episode events) ─────────
+  // Optional: only configured if vr.session_control is present in config.
+  // When active, button A starts/advances and button B re-records, so the
+  // operator never needs to touch the keyboard between episodes.
+
+  std::shared_ptr<trossen::hw::vr::VrSessionControlComponent> session_ctrl;
+  if (vr_cfg_top.contains("session_control")) {
+    const auto& sc_cfg = vr_cfg_top.at("session_control");
+    auto component = trossen::hw::HardwareRegistry::create(
+      "vr_session_control", "vr_session_ctrl", sc_cfg, true);
+    session_ctrl =
+      std::dynamic_pointer_cast<trossen::hw::vr::VrSessionControlComponent>(component);
+    std::cout << "  [ok] VR session control configured ("
+              << sc_cfg.value("controller_type", std::string{"right"})
+              << " controller, A=start B=re-record)\n";
+  }
+
+  // ── Session manager + producers ─────────────────────────────────────────
+
+  trossen::runtime::SessionManager mgr;
+  std::cout << "\nInitialized Session Manager\n"
+            << "  Starting episode index: " << mgr.stats().current_episode_index << "\n";
+  if (mgr.stats().current_episode_index > 0) {
+    std::cout << "  (Resuming from existing episodes in directory)\n";
+  }
+  std::cout << "\n";
+
+  std::cout << "Creating producers...\n";
+  for (const auto& prod_cfg : cfg.producers) {
+    const auto period =
+      std::chrono::milliseconds(static_cast<int>(1000.0f / prod_cfg.poll_rate_hz));
+    if (prod_cfg.type == "trossen_arm") {
+      auto prod = trossen::runtime::ProducerRegistry::create(
+        "trossen_arm", arm_components.at(prod_cfg.hardware_id), prod_cfg.to_registry_json());
+      mgr.add_producer(prod, period);
+      std::cout << "  [ok] Arm producer [" << prod_cfg.stream_id << "] ("
+                << prod_cfg.poll_rate_hz << " Hz)\n";
+    } else if (camera_components.count(prod_cfg.hardware_id)) {
+      const auto* cam = camera_cfg_map.at(prod_cfg.hardware_id);
+      if (trossen::runtime::PushProducerRegistry::is_registered(prod_cfg.type)) {
+        auto prod = trossen::runtime::PushProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_push_producer(prod);
+        std::cout << "  [ok] Camera producer (push) [" << prod_cfg.stream_id << "] ("
+                  << cam->width << "x" << cam->height << ")\n";
+      } else {
+        auto prod = trossen::runtime::ProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_producer(prod, period);
+        std::cout << "  [ok] Camera producer [" << prod_cfg.stream_id << "] ("
+                  << prod_cfg.poll_rate_hz << " Hz, "
+                  << cam->width << "x" << cam->height << ")\n";
+      }
+    }
+  }
+  std::cout << "\nProducers registered. Ready to record.\n";
+
+  // ── Observers ─────────────────────────────────────────────────────────
+
+  if (!cfg.observers.empty()) {
+    std::cout << "Creating observers...\n";
+    for (const auto& obs_cfg : cfg.observers) {
+      if (!obs_cfg.enabled) {
+        std::cout << "  [disabled] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " (skipped: enabled=false)\n";
+        continue;
+      }
+      try {
+        auto obs = trossen::observer::ObserverRegistry::create(
+          obs_cfg.type, obs_cfg.raw_json);
+        mgr.add_observer(obs);
+        std::cout << "  [ok] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " subscriptions=" << obs_cfg.subscriptions.size() << "\n";
+      } catch (const std::exception& e) {
+        std::cerr << "  [skip] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " failed to construct: " << e.what() << "\n";
+        const auto types = trossen::observer::ObserverRegistry::get_registered_types();
+        std::cerr << "         Registered observer types:";
+        for (const auto& t : types) std::cerr << " " << t;
+        std::cerr << "\n";
+        if (!trossen::observer::ObserverRegistry::is_registered(obs_cfg.type)) {
+          std::cerr << "         Hint: type '" << obs_cfg.type
+                    << "' is not registered. Rebuild with the matching CMake option "
+                    << "(e.g. -DTROSSEN_ENABLE_RERUN_OBSERVER=ON for the 'rerun' type) "
+                    << "or set 'enabled': false on this observer to silence the warning.\n";
+        }
+      }
+    }
+  }
+
+  // ── Teleop controllers ──────────────────────────────────────────────────
+  // VrArmComponent registered above is found by the factory via
+  // ActiveHardwareRegistry, paired with the follower, and wrapped in a
+  // TeleopController. add_teleop() hands lifecycle ownership to SessionManager.
+
+  auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+
+  const bool has_teleop = !controllers.empty();
+  for (auto& ctrl : controllers) mgr.add_teleop(std::move(ctrl));
+
+  // Wire VR button callbacks to SessionManager's thread-safe signals.
+  // set_callbacks() just stores lambdas; start() spawns the reader thread.
+  if (session_ctrl) {
+    session_ctrl->set_callbacks(
+      [&](trossen::hw::session_control::SessionControlEvent ev) {
+        using E = trossen::hw::session_control::SessionControlEvent;
+        switch (ev) {
+          case E::kStart:
+            mgr.stop_episode();
+            mgr.signal_reset_complete();
+            break;
+          case E::kRerecord:   mgr.request_rerecord();      break;
+          case E::kStopEarly:  mgr.stop_episode();          break;
+          case E::kStopSession: trossen::utils::g_stop_requested = true; break;
+          default: break;
+        }
+      },
+      [&]() {
+        // VR headset disconnected mid-session — end cleanly.
+        std::cout << "\n[vr] Headset disconnected. Ending session.\n";
+        trossen::utils::g_stop_requested = true;
+      });
+
+    const double sc_timeout =
+      vr_cfg_top.at("session_control").value("connection_timeout_s", 120.0);
+    std::cout << "\nWaiting for VR headset on port " << vr_port
+              << " (timeout " << sc_timeout
+              << " s) — open the VR app and connect to this host's IP...\n";
+    try {
+      session_ctrl->start();
+      std::cout << "VR headset connected. Button A = start, B = re-record.\n";
+    } catch (const std::exception& e) {
+      std::cerr << "\nError: VR headset did not connect — " << e.what() << "\n"
+                << "Open the VR app and connect to this host's IP, then re-run.\n";
+      mgr.shutdown();
+      return 1;
+    }
+  }
+
+  // ── Lifecycle callbacks ─────────────────────────────────────────────────
+
+  int depth_cameras = 0;
+  for (const auto& cam : cfg.hardware.cameras) {
+    if (cam.use_depth) ++depth_cameras;
+  }
+
+  mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
+    const std::string file_path =
+      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+    trossen::utils::print_episode_summary(file_path, stats);
+
+    trossen::utils::SanityCheckConfig sanity_cfg{
+      stats.elapsed.count(),
+      static_cast<int>(cfg.hardware.arms.size()),
+      joint_rate_hz,
+      static_cast<int>(cfg.hardware.cameras.size()),
+      static_cast<int>(camera_fps),
+      5.0,
+      depth_cameras
+    };
+    perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
+  });
+
+  mgr.on_pre_shutdown([&]() {
+    if (!has_teleop) {
+      for (auto& [id, arm] : arm_components) arm->end_teleop();
+    }
+  });
+
+  // ── Episode loop ────────────────────────────────────────────────────────
+
+  std::cout << "\nReady. Press A on the right VR controller (or ENTER) to start.\n"
+            << "  Hold the hand-grip trigger to teleop the arm.\n"
+            << "  A / ENTER      = start episode / advance to next / skip reset\n"
+            << "  B / LEFT arrow = re-record current or last episode\n"
+            << "  Ctrl+C         = end session\n\n";
+
+  // Wait for explicit A / ENTER before the very first episode.
+  {
+    const auto initial = mgr.wait_for_reset();
+    if (initial == trossen::runtime::UserAction::kStop ||
+        trossen::utils::g_stop_requested) {
+      std::cout << "\nAborted before first episode.\n";
+      if (session_ctrl) session_ctrl->stop();
+      mgr.shutdown();
+      return 0;
+    }
+  }
+
+  while (true) {
+    if (trossen::utils::g_stop_requested) {
+      std::cout << "\nStopping at user request (Ctrl+C).\n";
+      break;
+    }
+
+    mgr.print_episode_header();
+
+    if (!mgr.start_episode()) break;
+    std::cout << "Recording...\n";
+
+    auto action = mgr.monitor_episode();
+    if (action == trossen::runtime::UserAction::kReRecord) {
+      mgr.discard_current_episode();
+      continue;
+    }
+
+    if (mgr.is_episode_active()) mgr.stop_episode();
+
+    if (trossen::utils::g_stop_requested) {
+      std::cout << "\nStopping at user request (Ctrl+C).\n";
+      break;
+    }
+
+    action = mgr.wait_for_reset();
+    if (action == trossen::runtime::UserAction::kStop) break;
+    if (action == trossen::runtime::UserAction::kReRecord) {
+      mgr.discard_last_episode();
+      continue;
+    }
+  }
+
+  // shutdown() calls stop_episode() (no-op if already stopped) then on_pre_shutdown
+  mgr.shutdown();
+
+  if (session_ctrl) session_ctrl->stop();
+
+  const auto final_stats = mgr.stats();
+  std::vector<std::string> extra_info = {
+    "Data streams:         " +
+      std::to_string(cfg.hardware.arms.size()) + " arm(s) + " +
+      std::to_string(cfg.hardware.cameras.size()) + " camera(s)",
+    "VR controllers:       " + std::to_string(arm_ctrl_cfg.size())
+  };
+  trossen::utils::print_final_summary(
+    final_stats.total_episodes_completed, root, extra_info);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Adds the single-arm VR teleop demo: one VR right controller drives one follower arm in Cartesian space, with two cameras and live rerun visualization. Ties together every prior PR in the stack.

## Changes

- Right controller is the cartesian leader; the hand-grip is the deadman switch and re-gripping re-anchors with no jump. Trigger drives the gripper.
- Right A/B buttons map to session control (A = start/advance, B = re-record); keyboard (ENTER / arrows / Ctrl+C) works as a fallback.
- `config.json` wires the arm, two cameras, the VR arm controller, session control, teleop pair, and a rerun observer. README documents flow, config-key defaults, and the live viewer.
- Adds the `trossen_vr_solo` target to `examples/CMakeLists.txt`.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware

## Breaking Changes

None.

## Related Issues

N/A — part of the VR teleoperation feature stack.
