### PR TITLE
backend: write task_description to MCAP file metadata

### DIFF
--- a/include/trossen_sdk/configuration/types/backends/trossen_mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_mcap_backend_config.hpp
@@ -26,6 +26,10 @@ struct TrossenMCAPBackendConfig : public BaseConfig {
   // TODO(shantanuparab-tr): Remove episode index if not being used
   int episode_index{0};
 
+  /// Text description of the task being demonstrated (e.g. "pick up the cube").
+  /// Written to the MCAP file-level metadata if non-empty.
+  std::string task_description{""};
+
   std::string type() const override { return "trossen_mcap_backend"; }
 
   static TrossenMCAPBackendConfig from_json(const nlohmann::json& j) {
@@ -42,6 +46,7 @@ struct TrossenMCAPBackendConfig : public BaseConfig {
     if (j.contains("compression")) j.at("compression").get_to(c.compression);
     if (j.contains("dataset_id")) j.at("dataset_id").get_to(c.dataset_id);
     if (j.contains("episode_index")) j.at("episode_index").get_to(c.episode_index);
+    if (j.contains("task_description")) j.at("task_description").get_to(c.task_description);
 
     return c;
   }

--- a/python/trossen_sdk.cpp
+++ b/python/trossen_sdk.cpp
@@ -593,6 +593,7 @@ PYBIND11_MODULE(trossen_sdk, m) {
     .def_readwrite("compression", &TrossenMCAPBackendConfig::compression)
     .def_readwrite("dataset_id", &TrossenMCAPBackendConfig::dataset_id)
     .def_readwrite("episode_index", &TrossenMCAPBackendConfig::episode_index)
+    .def_readwrite("task_description", &TrossenMCAPBackendConfig::task_description)
     .def_static("from_json", &TrossenMCAPBackendConfig::from_json, py::arg("json"));
 
   py::class_<LeRobotV2BackendConfig, BaseConfig,

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -47,7 +47,9 @@ TrossenMCAPBackend::TrossenMCAPBackend(
   std::cout << "Compression: " << cfg_->compression << std::endl;
   std::cout << "Dataset ID: " << cfg_->dataset_id << std::endl;
   std::cout << "Episode Index: " << cfg_->episode_index << std::endl;
-  std::cout << "Task Description: " << cfg_->task_description << std::endl;
+  if (!cfg_->task_description.empty()) {
+    std::cout << "Task Description: " << cfg_->task_description << std::endl;
+  }
   std::cout << "======================================================" << std::endl;
   }
 TrossenMCAPBackend::~TrossenMCAPBackend() { close(); }

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -47,6 +47,7 @@ TrossenMCAPBackend::TrossenMCAPBackend(
   std::cout << "Compression: " << cfg_->compression << std::endl;
   std::cout << "Dataset ID: " << cfg_->dataset_id << std::endl;
   std::cout << "Episode Index: " << cfg_->episode_index << std::endl;
+  std::cout << "Task Description: " << cfg_->task_description << std::endl;
   std::cout << "======================================================" << std::endl;
   }
 TrossenMCAPBackend::~TrossenMCAPBackend() { close(); }
@@ -124,6 +125,9 @@ bool TrossenMCAPBackend::open() {
   metadata["episode_index"] = std::to_string(episode_index_);
   auto now = trossen::data::now_real();
   metadata["recording_start_time"] = std::to_string(now.to_ns());
+  if (!cfg_->task_description.empty()) {
+    metadata["task_description"] = cfg_->task_description;
+  }
 
   // Build dataset_info JSON from producer metadata (joint names, camera specs, etc.)
   nlohmann::ordered_json dataset_info;


### PR DESCRIPTION
## Summary

Adds a `task_description` field to the TrossenMCAP backend config a free-text label (e.g. "pick up the cube") written into the MCAP file's metadata record.

## Changes

- Add `task_description` field to `TrossenMCAPBackendConfig` (default `""`), parsed from JSON.
- Write it into the `trossen_sdk_recording` metadata record on `open()`, alongside
`robot_name`, `dataset_id`, etc. — only when non-empty.
- Log it in the backend's startup config banner.
- Pure additive change — no behavior change when the field is left unset.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [ ] Tested on hardware

## Breaking Changes

None.

## Related Issues

N/A — part of the task_description feature stack.