### PR TITLE
tests: add regression test and example config for task_description

### DIFF
--- a/examples/trossen_solo_ai/config.json
+++ b/examples/trossen_solo_ai/config.json
@@ -76,6 +76,7 @@
   "backend": {
     "root":             "~/.trossen_sdk",
     "dataset_id":       "solo_dataset",
+    "task_description": "",
     "compression":      "",
     "chunk_size_bytes": 4194304
   },

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,9 @@ target_link_libraries(test_null_backend PRIVATE trossen_sdk GTest::gtest_main)
 add_executable(test_backend_registry test_backend_registry.cpp)
 target_link_libraries(test_backend_registry PRIVATE trossen_sdk GTest::gtest_main)
 
+add_executable(test_trossen_mcap_backend test_trossen_mcap_backend.cpp)
+target_link_libraries(test_trossen_mcap_backend PRIVATE trossen_sdk GTest::gtest_main)
+
 add_executable(test_push_producer_registry test_push_producer_registry.cpp)
 target_link_libraries(test_push_producer_registry PRIVATE trossen_sdk GTest::gtest_main)
 
@@ -103,6 +106,7 @@ gtest_discover_tests(test_timestamp)
 gtest_discover_tests(test_record)
 gtest_discover_tests(test_null_backend)
 gtest_discover_tests(test_backend_registry)
+gtest_discover_tests(test_trossen_mcap_backend)
 gtest_discover_tests(test_push_producer_registry)
 gtest_discover_tests(test_push_producer_base)
 gtest_discover_tests(test_session_manager_push_producer)

--- a/tests/test_backend_registry.cpp
+++ b/tests/test_backend_registry.cpp
@@ -4,11 +4,9 @@
  */
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
-#include <string>
 
 #include "gtest/gtest.h"
 
@@ -142,49 +140,6 @@ TEST_F(BackendRegistryTest, PolymorphicBackendUsage) {
   backend->write(record);
   backend->flush();
   backend->close();
-}
-
-// Confirms a non-empty task_description ends up in the recorded .mcap file.
-TEST_F(BackendRegistryTest, TaskDescriptionWrittenToMetadata) {
-  auto cfg = trossen::configuration::GlobalConfig::instance()
-               .get_as<trossen::configuration::TrossenMCAPBackendConfig>(
-                 "trossen_mcap_backend");
-  ASSERT_NE(cfg, nullptr);
-
-  // Restores GlobalConfig on scope exit, so this test can't leak state into
-  // others even if an assertion below fails.
-  struct ConfigRestorer {
-    trossen::configuration::TrossenMCAPBackendConfig* cfg;
-    std::string root;
-    std::string dataset_id;
-    std::string task_description;
-    ~ConfigRestorer() {
-      cfg->root = root;
-      cfg->dataset_id = dataset_id;
-      cfg->task_description = task_description;
-    }
-  } restorer{cfg.get(), cfg->root, cfg->dataset_id, cfg->task_description};
-
-  cfg->root = std::filesystem::temp_directory_path().string();
-  cfg->dataset_id = "task_description_test";
-  cfg->task_description = "pick up the cube";
-
-  const auto episode_dir = std::filesystem::path(cfg->root) / cfg->dataset_id;
-  std::filesystem::remove_all(episode_dir);  // clear any file left by a previous run
-
-  auto backend = BackendRegistry::create("trossen_mcap");
-  ASSERT_NE(backend, nullptr);
-  EXPECT_TRUE(backend->open());
-  backend->close();
-
-  const auto mcap_path = episode_dir / "episode_000000.mcap";
-  ASSERT_TRUE(std::filesystem::exists(mcap_path));
-
-  std::ifstream mcap_file(mcap_path, std::ios::binary);
-  const std::string contents(
-    (std::istreambuf_iterator<char>(mcap_file)), std::istreambuf_iterator<char>());
-  EXPECT_NE(contents.find("task_description"), std::string::npos);
-  EXPECT_NE(contents.find("pick up the cube"), std::string::npos);
 }
 
 // Demo test showing typical usage pattern

--- a/tests/test_backend_registry.cpp
+++ b/tests/test_backend_registry.cpp
@@ -4,9 +4,11 @@
  */
 
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
+#include <string>
 
 #include "gtest/gtest.h"
 
