### PR TITLE
config: add robot description options to TrossenMCAP backend

### DIFF
--- a/include/trossen_sdk/configuration/types/backends/trossen_mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_mcap_backend_config.hpp
@@ -61,6 +61,11 @@ struct TrossenMCAPBackendConfig : public BaseConfig {
     }
     if (j.contains("urdf_variant")) j.at("urdf_variant").get_to(c.urdf_variant);
 
+    // Mesh embedding requires the robot description, so enable it implicitly.
+    if (c.include_meshes && !c.include_robot_description) {
+      c.include_robot_description = true;
+    }
+
     return c;
   }
 };

--- a/include/trossen_sdk/configuration/types/backends/trossen_mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_mcap_backend_config.hpp
@@ -26,6 +26,16 @@ struct TrossenMCAPBackendConfig : public BaseConfig {
   // TODO(shantanuparab-tr): Remove episode index if not being used
   int episode_index{0};
 
+  /// Write a /robot_description message to each MCAP file at recording start.
+  bool include_robot_description{false};
+  /// Embed mesh files as base64 data URIs inside the URDF (requires include_robot_description).
+  bool include_meshes{false};
+  /// Git ref (branch or tag) on TrossenRobotics/trossen_arm_description to download from.
+  std::string robot_description_ref{"main"};
+  /// URDF path within the description repo (e.g. "urdf/generated/stationary_ai.urdf").
+  /// Leave empty to auto-resolve from robot_name.
+  std::string urdf_variant{""};
+
   std::string type() const override { return "trossen_mcap_backend"; }
 
   static TrossenMCAPBackendConfig from_json(const nlohmann::json& j) {
@@ -42,6 +52,14 @@ struct TrossenMCAPBackendConfig : public BaseConfig {
     if (j.contains("compression")) j.at("compression").get_to(c.compression);
     if (j.contains("dataset_id")) j.at("dataset_id").get_to(c.dataset_id);
     if (j.contains("episode_index")) j.at("episode_index").get_to(c.episode_index);
+    if (j.contains("include_robot_description")) {
+      j.at("include_robot_description").get_to(c.include_robot_description);
+    }
+    if (j.contains("include_meshes")) j.at("include_meshes").get_to(c.include_meshes);
+    if (j.contains("robot_description_ref")) {
+      j.at("robot_description_ref").get_to(c.robot_description_ref);
+    }
+    if (j.contains("urdf_variant")) j.at("urdf_variant").get_to(c.urdf_variant);
 
     return c;
   }

--- a/src/configuration/sdk_config.cpp
+++ b/src/configuration/sdk_config.cpp
@@ -160,6 +160,10 @@ void SdkConfig::populate_global_config() const {
     bj["compression"] = b.compression;
     bj["dataset_id"] = b.dataset_id;
     bj["episode_index"] = b.episode_index;
+    bj["include_robot_description"] = b.include_robot_description;
+    bj["include_meshes"] = b.include_meshes;
+    bj["robot_description_ref"] = b.robot_description_ref;
+    bj["urdf_variant"] = b.urdf_variant;
     gc_json["trossen_mcap_backend"] = bj;
   }
 


### PR DESCRIPTION
### Summary

Adds the configuration surface for robot description recording. Nothing consumes these fields yet; the next PR wires them into the TrossenMCAP backend.

### Changes

- Add four fields to `TrossenMCAPBackendConfig`: `include_robot_description` (default off), `include_meshes`, `robot_description_ref` (git branch/tag, default `main`), and `urdf_variant` (explicit repo path, empty = auto-resolve from `robot_name`).
- Parse the new fields in `from_json` and forward them through `SdkConfig::populate_global_config`, so they work from JSON config and `--set` overrides alike.

### Test Plan

- [x] Builds cleanly (`make build`)
- [ ] Tests pass (make test)
- [x] Lint passes (`pre-commit run --all-files`)
- [ ] Tested on hardware

### Breaking Changes

None. All fields default to the previous behavior (no robot description written).

### Related Issues

None.