### PR TITLE
examples: enable robot description recording in solo demo

### DIFF
--- a/examples/trossen_solo_ai/config.json
+++ b/examples/trossen_solo_ai/config.json
@@ -74,10 +74,13 @@
   },
 
   "backend": {
-    "root":             "~/.trossen_sdk",
-    "dataset_id":       "solo_dataset",
-    "compression":      "",
-    "chunk_size_bytes": 4194304
+    "root":                     "~/.trossen_sdk",
+    "robot_name":               "trossen_solo_ai",
+    "dataset_id":               "solo_dataset",
+    "compression":              "",
+    "chunk_size_bytes":         4194304,
+    "include_robot_description": true,
+    "include_meshes": true
   },
 
   "observers": [

--- a/examples/trossen_solo_ai/config.json
+++ b/examples/trossen_solo_ai/config.json
@@ -75,7 +75,6 @@
 
   "backend": {
     "root":                     "~/.trossen_sdk",
-    "robot_name":               "trossen_solo_ai",
     "dataset_id":               "solo_dataset",
     "compression":              "",
     "chunk_size_bytes":         4194304,


### PR DESCRIPTION
### Summary

Turns on robot description recording (with embedded meshes) in the solo demo, so every episode file is self-contained and directly visualizable in Foxglove. 

### Changes

- `examples/trossen_solo_ai/config.json`: set `robot_name`, `include_robot_description: true`, `include_meshes: true` in the backend section.

### Test Plan

- [x] Builds cleanly (`make build`)
- [ ] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [x] Tested on hardware (if applicable)

### Breaking Changes

None. Adds ~5.7 MB per episode file for the embedded URDF.

### Related Issues

None.