@@ -142,33 +144,47 @@ TEST_F(BackendRegistryTest, PolymorphicBackendUsage) {
   backend->close();
 }
 
-// Test that a non-empty task_description flows into the backend config and
-// is written into the MCAP file's metadata record on open().
+// Confirms a non-empty task_description ends up in the recorded .mcap file.
 TEST_F(BackendRegistryTest, TaskDescriptionWrittenToMetadata) {
   auto cfg = trossen::configuration::GlobalConfig::instance()
                .get_as<trossen::configuration::TrossenMCAPBackendConfig>(
                  "trossen_mcap_backend");
   ASSERT_NE(cfg, nullptr);
 
-  // Isolate this test's output and restore shared GlobalConfig state after.
-  const std::string original_root = cfg->root;
-  const std::string original_dataset_id = cfg->dataset_id;
-  const std::string original_task_description = cfg->task_description;
+  // Restores GlobalConfig on scope exit, so this test can't leak state into
+  // others even if an assertion below fails.
+  struct ConfigRestorer {
+    trossen::configuration::TrossenMCAPBackendConfig* cfg;
+    std::string root;
+    std::string dataset_id;
+    std::string task_description;
+    ~ConfigRestorer() {
+      cfg->root = root;
+      cfg->dataset_id = dataset_id;
+      cfg->task_description = task_description;
+    }
+  } restorer{cfg.get(), cfg->root, cfg->dataset_id, cfg->task_description};
+
   cfg->root = std::filesystem::temp_directory_path().string();
   cfg->dataset_id = "task_description_test";
   cfg->task_description = "pick up the cube";
+
+  const auto episode_dir = std::filesystem::path(cfg->root) / cfg->dataset_id;
+  std::filesystem::remove_all(episode_dir);  // clear any file left by a previous run
 
   auto backend = BackendRegistry::create("trossen_mcap");
   ASSERT_NE(backend, nullptr);
   EXPECT_TRUE(backend->open());
   backend->close();
 
-  const auto mcap_path = std::filesystem::path(cfg->root) / cfg->dataset_id / "episode_000000.mcap";
-  EXPECT_TRUE(std::filesystem::exists(mcap_path));
+  const auto mcap_path = episode_dir / "episode_000000.mcap";
+  ASSERT_TRUE(std::filesystem::exists(mcap_path));
 
-  cfg->root = original_root;
-  cfg->dataset_id = original_dataset_id;
-  cfg->task_description = original_task_description;
+  std::ifstream mcap_file(mcap_path, std::ios::binary);
+  const std::string contents(
+    (std::istreambuf_iterator<char>(mcap_file)), std::istreambuf_iterator<char>());
+  EXPECT_NE(contents.find("task_description"), std::string::npos);
+  EXPECT_NE(contents.find("pick up the cube"), std::string::npos);
 }
 
 // Demo test showing typical usage pattern

--- a/tests/test_backend_registry.cpp
+++ b/tests/test_backend_registry.cpp
@@ -142,6 +142,35 @@ TEST_F(BackendRegistryTest, PolymorphicBackendUsage) {
   backend->close();
 }
 
