### PR TITLE
arm: emit end-effector pose from TrossenArmProducer

### DIFF
--- a/src/hw/arm/trossen_arm_producer.cpp
+++ b/src/hw/arm/trossen_arm_producer.cpp
@@ -107,6 +107,7 @@ void TrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::Rec
   }
 
   emit(rec);
+  ++stats_.produced;
 
   // Create and populate EndEffectorPoseRecord.
   // Cartesian positions [x, y, z, rx, ry, rz] from the arm driver's FK output;
@@ -127,10 +128,10 @@ void TrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::Rec
     eef_rec->gripper_position =
       static_cast<float>(robot_output_.joint.gripper.position);
     emit(eef_rec);
+    ++stats_.produced;
   }
 
   ++seq_;
-  ++stats_.produced;
 }
 
 // Register producer with registry

--- a/src/hw/arm/trossen_arm_producer.cpp
+++ b/src/hw/arm/trossen_arm_producer.cpp
@@ -82,10 +82,12 @@ void TrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::Rec
     data::Timespec::from_ns(device_ts) : data::now_mono();
   ts.realtime = data::now_real();
 
-  // Create and populate JointStateRecord
+  // Create and populate JointStateRecord.
+  // Both this record and the EndEffectorPoseRecord below share the same seq
+  // number because they come from the same physical driver read.
   auto rec = std::make_shared<data::JointStateRecord>();
   rec->ts = ts;
-  rec->seq = seq_++;
+  rec->seq = seq_;
   rec->id = cfg_.stream_id;
   // Convert double->float
   rec->positions.reserve(pos_d_.size());
@@ -105,6 +107,29 @@ void TrossenArmProducer::poll(const std::function<void(std::shared_ptr<data::Rec
   }
 
   emit(rec);
+
+  // Create and populate EndEffectorPoseRecord.
+  // Cartesian positions [x, y, z, rx, ry, rz] from the arm driver's FK output;
+  // gripper opening from the joint state. Guard on size to handle transient
+  // partial reads at startup.
+  const auto& cart_positions = robot_output_.cartesian.positions;
+  if (cart_positions.size() >= 6) {
+    auto eef_rec = std::make_shared<data::EndEffectorPoseRecord>();
+    eef_rec->ts = ts;
+    eef_rec->seq = seq_;
+    eef_rec->id = cfg_.stream_id;
+    eef_rec->x = static_cast<float>(cart_positions[0]);
+    eef_rec->y = static_cast<float>(cart_positions[1]);
+    eef_rec->z = static_cast<float>(cart_positions[2]);
+    eef_rec->rotation_x = static_cast<float>(cart_positions[3]);
+    eef_rec->rotation_y = static_cast<float>(cart_positions[4]);
+    eef_rec->rotation_z = static_cast<float>(cart_positions[5]);
+    eef_rec->gripper_position =
+      static_cast<float>(robot_output_.joint.gripper.position);
+    emit(eef_rec);
+  }
+
+  ++seq_;
   ++stats_.produced;
 }
 


### PR DESCRIPTION
## Summary

`TrossenArmProducer` now co-emits an `EndEffectorPoseRecord` alongside each `JointStateRecord`. 

## Changes

- Emit `EndEffectorPoseRecord` per `poll()` call. Position fields `[x, y, z, rx, ry, rz]` come from the arm driver's forward kinematics output; `gripper_position` from the joint state.
- Both records share the same `seq` and timestamp so they can be aligned trivially in downstream tooling.
- Emission is guarded on `cartesian.positions.size() >= 6` to skip partial reads during startup.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware (if applicable)

## Breaking Changes

None. Existing MCAP recordings are unaffected. New recordings gain one additional topic per arm.

## Related Issues

Part of the end-effector pose recording feature stack.