### PR TITLE
backend: write robot description to TrossenMCAP files

### DIFF
--- a/include/trossen_sdk/io/backends/trossen_mcap/proto/RobotDescription.proto
+++ b/include/trossen_sdk/io/backends/trossen_mcap/proto/RobotDescription.proto
@@ -5,4 +5,6 @@ package trossen_sdk;
 // Robot description message containing the URDF string
 message RobotDescription {
   string robot_description = 1;
+  // Git ref (branch or tag) used to download the URDF, e.g. "main" or "v1.2.0".
+  string git_ref = 2;
 }

--- a/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp
@@ -54,6 +54,9 @@ public:
 
     /// @brief Number of depth images written
     uint64_t depth_images_written{0};
+
+    /// @brief Number of robot description messages written (0 or 1 per MCAP file)
+    uint64_t robot_description_written{0};
   };
 
   /**
@@ -210,6 +213,20 @@ private:
   void write_end_effector_pose_record(const data::EndEffectorPoseRecord& end_effector_pose);
 
   /**
+   * @brief Ensure the robot description channel exists
+   *
+   * @return Pointer to the channel, or nullptr on failure
+   */
+  foxglove::RawChannel* ensure_robot_description_channel();
+
+  /**
+   * @brief Write the URDF string to the /robot_description channel
+   *
+   * @param urdf_string Full URDF XML string to store
+   */
+  void write_robot_description_to_mcap(const std::string& urdf_string);
+
+  /**
    * @brief Register protobuf schemas once
    */
   void register_schemas_once();
@@ -228,6 +245,12 @@ private:
 
   /// @brief Serialised FileDescriptorSet for the EndEffectorPose protobuf schema
   std::string schema_data_end_effector_pose_;
+
+  /// @brief Serialised FileDescriptorSet for the RobotDescription protobuf schema
+  std::string schema_data_robot_description_;
+
+  /// @brief Single robot description channel (written once per MCAP file)
+  std::optional<foxglove::RawChannel> robot_description_channel_;
 
   /// @brief Output file path
   std::filesystem::path path_;

--- a/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_schemas.hpp
+++ b/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_schemas.hpp
@@ -65,6 +65,15 @@ inline std::string end_effector_pose_topic(const std::string& stream_id) {
   return stream_id + "/end_effector/pose";
 }
 
