### PR TITLE
utils: add RobotDescriptionCache for URDF download and mesh embedding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,8 @@ jobs:
           pkg-config \
           libbz2-dev \
           zlib1g-dev \
-          nlohmann-json3-dev
+          nlohmann-json3-dev \
+          libcurl4-openssl-dev
 
     - name: Install Parquet dependencies
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(trossen_sdk SHARED
   src/runtime/push_producer_registry.cpp
   src/utils/app_utils.cpp
   src/utils/keyboard_input_utils.cpp
+  src/utils/robot_description_cache.cpp
 )
 
 if(TROSSEN_ENABLE_REALSENSE)
@@ -142,6 +143,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
   set(BZIP2_LIBRARIES /usr/lib/aarch64-linux-gnu/libbz2.so)
   set(BZIP2_INCLUDE_DIRS /usr/include)
 endif()
+find_package(CURL REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(BZip2 REQUIRED)
 
@@ -261,6 +263,7 @@ target_include_directories(trossen_sdk PUBLIC
 
 # Link against foxglove library
 target_link_libraries(trossen_sdk PRIVATE ${foxglove_SOURCE_DIR}/lib/libfoxglove.a)
+target_link_libraries(trossen_sdk PRIVATE CURL::libcurl)
 
 # Required OpenCV dependency for camera producer
 # On Ubuntu/Debian, OpenCV 4.x is typically installed as opencv4

--- a/include/trossen_sdk/utils/robot_description_cache.hpp
+++ b/include/trossen_sdk/utils/robot_description_cache.hpp
@@ -29,7 +29,7 @@ public:
   /**
    * @brief Resolves and returns the URDF string ready for MCAP storage.
    *
-   * @param robot_name Robot name from config (e.g. "trossen_ai_solo"). Used to
+   * @param robot_name Robot name from config (e.g. "trossen_solo_ai"). Used to
    *   select the URDF automatically when urdf_variant is empty.
    * @param urdf_variant Explicit repo-relative URDF path override
    *   (e.g. "urdf/generated/wxai/wxai_follower.urdf"). Empty = auto from robot_name.

--- a/include/trossen_sdk/utils/robot_description_cache.hpp
+++ b/include/trossen_sdk/utils/robot_description_cache.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file robot_description_cache.hpp
+ * @brief Downloads and caches URDF robot descriptions from the trossen_arm_description repo.
+ */
+
+#ifndef TROSSEN_SDK__UTILS__ROBOT_DESCRIPTION_CACHE_HPP_
+#define TROSSEN_SDK__UTILS__ROBOT_DESCRIPTION_CACHE_HPP_
+
+#include <string>
+
+namespace trossen::utils {
+
+/**
+ * @brief Downloads and returns a URDF string ready for storage in an MCAP file.
+ *
+ * Downloads the URDF and all referenced mesh/texture files from
+ * TrossenRobotics/trossen_arm_description and caches them under
+ * ~/.cache/trossen_sdk/robot_description/<git_ref>/. Subsequent calls for the same
+ * ref return cached files immediately with no network access.
+ *
+ * When include_meshes is false, all package:// mesh paths are replaced with
+ * absolute paths to the local cache so the URDF works directly in Rerun and
+ * other tools on the same machine without any additional steps.
+ * When include_meshes is true, every package:// path is replaced with a base64
+ * data URI so the returned string is fully self-contained and portable.
+ */
+class RobotDescriptionCache {
+public:
+  /**
+   * @brief Resolves and returns the URDF string ready for MCAP storage.
+   *
+   * @param robot_name Robot name from config (e.g. "trossen_ai_solo"). Used to
+   *   select the URDF automatically when urdf_variant is empty.
+   * @param urdf_variant Explicit repo-relative URDF path override
+   *   (e.g. "urdf/generated/wxai/wxai_follower.urdf"). Empty = auto from robot_name.
+   * @param git_ref Branch or tag on trossen_arm_description to fetch from (e.g. "main").
+   * @param include_meshes If true, download meshes and embed as base64 data URIs.
+   * @return URDF XML string, or empty string on error.
+   */
+  static std::string resolve(
+    const std::string& robot_name,
+    const std::string& urdf_variant,
+    const std::string& git_ref,
+    bool include_meshes);
+};
+
+}  // namespace trossen::utils
+
+#endif  // TROSSEN_SDK__UTILS__ROBOT_DESCRIPTION_CACHE_HPP_

--- a/src/utils/robot_description_cache.cpp
+++ b/src/utils/robot_description_cache.cpp
@@ -6,10 +6,12 @@
 
 #include <curl/curl.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <system_error>
 #include <unordered_map>
 
 #include "trossen_sdk/io/backend_utils.hpp"
@@ -94,9 +96,23 @@ std::string load_or_download(
   std::string data = download_url(url);
   if (data.empty()) return "";
 
-  std::filesystem::create_directories(cached.parent_path());
+  // Cache writes are best-effort: on failure, still return the downloaded
+  // content and remove any partial file so it is not later read as valid.
+  std::error_code ec;
+  std::filesystem::create_directories(cached.parent_path(), ec);
+  if (ec) {
+    std::cerr << "[robot_description] Failed to create cache dir "
+              << cached.parent_path() << ": " << ec.message() << "\n";
+    return data;
+  }
   std::ofstream out(cached, std::ios::binary);
   out.write(data.data(), static_cast<std::streamsize>(data.size()));
+  if (!out) {
+    std::cerr << "[robot_description] Failed to write cache file " << cached
+              << "; skipping cache\n";
+    out.close();
+    std::filesystem::remove(cached, ec);
+  }
   return data;
 }
 
@@ -163,7 +179,12 @@ std::string patch_paths_to_cache(
       continue;
     }
 
-    load_or_download(rel_path, git_ref, ref_cache_dir);
+    // Skip rewriting when the asset is unavailable; keep the original
+    // package:// reference instead of pointing at a missing cache file.
+    if (load_or_download(rel_path, git_ref, ref_cache_dir).empty()) {
+      pos = end;
+      continue;
+    }
     std::string abs_path = (ref_cache_dir / rel_path).string();
 
     result = result.substr(0, pos) + abs_path + result.substr(end);
@@ -242,7 +263,13 @@ std::string RobotDescriptionCache::resolve(
   }
 
   auto ref_cache_dir = cache_root() / git_ref;
-  std::filesystem::create_directories(ref_cache_dir);
+  std::error_code ec;
+  std::filesystem::create_directories(ref_cache_dir, ec);
+  if (ec) {
+    std::cerr << "[robot_description] Failed to create cache dir "
+              << ref_cache_dir << ": " << ec.message() << "\n";
+    return "";
+  }
 
   std::string urdf = load_or_download(urdf_path, git_ref, ref_cache_dir);
   if (urdf.empty()) return "";

--- a/src/utils/robot_description_cache.cpp
+++ b/src/utils/robot_description_cache.cpp
@@ -1,0 +1,260 @@
+/**
+ * @file robot_description_cache.cpp
+ */
+
+#include "trossen_sdk/utils/robot_description_cache.hpp"
+
+#include <curl/curl.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+#include "trossen_sdk/io/backend_utils.hpp"
+
+namespace trossen::utils {
+
+namespace {
+
+static constexpr char kRepoBase[] =
+  "https://raw.githubusercontent.com/TrossenRobotics/trossen_arm_description/";
+
+// Maps the robot_name field from backend config to the repo-relative URDF path.
+// Override with urdf_variant in config for variants not listed here (e.g. leader arm).
+static const std::unordered_map<std::string, std::string> kUrdfLookup = {
+  {"trossen_solo_ai",       "urdf/generated/wxai/wxai_follower.urdf"},
+  {"trossen_stationary_ai", "urdf/generated/stationary_ai.urdf"},
+  {"trossen_mobile_ai",     "urdf/generated/mobile_ai.urdf"},
+};
+
+// Download
+
+static size_t curl_write_cb(char* data, size_t size, size_t nmemb, void* userp) {
+  static_cast<std::string*>(userp)->append(data, size * nmemb);
+  return size * nmemb;
+}
+
+std::string download_url(const std::string& url) {
+  CURL* curl = curl_easy_init();
+  if (!curl) {
+    std::cerr << "[robot_description] curl_easy_init failed\n";
+    return "";
+  }
+
+  std::string response;
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_cb);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+
+  CURLcode res = curl_easy_perform(curl);
+  long http_code = 0;  // NOLINT(runtime/int) — libcurl requires long* for CURLINFO_RESPONSE_CODE
+  if (res == CURLE_OK) {
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+  }
+  curl_easy_cleanup(curl);
+
+  if (res != CURLE_OK) {
+    std::cerr << "[robot_description] Download failed (" << url << "): "
+              << curl_easy_strerror(res) << "\n";
+    return "";
+  }
+  if (http_code != 200) {
+    std::cerr << "[robot_description] HTTP " << http_code << " for " << url << "\n";
+    return "";
+  }
+  return response;
+}
+
+// Cache
+
+std::filesystem::path cache_root() {
+  return trossen::io::backends::get_default_root_path() / "robot_description";
+}
+
+// Returns file content from the local cache. On a cache miss, downloads the file
+// from GitHub, saves it, and returns the content.
+std::string load_or_download(
+  const std::string& rel_path,
+  const std::string& git_ref,
+  const std::filesystem::path& ref_cache_dir)
+{
+  auto cached = ref_cache_dir / rel_path;
+
+  if (std::filesystem::exists(cached)) {
+    std::ifstream f(cached, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(f), {});
+  }
+
+  std::string url = std::string(kRepoBase) + git_ref + "/" + rel_path;
+  std::cout << "[robot_description] Downloading " << url << "\n";
+  std::string data = download_url(url);
+  if (data.empty()) return "";
+
+  std::filesystem::create_directories(cached.parent_path());
+  std::ofstream out(cached, std::ios::binary);
+  out.write(data.data(), static_cast<std::streamsize>(data.size()));
+  return data;
+}
+
+// Base64
+
+static constexpr char kBase64Chars[] =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+std::string base64_encode(const std::string& input) {
+  std::string result;
+  result.reserve(((input.size() + 2) / 3) * 4);
+
+  size_t i = 0;
+  const size_t n = input.size();
+  while (i + 2 < n) {
+    uint32_t b = (static_cast<uint8_t>(input[i]) << 16) |
+                 (static_cast<uint8_t>(input[i + 1]) << 8) |
+                  static_cast<uint8_t>(input[i + 2]);
+    result += kBase64Chars[(b >> 18) & 0x3f];
+    result += kBase64Chars[(b >> 12) & 0x3f];
+    result += kBase64Chars[(b >>  6) & 0x3f];
+    result += kBase64Chars[(b) & 0x3f];
+    i += 3;
+  }
+  if (i < n) {
+    uint32_t b = static_cast<uint8_t>(input[i]) << 16;
+    if (i + 1 < n) b |= static_cast<uint8_t>(input[i + 1]) << 8;
+    result += kBase64Chars[(b >> 18) & 0x3f];
+    result += kBase64Chars[(b >> 12) & 0x3f];
+    result += (i + 1 < n) ? kBase64Chars[(b >> 6) & 0x3f] : '=';
+    result += '=';
+  }
+  return result;
+}
+
+// URDF path patching
+
+static bool is_mesh_or_texture(const std::string& rel_path) {
+  return rel_path.ends_with(".stl") || rel_path.ends_with(".STL") ||
+         rel_path.ends_with(".dae") || rel_path.ends_with(".DAE") ||
+         rel_path.ends_with(".png") || rel_path.ends_with(".PNG");
+}
+
+// Replaces every package://trossen_arm_description/ reference with the absolute path
+// of the corresponding file in the local cache, downloading it first if needed.
+// The returned URDF works directly in Rerun and other tools without any ROS environment.
+std::string patch_paths_to_cache(
+  const std::string& urdf,
+  const std::string& git_ref,
+  const std::filesystem::path& ref_cache_dir)
+{
+  const std::string prefix = "package://trossen_arm_description/";
+  std::string result = urdf;
+  size_t pos = 0;
+
+  while ((pos = result.find(prefix, pos)) != std::string::npos) {
+    size_t end = result.find('"', pos);
+    if (end == std::string::npos) break;
+
+    std::string rel_path = result.substr(pos + prefix.size(), end - pos - prefix.size());
+
+    if (!is_mesh_or_texture(rel_path)) {
+      pos = end;
+      continue;
+    }
+
+    load_or_download(rel_path, git_ref, ref_cache_dir);
+    std::string abs_path = (ref_cache_dir / rel_path).string();
+
+    result = result.substr(0, pos) + abs_path + result.substr(end);
+    pos += abs_path.size();
+  }
+
+  return result;
+}
+
+// Replaces every package://trossen_arm_description/ reference with a base64-encoded
+// data URI, making the URDF fully self-contained. The closing quote of each filename
+// attribute is used as the boundary, so extra XML attributes like scale="..." are
+// preserved.
+std::string patch_paths_to_data_uris(
+  const std::string& urdf,
+  const std::string& git_ref,
+  const std::filesystem::path& ref_cache_dir)
+{
+  const std::string prefix = "package://trossen_arm_description/";
+  std::string result = urdf;
+  size_t pos = 0;
+
+  while ((pos = result.find(prefix, pos)) != std::string::npos) {
+    size_t end = result.find('"', pos);
+    if (end == std::string::npos) break;
+
+    std::string rel_path = result.substr(pos + prefix.size(), end - pos - prefix.size());
+
+    std::string mime;
+    if (rel_path.ends_with(".stl") || rel_path.ends_with(".STL")) {
+      mime = "model/stl";
+    } else if (rel_path.ends_with(".dae") || rel_path.ends_with(".DAE")) {
+      mime = "model/vnd.collada+xml";
+    } else if (rel_path.ends_with(".png") || rel_path.ends_with(".PNG")) {
+      mime = "image/png";
+    } else {
+      pos = end;
+      continue;
+    }
+
+    std::string asset_data = load_or_download(rel_path, git_ref, ref_cache_dir);
+    if (asset_data.empty()) {
+      pos = end;
+      continue;
+    }
+
+    std::string data_uri = "data:" + mime + ";base64," + base64_encode(asset_data);
+    result = result.substr(0, pos) + data_uri + result.substr(end);
+    pos += data_uri.size();
+  }
+
+  return result;
+}
+
+}  // namespace
+
+// Public API
+
+std::string RobotDescriptionCache::resolve(
+  const std::string& robot_name,
+  const std::string& urdf_variant,
+  const std::string& git_ref,
+  bool include_meshes)
+{
+  std::string urdf_path;
+  if (!urdf_variant.empty()) {
+    urdf_path = urdf_variant;
+  } else {
+    auto it = kUrdfLookup.find(robot_name);
+    if (it == kUrdfLookup.end()) {
+      std::cerr << "[robot_description] No URDF known for robot_name='"
+                << robot_name << "'. Set urdf_variant in config to override.\n";
+      return "";
+    }
+    urdf_path = it->second;
+  }
+
+  auto ref_cache_dir = cache_root() / git_ref;
+  std::filesystem::create_directories(ref_cache_dir);
+
+  std::string urdf = load_or_download(urdf_path, git_ref, ref_cache_dir);
+  if (urdf.empty()) return "";
+
+  if (!include_meshes) {
+    // Replace package:// paths with absolute local cache paths so the URDF
+    // is immediately usable by Rerun and other tools on this machine.
+    return patch_paths_to_cache(urdf, git_ref, ref_cache_dir);
+  }
+
+  // Embed all mesh files as base64 data URIs for a fully portable URDF.
+  return patch_paths_to_data_uris(urdf, git_ref, ref_cache_dir);
+}
+
+}  // namespace trossen::utils


### PR DESCRIPTION
### Summary

This PR adds a small utility that resolves a robot name to its URDF, downloading and caching files locally, and optionally embeds all meshes as base64 data URIs so the resulting URDF is fully self-contained and portable.

### Changes

- Add `RobotDescriptionCache::resolve(robot_name, urdf_variant, git_ref, include_meshes)` — returns the URDF string for a robot, downloading from `TrossenRobotics/trossen_arm_description` at the given git ref on cache miss.
- Files are cached under `~/.cache/trossen_sdk/robot_description/<git_ref>/` so repeated recordings never re-download.
- With `include_meshes=false`, `package://` mesh references are rewritten to absolute local cache paths (usable by Rerun on the same machine). With `include_meshes=true`, meshes are embedded as base64 data URIs (usable anywhere, including Foxglove).
- Link libcurl into `trossen_sdk` and add `libcurl4-openssl-dev` to the CI dependencies.

### Test Plan

- [x] Builds cleanly (`make build`)
- [ ]  Tests pass(make test)
- [x] Lint passes (`pre-commit run --all-files`)
- [ ] Tested on hardware

### Breaking Changes

None. New utility, not called by anything yet.

### Related Issues

None.