+// Test that a non-empty task_description flows into the backend config and
+// is written into the MCAP file's metadata record on open().
+TEST_F(BackendRegistryTest, TaskDescriptionWrittenToMetadata) {
+  auto cfg = trossen::configuration::GlobalConfig::instance()
+               .get_as<trossen::configuration::TrossenMCAPBackendConfig>(
+                 "trossen_mcap_backend");
+  ASSERT_NE(cfg, nullptr);
+
+  // Isolate this test's output and restore shared GlobalConfig state after.
+  const std::string original_root = cfg->root;
+  const std::string original_dataset_id = cfg->dataset_id;
+  const std::string original_task_description = cfg->task_description;
+  cfg->root = std::filesystem::temp_directory_path().string();
+  cfg->dataset_id = "task_description_test";
+  cfg->task_description = "pick up the cube";
+
+  auto backend = BackendRegistry::create("trossen_mcap");
+  ASSERT_NE(backend, nullptr);
+  EXPECT_TRUE(backend->open());
+  backend->close();
+
+  const auto mcap_path = std::filesystem::path(cfg->root) / cfg->dataset_id / "episode_000000.mcap";
+  EXPECT_TRUE(std::filesystem::exists(mcap_path));
+
+  cfg->root = original_root;
+  cfg->dataset_id = original_dataset_id;
+  cfg->task_description = original_task_description;
+}
+
 // Demo test showing typical usage pattern
 TEST_F(BackendRegistryTest, TypicalUsageDemo) {
   // Simulate selecting backend type at runtime (e.g., from config file)

--- a/tests/test_trossen_mcap_backend.cpp
+++ b/tests/test_trossen_mcap_backend.cpp
@@ -1,0 +1,83 @@
+/**
+ * @file test_trossen_mcap_backend.cpp
+ * @brief Unit tests for TrossenMCAPBackend
+ */
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+#include "trossen_sdk/io/backend_registry.hpp"
+#include "trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp"
+
+using trossen::io::BackendRegistry;
+
+// Test fixture to load configuration before running tests
+class TrossenMCAPBackendTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    // Tests run from build/tests directory, so we need to go up two levels
+    const std::string config_path = "../../tests/test_config.json";
+
+    if (!std::filesystem::exists(config_path)) {
+      std::cerr << "Warning: " << config_path << " not found" << std::endl;
+      std::cerr << "Current directory: " << std::filesystem::current_path() << std::endl;
+      return;
+    }
+
+    try {
+      auto j = trossen::configuration::JsonLoader::load(config_path);
+      trossen::configuration::GlobalConfig::instance().load_from_json(j);
+    } catch (const std::exception& e) {
+      std::cerr << "Error loading config: " << e.what() << std::endl;
+    }
+  }
+};
+
+// Confirms a non-empty task_description ends up in the recorded .mcap file.
+TEST_F(TrossenMCAPBackendTest, TaskDescriptionWrittenToMetadata) {
+  auto cfg = trossen::configuration::GlobalConfig::instance()
+               .get_as<trossen::configuration::TrossenMCAPBackendConfig>(
+                 "trossen_mcap_backend");
+  ASSERT_NE(cfg, nullptr);
+
+  // Restores GlobalConfig on scope exit, so this test can't leak state into
+  // others even if an assertion below fails.
+  struct ConfigRestorer {
+    trossen::configuration::TrossenMCAPBackendConfig* cfg;
+    std::string root;
+    std::string dataset_id;
+    std::string task_description;
+    ~ConfigRestorer() {
+      cfg->root = root;
+      cfg->dataset_id = dataset_id;
+      cfg->task_description = task_description;
+    }
+  } restorer{cfg.get(), cfg->root, cfg->dataset_id, cfg->task_description};
+
+  cfg->root = std::filesystem::temp_directory_path().string();
+  cfg->dataset_id = "task_description_test";
+  cfg->task_description = "pick up the cube";
+
+  const auto episode_dir = std::filesystem::path(cfg->root) / cfg->dataset_id;
+  std::filesystem::remove_all(episode_dir);  // clear any file left by a previous run
+
+  auto backend = BackendRegistry::create("trossen_mcap");
+  ASSERT_NE(backend, nullptr);
+  EXPECT_TRUE(backend->open());
+  backend->close();
+
+  const auto mcap_path = episode_dir / "episode_000000.mcap";
+  ASSERT_TRUE(std::filesystem::exists(mcap_path));
+
+  std::ifstream mcap_file(mcap_path, std::ios::binary);
+  const std::string contents(
+    (std::istreambuf_iterator<char>(mcap_file)), std::istreambuf_iterator<char>());
+  EXPECT_NE(contents.find("task_description"), std::string::npos);
+  EXPECT_NE(contents.find("pick up the cube"), std::string::npos);
+}


### PR DESCRIPTION
## Summary

Adds test coverage and example usage for the `task_description` field.

## Changes

- Add `BackendRegistryTest.TaskDescriptionWrittenToMetadata`: opens a TrossenMCAP backend with `task_description` set and asserts the episode file is written.
- Add `"task_description": ""` to `examples/trossen_solo_ai/config.json` so the field is visible in the reference config.

## Test Plan

- [x] Builds cleanly (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`pre-commit run --all-files`)
- [ ] Tested on hardware

## Breaking Changes

None.

## Related Issues

N/A — part of the task_description feature stack.