+/**
+ * @brief Get topic name for the robot description (URDF) channel
+ *
+ * @return Fixed topic name "/robot_description"
+ */
+inline std::string robot_description_topic() {
+  return "/robot_description";
+}
+
 }  // namespace trossen::trossen_mcap_defs
 
 #endif  // TROSSEN_SDK__IO__BACKENDS__TROSSEN_MCAP__TROSSEN_MCAP_SCHEMAS_HPP_

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -166,13 +166,19 @@ bool TrossenMCAPBackend::open() {
   }
 
   if (cfg_->include_robot_description) {
-    std::string urdf = trossen::utils::RobotDescriptionCache::resolve(
-      cfg_->robot_name,
-      cfg_->urdf_variant,
-      cfg_->robot_description_ref,
-      cfg_->include_meshes);
-    if (!urdf.empty()) {
-      write_robot_description_to_mcap(urdf);
+    // The robot description is optional, so a failure here must not abort open().
+    try {
+      std::string urdf = trossen::utils::RobotDescriptionCache::resolve(
+        cfg_->robot_name,
+        cfg_->urdf_variant,
+        cfg_->robot_description_ref,
+        cfg_->include_meshes);
+      if (!urdf.empty()) {
+        write_robot_description_to_mcap(urdf);
+      }
+    } catch (const std::exception& e) {
+      std::cerr << "Failed to resolve/write robot description: " << e.what()
+                << "; continuing without it\n";
     }
   }
 
@@ -468,7 +474,10 @@ void TrossenMCAPBackend::write_robot_description_to_mcap(const std::string& urdf
   msg.set_git_ref(cfg_->robot_description_ref);
 
   std::string payload;
-  msg.SerializeToString(&payload);
+  if (!msg.SerializeToString(&payload)) {
+    std::cerr << "Failed to serialize robot description; skipping\n";
+    return;
+  }
 
   auto st = channel->log(
     reinterpret_cast<const std::byte*>(payload.data()),

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -14,10 +14,12 @@
 #include "EndEffectorPose.pb.h"
 #include "JointState.pb.h"
 #include "Odometry2D.pb.h"
+#include "RobotDescription.pb.h"
 #include "nlohmann/json.hpp"
 #include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp"
+#include "trossen_sdk/utils/robot_description_cache.hpp"
 #include "trossen_sdk/version.hpp"
 
 namespace trossen::io::backends {
@@ -163,6 +165,17 @@ bool TrossenMCAPBackend::open() {
     std::cerr << "Failed to write metadata: " << foxglove::strerror(st) << "\n";
   }
 
+  if (cfg_->include_robot_description) {
+    std::string urdf = trossen::utils::RobotDescriptionCache::resolve(
+      cfg_->robot_name,
+      cfg_->urdf_variant,
+      cfg_->robot_description_ref,
+      cfg_->include_meshes);
+    if (!urdf.empty()) {
+      write_robot_description_to_mcap(urdf);
+    }
+  }
+
   return true;
 }
 
@@ -181,6 +194,10 @@ void TrossenMCAPBackend::close_resources() {
   }
   for (auto& [name, channel] : image_channels_) {
     channel.close();
+  }
+  if (robot_description_channel_.has_value()) {
+    robot_description_channel_->close();
+    robot_description_channel_.reset();
   }
   if (writer_) {
     auto st = writer_->close();
@@ -412,6 +429,57 @@ foxglove::RawChannel* TrossenMCAPBackend::ensure_end_effector_pose_channel(
   auto [inserted_it, _] = end_effector_pose_channels_.emplace(
     stream_id, std::move(channel_result.value()));
   return &inserted_it->second;
+}
+
+foxglove::RawChannel* TrossenMCAPBackend::ensure_robot_description_channel() {
+  if (robot_description_channel_.has_value()) {
+    return &robot_description_channel_.value();
+  }
+
+  foxglove::Schema schema;
+  schema.name = "trossen_sdk.RobotDescription";
+  schema.encoding = "protobuf";
+  schema.data = reinterpret_cast<const std::byte*>(schema_data_robot_description_.data());
+  schema.data_len = schema_data_robot_description_.size();
+
+  auto channel_result = foxglove::RawChannel::create(
+    trossen_mcap_defs::robot_description_topic(),
+    "protobuf",
+    schema,
+    context_,
+    std::nullopt);
+
+  if (!channel_result.has_value()) {
+    std::cerr << "Failed to create robot description channel: "
+              << foxglove::strerror(channel_result.error()) << "\n";
+    return nullptr;
+  }
+
+  robot_description_channel_ = std::move(channel_result.value());
+  return &robot_description_channel_.value();
+}
+
+void TrossenMCAPBackend::write_robot_description_to_mcap(const std::string& urdf_string) {
+  auto* channel = ensure_robot_description_channel();
+  if (!channel) return;
+
+  trossen_sdk::RobotDescription msg;
+  msg.set_robot_description(urdf_string);
+  msg.set_git_ref(cfg_->robot_description_ref);
+
+  std::string payload;
+  msg.SerializeToString(&payload);
+
+  auto st = channel->log(
+    reinterpret_cast<const std::byte*>(payload.data()),
+    payload.size(),
+    trossen::data::now_real().to_ns());
+
+  if (st != foxglove::FoxgloveError::Ok) {
+    std::cerr << "Failed to write robot description: " << foxglove::strerror(st) << "\n";
+  } else {
+    ++stats_.robot_description_written;
+  }
 }
 
 void TrossenMCAPBackend::write_end_effector_pose_record(
@@ -702,6 +770,8 @@ void TrossenMCAPBackend::register_schemas_once() {
     "trossen_sdk/io/backends/trossen_mcap/proto/Odometry2D.proto");
   schema_data_end_effector_pose_ = build_schema_blob(
     "trossen_sdk/io/backends/trossen_mcap/proto/EndEffectorPose.proto");
+  schema_data_robot_description_ = build_schema_blob(
+    "trossen_sdk/io/backends/trossen_mcap/proto/RobotDescription.proto");
 }
 
 bool TrossenMCAPBackend::is_depth_topic(const std::string& topic) {


### PR DESCRIPTION
### Summary

Writes the robot's URDF into every MCAP file. On `open()`, when `include_robot_description` is set, the backend resolves the URDF through `RobotDescriptionCache` and logs a single message on a `/robot_description` channel, so each episode file carries the exact robot model it was recorded with.

### Changes

- Add `git_ref` to the `RobotDescription` proto so the file records which description version it embeds.
- Add `robot_description_topic()` (`/robot_description`) to the TrossenMCAP topic helpers.
- Add the channel setup and single-message write to `TrossenMCAPBackend::open()`, plus a `robot_description_written` stat and clean channel teardown in `close_resources()`.

### Test Plan

- [x] Builds cleanly (`make build`)
- [ ] Tests pass(make test)
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Verified on hardware

### Breaking Changes

None. With `include_robot_description=false` (the default) the output files are unchanged.

### Related Issues

None.