### PR TITLE
examples: update sanity check for end-effector pose

### DIFF
--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -343,7 +343,10 @@ int main(int argc, char** argv) {
   // arm re-homing are owned by the SessionManager.)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
     const std::string file_path =
-      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+      trossen::utils::generate_episode_path(
+        root + "/" + cfg.mcap_backend.dataset_id,
+        stats.current_episode_index,
+        "mcap");
     trossen::utils::print_episode_summary(file_path, stats);
 
     trossen::utils::SanityCheckConfig sanity_cfg{
@@ -353,7 +356,8 @@ int main(int argc, char** argv) {
       static_cast<int>(cfg.hardware.cameras.size()),
       static_cast<int>(camera_fps),
       5.0,
-      depth_cameras
+      depth_cameras,
+      static_cast<int>(cfg.hardware.arms.size())  // one EEF pose producer per arm
     };
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -309,7 +309,10 @@ int main(int argc, char** argv) {
   // arm re-homing are owned by the SessionManager.)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
     const std::string file_path =
-      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+      trossen::utils::generate_episode_path(
+        root + "/" + cfg.mcap_backend.dataset_id,
+        stats.current_episode_index,
+        "mcap");
     trossen::utils::print_episode_summary(file_path, stats);
 
     trossen::utils::SanityCheckConfig sanity_cfg{
@@ -319,7 +322,8 @@ int main(int argc, char** argv) {
       static_cast<int>(cfg.hardware.cameras.size()),
       static_cast<int>(camera_fps),
       5.0,
-      depth_cameras
+      depth_cameras,
+      static_cast<int>(cfg.hardware.arms.size())  // one EEF pose producer per arm
     };
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -310,7 +310,10 @@ int main(int argc, char** argv) {
   // arm re-homing are owned by the SessionManager.)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
     const std::string file_path =
-      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+      trossen::utils::generate_episode_path(
+        root + "/" + cfg.mcap_backend.dataset_id,
+        stats.current_episode_index,
+        "mcap");
     trossen::utils::print_episode_summary(file_path, stats);
 
     trossen::utils::SanityCheckConfig sanity_cfg{
@@ -320,7 +323,8 @@ int main(int argc, char** argv) {
       static_cast<int>(cfg.hardware.cameras.size()),
       static_cast<int>(camera_fps),
       5.0,
-      depth_cameras
+      depth_cameras,
+      static_cast<int>(cfg.hardware.arms.size())  // one EEF pose producer per arm
     };
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });

--- a/examples/trossen_vr_mobile/trossen_vr_mobile.cpp
+++ b/examples/trossen_vr_mobile/trossen_vr_mobile.cpp
@@ -426,7 +426,10 @@ int main(int argc, char** argv) {
 
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
     const std::string file_path =
-      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+      trossen::utils::generate_episode_path(
+        root + "/" + cfg.mcap_backend.dataset_id,
+        stats.current_episode_index,
+        "mcap");
     trossen::utils::print_episode_summary(file_path, stats);
 
     trossen::utils::SanityCheckConfig sanity_cfg{
@@ -436,7 +439,8 @@ int main(int argc, char** argv) {
       static_cast<int>(cfg.hardware.cameras.size()),
       static_cast<int>(camera_fps),
       5.0,
-      depth_cameras
+      depth_cameras,
+      static_cast<int>(cfg.hardware.arms.size())  // one EEF pose producer per arm
     };
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });

--- a/examples/trossen_vr_solo/trossen_vr_solo.cpp
+++ b/examples/trossen_vr_solo/trossen_vr_solo.cpp
@@ -355,7 +355,10 @@ int main(int argc, char** argv) {
 
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
     const std::string file_path =
-      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+      trossen::utils::generate_episode_path(
+        root + "/" + cfg.mcap_backend.dataset_id,
+        stats.current_episode_index,
+        "mcap");
     trossen::utils::print_episode_summary(file_path, stats);
 
     trossen::utils::SanityCheckConfig sanity_cfg{
@@ -365,7 +368,8 @@ int main(int argc, char** argv) {
       static_cast<int>(cfg.hardware.cameras.size()),
       static_cast<int>(camera_fps),
       5.0,
-      depth_cameras
+      depth_cameras,
+      static_cast<int>(cfg.hardware.arms.size())  // one EEF pose producer per arm
     };
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });

--- a/examples/trossen_vr_stationary/trossen_vr_stationary.cpp
+++ b/examples/trossen_vr_stationary/trossen_vr_stationary.cpp
@@ -362,7 +362,10 @@ int main(int argc, char** argv) {
 
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
     const std::string file_path =
-      trossen::utils::generate_episode_path(root, stats.current_episode_index);
+      trossen::utils::generate_episode_path(
+        root + "/" + cfg.mcap_backend.dataset_id,
+        stats.current_episode_index,
+        "mcap");
     trossen::utils::print_episode_summary(file_path, stats);
 
     trossen::utils::SanityCheckConfig sanity_cfg{
@@ -372,7 +375,8 @@ int main(int argc, char** argv) {
       static_cast<int>(cfg.hardware.cameras.size()),
       static_cast<int>(camera_fps),
       5.0,
-      depth_cameras
+      depth_cameras,
+      static_cast<int>(cfg.hardware.arms.size())  // one EEF pose producer per arm
     };
     perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
   });

--- a/include/trossen_sdk/utils/app_utils.hpp
+++ b/include/trossen_sdk/utils/app_utils.hpp
@@ -67,13 +67,14 @@ void print_final_summary(
  * @brief Configuration for sanity check validation
  */
 struct SanityCheckConfig {
-  double actual_duration_s;     ///< Actual episode duration
-  int joint_producers;          ///< Number of joint state producers
-  float joint_rate_hz;          ///< Joint state sample rate
-  int camera_producers;         ///< Number of camera producers
-  int camera_fps;               ///< Camera frame rate
-  double tolerance_percent;     ///< Tolerance as percentage (default: 5.0%)
-  int depth_camera_producers;   ///< Number of depth-capable cameras (each emits 2x records)
+  double actual_duration_s;            ///< Actual episode duration
+  int joint_producers;                 ///< Number of joint state producers
+  float joint_rate_hz;                 ///< Joint state sample rate
+  int camera_producers;                ///< Number of camera producers
+  int camera_fps;                      ///< Camera frame rate
+  double tolerance_percent;            ///< Tolerance as percentage (default: 5.0%)
+  int depth_camera_producers;          ///< Number of depth-capable cameras (each emits 2x records)
+  int end_effector_pose_producers{0};  ///< Number of end-effector pose producers
 };
 
 /**

--- a/src/utils/app_utils.cpp
+++ b/src/utils/app_utils.cpp
@@ -197,14 +197,18 @@ bool perform_sanity_check(
   const SanityCheckConfig& config)
 {
   // Expected sink records: each producer enqueues 1 record per poll/frame.
+  // TrossenArmProducer emits both a JointStateRecord and an EndEffectorPoseRecord
+  // per poll, so joint and end-effector pose counts are tracked separately.
   // Depth cameras embed color + depth in a single ImageRecord, so they count
   // as 1 sink record per frame (same as color-only cameras). The backend then
   // writes the depth as a separate channel in the output file.
   int expected_joint = static_cast<int>(
     config.joint_rate_hz * config.actual_duration_s * config.joint_producers);
+  int expected_end_effector_pose = static_cast<int>(
+    config.joint_rate_hz * config.actual_duration_s * config.end_effector_pose_producers);
   int expected_camera = static_cast<int>(
     config.camera_fps * config.actual_duration_s * config.camera_producers);
-  int expected_total = expected_joint + expected_camera;
+  int expected_total = expected_joint + expected_end_effector_pose + expected_camera;
 
   // Backend output writes: depth cameras produce 2 channel writes per frame
   int color_only = config.camera_producers - config.depth_camera_producers;
@@ -228,6 +232,7 @@ bool perform_sanity_check(
             << config.actual_duration_s << "s\n";
   std::cout << "  Expected:        ~" << expected_total << " sink records ("
             << expected_joint << " joints + "
+            << expected_end_effector_pose << " end-effector poses + "
             << expected_camera << " camera frames)\n";
   std::cout << "  Actual:          " << actual_records << " sink records\n";
   std::cout << "  Tolerance:       " << min_expected << " - " << max_expected


### PR DESCRIPTION
## Summary

Updates all six demo apps to account for the new end-effector pose records in the post-episode sanity check, and fixes a pre-existing bug where the episode file path shown after recording was missing the dataset subdirectory.

## Changes

- Add `end_effector_pose_producers` field to `SanityCheckConfig` (defaults to 0, so any example that is not updated continues to compile and behave as before).
- Update `perform_sanity_check()` to include EEF records in the expected total.
- All six examples — `trossen_solo_ai`, `trossen_stationary_ai`, `trossen_mobile_ai`, `trossen_vr_solo`, `trossen_vr_stationary`, `trossen_vr_mobile` — pass `cfg.hardware.arms.size()` as `end_effector_pose_producers`.
- Fix episode file path in the post-episode summary: was missing the `dataset_id` subdirectory and used the wrong extension.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware (if applicable)

## Breaking Changes

None.

## Related Issues

Part of the end-effector pose recording feature stack.