### PR TITLE
arm: add EndEffectorPoseRecord and proto schema

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ set(PROTOBUF_IMPORT_DIRS ${TROSSEN_PROTO_PATH})
 set(TROSSEN_PROTO_FILES
   ${TROSSEN_PROTO_PATH}/JointState.proto
   ${TROSSEN_PROTO_PATH}/Odometry2D.proto
+  ${TROSSEN_PROTO_PATH}/EndEffectorPose.proto
   ${TROSSEN_PROTO_PATH}/RobotDescription.proto
   ${TROSSEN_PROTO_PATH}/Timestamp.proto
 )

--- a/include/trossen_sdk/data/record.hpp
+++ b/include/trossen_sdk/data/record.hpp
@@ -113,7 +113,7 @@ struct JointStateRecord : public RecordBase {
 /**
  * @brief End-effector pose of a robot arm, expressed in the robot base frame.
  *
- * Position is in meters. Orientation is an axis-angle vector (rx, ry, rz):
+ * Position is in meters. Orientation is an axis-angle vector (rotation_x, rotation_y, rotation_z):
  * the vector magnitude is the rotation angle (rad), the unit vector is the
  * rotation axis. Computed by libtrossen_arm FK; co-emitted with JointStateRecord
  * from the same poll() call so the two records share the same seq number.

--- a/include/trossen_sdk/data/record.hpp
+++ b/include/trossen_sdk/data/record.hpp
@@ -111,6 +111,37 @@ struct JointStateRecord : public RecordBase {
 
 
 /**
+ * @brief End-effector pose of a robot arm, expressed in the robot base frame.
+ *
+ * Position is in meters. Orientation is an axis-angle vector (rx, ry, rz):
+ * the vector magnitude is the rotation angle (rad), the unit vector is the
+ * rotation axis. Computed by libtrossen_arm FK; co-emitted with JointStateRecord
+ * from the same poll() call so the two records share the same seq number.
+ */
+struct EndEffectorPoseRecord : public RecordBase {
+  /// @brief End-effector position along x-axis in the robot base frame (m)
+  float x{0.f};
+
+  /// @brief End-effector position along y-axis in the robot base frame (m)
+  float y{0.f};
+
+  /// @brief End-effector position along z-axis in the robot base frame (m)
+  float z{0.f};
+
+  /// @brief Axis-angle rotation component around x (rad)
+  float rotation_x{0.f};
+
+  /// @brief Axis-angle rotation component around y (rad)
+  float rotation_y{0.f};
+
+  /// @brief Axis-angle rotation component around z (rad)
+  float rotation_z{0.f};
+
+  /// @brief Gripper jaw opening distance (m)
+  float gripper_position{0.f};
+};
+
+/**
  * @brief 2D odometry state (pose + velocity), mirroring nav_msgs/Odometry.
  */
 struct Odometry2DRecord : public RecordBase {

--- a/include/trossen_sdk/io/backends/trossen_mcap/proto/EndEffectorPose.proto
+++ b/include/trossen_sdk/io/backends/trossen_mcap/proto/EndEffectorPose.proto
@@ -4,7 +4,7 @@ package trossen_sdk.msg;
 import "Timestamp.proto";
 
 // End-effector pose of a robot arm, expressed in the robot base frame.
-// Orientation is encoded as a 3-element axis-angle vector (rx, ry, rz).
+// Orientation is encoded as a 3-element axis-angle vector (rotation_x, rotation_y, rotation_z).
 // The gripper opening is appended as a separate scalar.
 message EndEffectorPose {
   // Dual timestamp (monotonic for ordering, realtime for wall-clock alignment)

--- a/include/trossen_sdk/io/backends/trossen_mcap/proto/EndEffectorPose.proto
+++ b/include/trossen_sdk/io/backends/trossen_mcap/proto/EndEffectorPose.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package trossen_sdk.msg;
+
+import "Timestamp.proto";
+
+// End-effector pose of a robot arm, expressed in the robot base frame.
+// Orientation is encoded as a 3-element axis-angle vector (rx, ry, rz).
+// The gripper opening is appended as a separate scalar.
+message EndEffectorPose {
+  // Dual timestamp (monotonic for ordering, realtime for wall-clock alignment)
+  trossen_sdk.Timestamp ts = 1;
+
+  // Monotonic sequence number, shared with the co-emitted JointState record
+  // from the same poll() call for easy temporal alignment.
+  uint64 seq = 2;
+
+  // End-effector position in the robot base frame (meters)
+  float x = 3;
+  float y = 4;
+  float z = 5;
+
+  // End-effector orientation as an axis-angle vector (radians).
+  // The magnitude of (rotation_x, rotation_y, rotation_z) is the rotation
+  // angle; the unit vector gives the rotation axis.
+  float rotation_x = 6;
+  float rotation_y = 7;
+  float rotation_z = 8;
+
+  // Gripper jaw opening distance (meters)
+  float gripper_position = 9;
+}


### PR DESCRIPTION
## Summary

Defines `EndEffectorPoseRecord` and its protobuf schema — the data type used to store end-effector pose in MCAP files. Nothing emits this record yet; this PR just establishes what the data looks like.

## Changes

- Add `EndEffectorPoseRecord` struct to `record.hpp`: x, y, z, rotation_x, rotation_y, rotation_z, and gripper_position fields.
- Add `EndEffectorPose.proto` with one named scalar field per axis plus timestamp and sequence number.
- Register `EndEffectorPose.proto` in `CMakeLists.txt` so it is compiled alongside the other SDK schemas.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware (if applicable)

## Breaking Changes

None.

## Related Issues

Part of the end-effector pose recording feature stack.