### PR TITLE
Name TrossenMCAP episodes with a UUIDv7

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A C++ SDK for recording robot demonstrations with Trossen AI Kit arms, Stereolab
 - Record synchronized episodes from arms, cameras, and a mobile base to a single `.mcap` file per episode
 - Config-driven setup: one JSON file describes all hardware, producers, and session parameters
 - CLI overrides via `--set key=value` dot-notation for quick iteration without editing JSON
-- Automatic episode numbering with resumption from existing episodes in the output directory
+- Unique, time-ordered episode filenames (UUIDv7) with resumption from existing episodes in the output directory
 - Joint states recordable up to 200 Hz; cameras at configurable frame rates
 - Converts recorded TrossenMCAP files to LeRobot V2 format (Parquet + MP4 video) with per-episode statistics computed during conversion
 - Interactive episode controls: re-record, skip, and discard episodes with keyboard shortcuts during recording
@@ -54,8 +54,8 @@ The diagram below shows how sensor data flows through the SDK — from hardware 
 Record demonstrations           Convert to training format
 ─────────────────────────       ─────────────────────────────────────────────
 Run example script          →   trossen_mcap_to_lerobot_v2 <input> <output>
-  ↓ episode_000000.mcap              ↓ Parquet + MP4 per episode
-  ↓ episode_000001.mcap              ↓ info.json with per-episode statistics
+  ↓ 0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap   ↓ Parquet + MP4 per episode
+  ↓ 0190b3c2-2f5a-7e91-b0c4-7d8e9f0a1b2c.mcap   ↓ info.json with per-episode statistics
   ↓ ...
 ```
 
@@ -373,7 +373,7 @@ After recording, convert your `.mcap` episodes to LeRobot V2 format:
 
 ```bash
 # Convert a single episode
-./build/scripts/trossen_mcap_to_lerobot_v2 ~/.trossen_sdk/my_dataset/episode_000000.mcap ~/lerobot_datasets
+./build/scripts/trossen_mcap_to_lerobot_v2 ~/.trossen_sdk/my_dataset/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap ~/lerobot_datasets
 
 # Convert all episodes in a folder (batch mode)
 ./build/scripts/trossen_mcap_to_lerobot_v2 ~/.trossen_sdk/my_dataset/ ~/lerobot_datasets

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -198,8 +198,8 @@ Backend
       "chunk_size_bytes": 4194304             // MCAP chunk size (4 MB default)
     }
 
-Episodes land at ``<root>/<dataset_id>/episode_NNNNNN.mcap``.
-Episode numbers are assigned automatically and resume from the highest existing index in the directory.
+Episodes land at ``<root>/<dataset_id>/<id>.mcap``, where ``<id>`` is a UUIDv7 (e.g. ``0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap``).
+Because UUIDv7 leads with a timestamp, filenames are globally unique and sort chronologically.
 
 Observers
 ---------

--- a/docs/convert.rst
+++ b/docs/convert.rst
@@ -39,7 +39,7 @@ The tool operates in two modes, distinguished by the first argument:
 .. code-block:: bash
 
     # Single-episode mode (first argument is an .mcap file)
-    ./build/scripts/trossen_mcap_to_lerobot_v2 <path/to/episode_000000.mcap>
+    ./build/scripts/trossen_mcap_to_lerobot_v2 <path/to/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap>
 
     # Batch mode (first argument is a directory containing .mcap files)
     ./build/scripts/trossen_mcap_to_lerobot_v2 <path/to/dataset_folder/>
@@ -71,8 +71,7 @@ Examples per robot:
 
 .. note::
 
-    Episode numbers are extracted from the filename (``episode_NNNNNN.mcap``, six-digit zero-padded).
-    Batch mode processes all matching files in episode-index order.
+    Batch mode processes the ``.mcap`` files in the order they were recorded (by the ``recording_start_time`` stored in each file) and assigns LeRobot episode indices from that order, so episode 0 is the earliest recording.
 
 Configuring the Conversion
 ==========================
@@ -97,7 +96,6 @@ Point it at a different config with ``--config <path>``.
         "max_image_queue":       10,                               // Back-pressure bound
         "png_compression_level": 5,                                // Intermediate PNG quality
         "chunk_size":            2,                                // Episodes per chunk-NNN folder
-        "episode_index":         0,                                // Starting episode index
         "overwrite_existing":    false                             // Refuse to clobber existing files
       }
     }
@@ -282,13 +280,15 @@ FFmpeg not found or codec error
 Install FFmpeg with ``sudo apt-get install ffmpeg``.
 The tool shells out to FFmpeg for AV1 encoding of the image streams.
 
-Episode numbering mismatch
---------------------------
+Episode ordering
+----------------
 
-The tool extracts episode indices from the MCAP filename.
-Filenames must follow ``episode_NNNNNN.mcap`` (six-digit zero-padded).
-This is the format the SDK writes natively.
-Do not rename the files.
+The tool assigns LeRobot episode indices from the order the episodes were recorded (the ``recording_start_time`` in each file's metadata), not from their (random) filenames.
+A newly recorded episode has a later timestamp, so it sorts to the end and receives the next index; existing episodes keep their indices, and the idempotent skip lets you re-run after recording more without re-converting what is already done.
+
+This assumes the recording clocks are consistent.
+When merging ``.mcap`` files from multiple machines whose clocks are not synchronized, the cross-machine ordering is only as reliable as those clocks, and inserting a file with an earlier timestamp can shift later indices.
+Files missing ``recording_start_time`` sort last, ordered by filename.
 
 What's Next
 ===========

--- a/docs/diagrams/trossen-mcap-dataflow.svg
+++ b/docs/diagrams/trossen-mcap-dataflow.svg
@@ -127,7 +127,7 @@
 
   <!-- ==================== ROW 6: MCAP Episode File (green) ==================== -->
   <rect x="100" y="574" width="760" height="120" rx="8" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
-  <text x="480" y="598" text-anchor="middle" font-size="14" font-weight="700" fill="#065f46">episode_NNNNNN.mcap</text>
+  <text x="480" y="598" text-anchor="middle" font-size="14" font-weight="700" fill="#065f46">&lt;uuid&gt;.mcap</text>
 
   <!-- Metadata block -->
   <rect x="120" y="611" width="340" height="70" rx="5" fill="#fff" stroke="#34d399" stroke-width="1.2"/>

--- a/docs/record.rst
+++ b/docs/record.rst
@@ -81,8 +81,9 @@ A recording session proceeds through the following phases:
 #.  **Shutdown.**
     After ``session.max_episodes`` episodes the teleop thread stops and the process exits cleanly.
 
-Episodes are written to ``<backend.root>/<backend.dataset_id>/episode_NNNNNN.mcap``.
-Episode numbers are assigned automatically and resume from the highest existing index in the directory.
+Episodes are written to ``<backend.root>/<backend.dataset_id>/<id>.mcap``, where ``<id>`` is a UUIDv7 (e.g. ``0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap``).
+Because UUIDv7 leads with a timestamp, filenames are globally unique and sort chronologically.
+
 Re-running the demo against the same ``dataset_id`` appends rather than overwriting.
 
 What Gets Recorded

--- a/docs/replay.rst
+++ b/docs/replay.rst
@@ -50,7 +50,7 @@ Example:
         .. code-block:: bash
 
             ./build/scripts/replay_trossen_mcap_jointstate \
-                ~/.trossen_sdk/solo_dataset/episode_000000.mcap \
+                ~/.trossen_sdk/solo_dataset/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap \
                 scripts/replay_trossen_mcap_jointstate/config.json
 
     .. group-tab:: Stationary
@@ -58,7 +58,7 @@ Example:
         .. code-block:: bash
 
             ./build/scripts/replay_trossen_mcap_jointstate \
-                ~/.trossen_sdk/stationary_dataset/episode_000000.mcap \
+                ~/.trossen_sdk/stationary_dataset/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap \
                 scripts/replay_trossen_mcap_jointstate/config.json
 
     .. group-tab:: Mobile
@@ -66,7 +66,7 @@ Example:
         .. code-block:: bash
 
             ./build/scripts/replay_trossen_mcap_jointstate \
-                ~/.trossen_sdk/mobile_dataset/episode_000000.mcap \
+                ~/.trossen_sdk/mobile_dataset/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap \
                 scripts/replay_trossen_mcap_jointstate/config.json
 
 Configuring the Replay

--- a/docs/visualize.rst
+++ b/docs/visualize.rst
@@ -61,7 +61,7 @@ Opening an Episode
 
         .. code-block:: text
 
-            ~/.trossen_sdk/solo_dataset/episode_000000.mcap
+            ~/.trossen_sdk/solo_dataset/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap
 
     .. group-tab:: Stationary
 
@@ -69,7 +69,7 @@ Opening an Episode
 
         .. code-block:: text
 
-            ~/.trossen_sdk/stationary_dataset/episode_000000.mcap
+            ~/.trossen_sdk/stationary_dataset/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap
 
     .. group-tab:: Mobile
 
@@ -77,7 +77,7 @@ Opening an Episode
 
         .. code-block:: text
 
-            ~/.trossen_sdk/mobile_dataset/episode_000000.mcap
+            ~/.trossen_sdk/mobile_dataset/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap
 
 Foxglove parses the MCAP index and exposes every channel in the left-hand data source panel.
 

--- a/examples/trossen_mobile_ai/README.md
+++ b/examples/trossen_mobile_ai/README.md
@@ -98,7 +98,7 @@ The script will:
 5. Repeat until `max_episodes` is reached or Ctrl+C is pressed
 6. Return arms to the sleep position
 
-Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
+Episodes are saved to `~/.trossen_sdk/<dataset_id>/<id>.mcap` (`<id>` is a UUIDv7).
 
 ### Optional: home staging
 

--- a/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
+++ b/examples/trossen_mobile_ai/trossen_mobile_ai.cpp
@@ -342,9 +342,7 @@ int main(int argc, char** argv) {
   // After each episode: print a summary and run sanity checks. (Teleop reset and
   // arm re-homing are owned by the SessionManager.)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
-    const std::string file_path =
-      trossen::utils::generate_episode_path(root, stats.current_episode_index);
-    trossen::utils::print_episode_summary(file_path, stats);
+    trossen::utils::print_episode_summary(stats.current_episode_path, stats);
 
     trossen::utils::SanityCheckConfig sanity_cfg{
       stats.elapsed.count(),

--- a/examples/trossen_solo_ai/README.md
+++ b/examples/trossen_solo_ai/README.md
@@ -73,7 +73,7 @@ The script will:
 5. Repeat until `max_episodes` is reached or Ctrl+C is pressed
 6. Return arms to the sleep position
 
-Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
+Episodes are saved to `~/.trossen_sdk/<dataset_id>/<id>.mcap` (`<id>` is a UUIDv7).
 
 ### Optional: home staging
 

--- a/examples/trossen_solo_ai/trossen_solo_ai.cpp
+++ b/examples/trossen_solo_ai/trossen_solo_ai.cpp
@@ -308,9 +308,7 @@ int main(int argc, char** argv) {
   // After each episode: print a summary and run sanity checks. (Teleop reset and
   // arm re-homing are owned by the SessionManager.)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
-    const std::string file_path =
-      trossen::utils::generate_episode_path(root, stats.current_episode_index);
-    trossen::utils::print_episode_summary(file_path, stats);
+    trossen::utils::print_episode_summary(stats.current_episode_path, stats);
 
     trossen::utils::SanityCheckConfig sanity_cfg{
       stats.elapsed.count(),

--- a/examples/trossen_stationary_ai/README.md
+++ b/examples/trossen_stationary_ai/README.md
@@ -79,7 +79,7 @@ The script will:
 5. Repeat until `max_episodes` is reached or Ctrl+C is pressed
 6. Return arms to the sleep position
 
-Episodes are saved to `~/.trossen_sdk/<dataset_id>/episode_NNNNNN.mcap`.
+Episodes are saved to `~/.trossen_sdk/<dataset_id>/<id>.mcap` (`<id>` is a UUIDv7).
 
 ### Optional: home staging
 

--- a/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
+++ b/examples/trossen_stationary_ai/trossen_stationary_ai.cpp
@@ -309,9 +309,7 @@ int main(int argc, char** argv) {
   // After each episode: print a summary and run sanity checks. (Teleop reset and
   // arm re-homing are owned by the SessionManager.)
   mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
-    const std::string file_path =
-      trossen::utils::generate_episode_path(root, stats.current_episode_index);
-    trossen::utils::print_episode_summary(file_path, stats);
+    trossen::utils::print_episode_summary(stats.current_episode_path, stats);
 
     trossen::utils::SanityCheckConfig sanity_cfg{
       stats.elapsed.count(),

--- a/include/trossen_sdk/configuration/types/backends/trossen_mcap_backend_config.hpp
+++ b/include/trossen_sdk/configuration/types/backends/trossen_mcap_backend_config.hpp
@@ -23,8 +23,6 @@ struct TrossenMCAPBackendConfig : public BaseConfig {
   int chunk_size_bytes{TROSSEN_MCAP_DEFAULT_CHUNK_SIZE_BYTES};
   std::string compression{TROSSEN_MCAP_DEFAULT_COMPRESSION};
   std::string dataset_id{trossen::io::backends::auto_generate_dataset_id()};
-  // TODO(shantanuparab-tr): Remove episode index if not being used
-  int episode_index{0};
 
   /// Text description of the task being demonstrated (e.g. "pick up the cube").
   /// Written to the MCAP file-level metadata if non-empty.
@@ -45,7 +43,6 @@ struct TrossenMCAPBackendConfig : public BaseConfig {
     if (j.contains("chunk_size_bytes")) j.at("chunk_size_bytes").get_to(c.chunk_size_bytes);
     if (j.contains("compression")) j.at("compression").get_to(c.compression);
     if (j.contains("dataset_id")) j.at("dataset_id").get_to(c.dataset_id);
-    if (j.contains("episode_index")) j.at("episode_index").get_to(c.episode_index);
     if (j.contains("task_description")) j.at("task_description").get_to(c.task_description);
 
     return c;

--- a/include/trossen_sdk/io/backend.hpp
+++ b/include/trossen_sdk/io/backend.hpp
@@ -107,15 +107,16 @@ public:
   /**
    * @brief Discard all data for the current episode
    *
-   * Closes the backend without finalizing, then deletes all files/directories
-   * associated with the current episode_index_. Used for re-recording.
-   * Safe to call even if the backend was already closed (e.g., by Sink::stop()).
+   * Closes the backend without finalizing, then deletes the output file(s) the backend
+   * wrote for the current episode. Used for re-recording. How the backend identifies those
+   * files is implementation-defined. Safe to call even if the backend was already closed
+   * (e.g., by Sink::stop()).
    */
   virtual void discard_episode() = 0;
 
   /**
-   * @brief Scan directory for existing episode files and return next index
-   * @return Next episode index to use
+   * @brief Count existing episodes in the output directory
+   * @return Number of existing episodes, which the caller uses as the next episode index
    */
   virtual uint32_t scan_existing_episodes() = 0;
 
@@ -128,6 +129,18 @@ public:
   virtual void set_episode_index(uint32_t episode_index) {
     episode_index_ = episode_index;
   }
+
+  /**
+   * @brief Path of the output file/artifact for the current episode
+   *
+   * Returns the concrete path the backend writes this episode to (e.g. the .mcap
+   * file or the LeRobot .parquet file), valid after open() and until the backend is
+   * closed/destroyed. Used for user-facing reporting. Defaults to empty for backends
+   * that produce no file (e.g. the null backend).
+   *
+   * @return Output path as a string, or an empty string if not applicable
+   */
+  virtual std::string current_output_path() const { return ""; }
 
 protected:
   /// @brief Whether the backend is opened

--- a/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
+++ b/include/trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp
@@ -855,6 +855,15 @@ public:
    uint32_t scan_existing_episodes() override;
 
   /**
+   * @brief Path of the .parquet file for the current episode
+   * @return The output parquet path as a string (empty until open() has run)
+   */
+  std::string current_output_path() const override {
+    if (data_root_.empty()) return "";
+    return (data_root_ / format_episode_parquet(episode_index_)).string();
+  }
+
+  /**
    * @brief Image encoding statistics
    */
   struct ImageEncodeStats {

--- a/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp
+++ b/include/trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp
@@ -6,12 +6,17 @@
 #ifndef TROSSEN_SDK__IO__BACKENDS__TROSSEN_MCAP_BACKEND_HPP
 #define TROSSEN_SDK__IO__BACKENDS__TROSSEN_MCAP_BACKEND_HPP
 
+#include <chrono>
+#include <cstdint>
 #include <filesystem>
+#include <iomanip>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <random>
 #include <regex>
 #include <span>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -30,6 +35,46 @@ namespace trossen::io::backends {
 
 /// @brief Initial buffer size for encoded messages
 const size_t TROSSEN_MCAP_INITIAL_ENCODED_BUFFER_SIZE = 1024 * 1024;  // 1 MB
+
+/**
+ * @brief Generate a UUIDv7 episode id (RFC 9562) in canonical form
+ * @return A lowercase canonical UUID string, e.g. "0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f"
+ *
+ * UUIDv7 leads with a 48-bit Unix millisecond timestamp, so the canonical string is
+ * lexicographically time-ordered: sorting filenames by name matches recording order.
+ * That keeps ordering stable across distributed machines merged into one dataset (the id
+ * is globally unique without coordination) and lets consumers that sort by filename (e.g.
+ * the cloud episode listing) present episodes chronologically. The remaining 74 bits come
+ * from std::random_device, so the id is also a unique identifier for the episode.
+ */
+inline std::string generate_episode_id() {
+  const auto now = std::chrono::system_clock::now();
+  const std::uint64_t unix_ts_ms = static_cast<std::uint64_t>(
+    std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
+
+  std::random_device rd;
+  std::uniform_int_distribution<std::uint64_t> dist;
+  const std::uint64_t rand_a = dist(rd);  // 12 bits used
+  const std::uint64_t rand_b = dist(rd);  // 62 bits used
+
+  // Assemble the 128 bits into two 64-bit halves per RFC 9562.
+  const std::uint64_t high =
+    (unix_ts_ms << 16)              // 48-bit ms timestamp in bits 63..16
+    | (std::uint64_t{0x7} << 12)    // version 7 in bits 15..12
+    | (rand_a & 0x0FFFULL);         // 12 random bits in bits 11..0
+  const std::uint64_t low =
+    (std::uint64_t{0x2} << 62)      // variant 0b10 in the top 2 bits
+    | (rand_b & 0x3FFFFFFFFFFFFFFFULL);  // 62 random bits
+
+  std::ostringstream oss;
+  oss << std::hex << std::setfill('0')
+      << std::setw(8) << (high >> 32) << '-'
+      << std::setw(4) << ((high >> 16) & 0xFFFFULL) << '-'
+      << std::setw(4) << (high & 0xFFFFULL) << '-'
+      << std::setw(4) << (low >> 48) << '-'
+      << std::setw(12) << (low & 0xFFFFFFFFFFFFULL);
+  return oss.str();
+}
 
 /**
  * @brief TrossenMCAPBackend writes records into a TrossenMCAP file.
@@ -68,11 +113,6 @@ public:
 
   /**
    * @brief Prepare backend for a new episode
-   *
-   * @param output_path Output file path for this episode
-   * @param episode_index Zero-based episode index (unused)
-   * @param dataset_id Dataset identifier (unused)
-   * @param repository_id Repository identifier (unused)
    */
   void preprocess_episode() override;
 
@@ -120,11 +160,18 @@ public:
   Stats stats() const { return stats_; }
 
   /**
-   * @brief Scan directory for existing episode files and return next index
+   * @brief Count existing episode files in the dataset directory
    *
-   * @return Next episode index (max_found + 1, or 0 if none found)
+   * @return Number of existing episode files (0 if none)
    */
   uint32_t scan_existing_episodes() override;
+
+  /**
+   * @brief Path of the .mcap file for the current episode
+   *
+   * @return The output path as a string (empty if open() has not run)
+   */
+  std::string current_output_path() const override { return path_.string(); }
 
 private:
   /**
@@ -134,6 +181,16 @@ private:
    * Caller must hold writer_mutex_.
    */
   void close_resources();
+
+  /**
+   * @brief Find the most-recently-written <uuid>.mcap episode file in the dataset dir
+   *
+   * Used by discard_episode() when this backend never opened a file (the re-record
+   * path creates a fresh backend), so there is no stored path_ to delete.
+   *
+   * @return Path to the newest matching episode file, or an empty path if none found
+   */
+  std::filesystem::path find_latest_episode_file() const;
 
   /**
    * @brief Ensure an image channel exists for the given camera name

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -3,8 +3,8 @@
  * @brief Session Manager orchestrates discrete recording sessions (episodes).
  *
  * The Session Manager controls the lifecycle of individual episode recordings, each producing a
- * separate output file (e.g., episode_000000.mcap). It manages Scheduler, Sink, and Backend
- * instances per episode, ensuring clean separation between recording sessions.
+ * separate output file (e.g., a UUIDv7 <id>.mcap). It manages Scheduler, Sink, and
+ * Backend instances per episode, ensuring clean separation between recording sessions.
  */
 
 #ifndef TROSSEN_SDK__RUNTIME__SESSION_MANAGER_HPP
@@ -141,7 +141,7 @@ public:
    *
    * @return true on success, false if max_episodes reached or setup fails
    *
-   * - Creates episode_NNNNNN.mcap file (6-digit zero-padded index)
+   * - Creates the episode's backend output file (e.g. a UUIDv7 <id>.mcap file)
    * - Instantiates Backend + Sink
    * - Starts push producers
    * - Fires pre-episode callbacks (can abort episode)
@@ -244,6 +244,11 @@ public:
   struct Stats {
     /// @brief Current or next episode number
     uint32_t current_episode_index;
+
+    /// @brief Output file path of the active episode, or of the most recently finished
+    /// one between episodes (for post-episode reporting). Empty before the first episode
+    /// and after a discard (the discarded file is deleted, so no path is reported).
+    std::string current_episode_path;
 
     /// @brief Is an episode currently recording?
     bool episode_active;
@@ -459,6 +464,10 @@ private:
 
   /// @brief Next episode index to use
   uint32_t next_episode_index_{0};
+
+  /// @brief Output path of the current/last episode, captured from the backend after
+  /// open() so it survives the backend being reset during teardown (for reporting).
+  std::string current_episode_path_;
 
   /// @brief Episode start time (for duration tracking)
   std::chrono::steady_clock::time_point episode_start_time_;

--- a/include/trossen_sdk/utils/app_utils.hpp
+++ b/include/trossen_sdk/utils/app_utils.hpp
@@ -104,19 +104,6 @@ bool perform_sanity_check(
 bool interruptible_sleep(std::chrono::duration<double> duration);
 
 /**
- * @brief Generate episode file path
- *
- * @param output_dir Base output directory
- * @param episode_index Episode index
- * @param extension File extension (default: "trossen_mcap")
- * @return Full path to episode file
- */
-std::string generate_episode_path(
-  const std::string& output_dir,
-  uint32_t episode_index,
-  const std::string& extension = "trossen_mcap");
-
-/**
  * @brief Announce a message via text-to-speech (spd-say)
  *
  * Safe to call even if spd-say is not installed -- fails silently.

--- a/python/trossen_sdk.cpp
+++ b/python/trossen_sdk.cpp
@@ -160,6 +160,9 @@ public:
   void set_episode_index(uint32_t episode_index) override {
     PYBIND11_OVERRIDE(void, Backend, set_episode_index, episode_index);
   }
+  std::string current_output_path() const override {
+    PYBIND11_OVERRIDE(std::string, Backend, current_output_path);
+  }
 };
 
 /// Trampoline for TeleopTypeIO (virtual leaders in Python).
@@ -413,7 +416,8 @@ PYBIND11_MODULE(trossen_sdk, m) {
     .def("close", &Backend::close)
     .def("discard_episode", &Backend::discard_episode)
     .def("scan_existing_episodes", &Backend::scan_existing_episodes)
-    .def("set_episode_index", &Backend::set_episode_index, py::arg("episode_index"));
+    .def("set_episode_index", &Backend::set_episode_index, py::arg("episode_index"))
+    .def("current_output_path", &Backend::current_output_path);
 
   py::class_<Backend::Config>(m, "BackendConfig")
     .def(py::init<>())
@@ -592,7 +596,6 @@ PYBIND11_MODULE(trossen_sdk, m) {
     .def_readwrite("chunk_size_bytes", &TrossenMCAPBackendConfig::chunk_size_bytes)
     .def_readwrite("compression", &TrossenMCAPBackendConfig::compression)
     .def_readwrite("dataset_id", &TrossenMCAPBackendConfig::dataset_id)
-    .def_readwrite("episode_index", &TrossenMCAPBackendConfig::episode_index)
     .def_readwrite("task_description", &TrossenMCAPBackendConfig::task_description)
     .def_static("from_json", &TrossenMCAPBackendConfig::from_json, py::arg("json"));
 
@@ -758,6 +761,8 @@ PYBIND11_MODULE(trossen_sdk, m) {
     py::class_<SessionManager::Stats>(m, "SessionManagerStats")
       .def_readwrite("current_episode_index",
                      &SessionManager::Stats::current_episode_index)
+      .def_readwrite("current_episode_path",
+                     &SessionManager::Stats::current_episode_path)
       .def_readwrite("episode_active", &SessionManager::Stats::episode_active)
       .def_property("elapsed",
         [](const SessionManager::Stats& s) { return s.elapsed.count(); },
@@ -883,10 +888,6 @@ PYBIND11_MODULE(trossen_sdk, m) {
     m.def("interruptible_sleep", &interruptible_sleep, py::arg("duration"),
           py::call_guard<py::gil_scoped_release>(),
           "Sleep that returns early if Ctrl+C pressed");
-
-    m.def("generate_episode_path", &generate_episode_path,
-          py::arg("output_dir"), py::arg("episode_index"),
-          py::arg("extension") = "trossen_mcap");
 
     m.def("announce", &announce, py::arg("message"), py::arg("block") = true,
           "Announce a message via text-to-speech");

--- a/python/trossen_sdk/demo/trossen_mobile_ai.py
+++ b/python/trossen_sdk/demo/trossen_mobile_ai.py
@@ -139,8 +139,7 @@ def main():
         lambda: print("Episode started - recording active."))
     mgr.on_episode_ended(lambda stats: (
         _stop_controllers(controllers),
-        ts.print_episode_summary(
-            ts.generate_episode_path(root, stats.current_episode_index), stats),
+        ts.print_episode_summary(stats.current_episode_path, stats),
     ))
     mgr.on_pre_shutdown(lambda: _stop_controllers(controllers))
 

--- a/python/trossen_sdk/demo/trossen_solo_ai.py
+++ b/python/trossen_sdk/demo/trossen_solo_ai.py
@@ -120,8 +120,7 @@ def main():
         lambda: print("Episode started - recording active."))
     mgr.on_episode_ended(lambda stats: (
         _stop_controllers(controllers),
-        ts.print_episode_summary(
-            ts.generate_episode_path(root, stats.current_episode_index), stats),
+        ts.print_episode_summary(stats.current_episode_path, stats),
     ))
     mgr.on_pre_shutdown(lambda: _stop_controllers(controllers))
 

--- a/python/trossen_sdk/demo/trossen_stationary_ai.py
+++ b/python/trossen_sdk/demo/trossen_stationary_ai.py
@@ -121,8 +121,7 @@ def main():
         lambda: print("Episode started - recording active."))
     mgr.on_episode_ended(lambda stats: (
         _stop_controllers(controllers),
-        ts.print_episode_summary(
-            ts.generate_episode_path(root, stats.current_episode_index), stats),
+        ts.print_episode_summary(stats.current_episode_path, stats),
     ))
     mgr.on_pre_shutdown(lambda: _stop_controllers(controllers))
 

--- a/scripts/replay_trossen_mcap_jointstate/README.md
+++ b/scripts/replay_trossen_mcap_jointstate/README.md
@@ -28,7 +28,7 @@ Example:
 
 ```bash
 ./build/scripts/replay_trossen_mcap_jointstate \
-    ~/.trossen_sdk/my_dataset/episode_000000.mcap \
+    ~/.trossen_sdk/my_dataset/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap \
     scripts/replay_trossen_mcap_jointstate/config.json
 ```
 

--- a/scripts/replay_trossen_mcap_jointstate/replay_trossen_mcap_jointstate.cpp
+++ b/scripts/replay_trossen_mcap_jointstate/replay_trossen_mcap_jointstate.cpp
@@ -15,7 +15,7 @@
  *   --help            Show this help message
  *
  * Examples:
- *   ./replay_trossen_mcap_jointstate ~/datasets/episode_000000.mcap
+ *   ./replay_trossen_mcap_jointstate ~/datasets/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap
  *   ./replay_trossen_mcap_jointstate ~/datasets/episode.mcap --speed 0.5
  *   ./replay_trossen_mcap_jointstate ~/datasets/episode.mcap --config my_config.json
  */
@@ -121,7 +121,7 @@ int main(int argc, char** argv) {
     std::cerr << "  --speed <float>   Playback speed multiplier\n";
     std::cerr << "  --help            Show this help\n";
     std::cerr << "\nExamples:\n";
-    std::cerr << "  " << argv[0] << " ~/datasets/episode_000000.mcap\n";
+    std::cerr << "  " << argv[0] << " ~/datasets/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap\n";
     std::cerr << "  " << argv[0] << " ~/datasets/episode.mcap --speed 0.5\n";
     std::cerr << "  " << argv[0] << " ~/datasets/episode.mcap --config my_config.json\n";
     return 0;

--- a/scripts/trossen_mcap_to_lerobot_v2/README.md
+++ b/scripts/trossen_mcap_to_lerobot_v2/README.md
@@ -19,7 +19,7 @@ The tool is always built as part of the standard SDK build.
 
 ```bash
 # Convert a single episode
-./build/scripts/trossen_mcap_to_lerobot_v2 <path/to/episode_000000.mcap> [output_dir]
+./build/scripts/trossen_mcap_to_lerobot_v2 <path/to/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap> [output_dir]
 
 # Convert all episodes in a folder (batch mode)
 ./build/scripts/trossen_mcap_to_lerobot_v2 <path/to/dataset_folder/> [output_dir]
@@ -31,7 +31,7 @@ Examples:
 
 ```bash
 ./build/scripts/trossen_mcap_to_lerobot_v2 \
-    ~/.trossen_sdk/my_dataset/episode_000000.mcap \
+    ~/.trossen_sdk/my_dataset/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap \
     ~/lerobot_datasets
 
 ./build/scripts/trossen_mcap_to_lerobot_v2 \
@@ -39,8 +39,7 @@ Examples:
     ~/lerobot_datasets
 ```
 
-Episode numbers are extracted automatically from filenames (`episode_NNNNNN.mcap`).
-Batch mode processes all `.mcap` files in the folder in episode-index order.
+Batch mode processes all `.mcap` files in the order they were recorded (by the `recording_start_time` in each file's metadata) and assigns LeRobot episode indices from that order, so episode 0 is the earliest recording.
 
 ---
 
@@ -177,4 +176,6 @@ sudo apt-get install libarrow-dev libparquet-dev
 sudo apt-get install ffmpeg
 ```
 
-**Episode numbering mismatch:** filenames must follow `episode_NNNNNN.mcap` (6-digit zero-padded).
+**Episode ordering:** LeRobot indices follow the order episodes were recorded (`recording_start_time`), not their filenames.
+Newly recorded episodes have later timestamps and append at the end, so you can re-run after recording more without re-converting existing episodes.
+Merging files from machines with unsynchronized clocks is only as reliable as those clocks; files missing `recording_start_time` sort last, by filename.

--- a/scripts/trossen_mcap_to_lerobot_v2/trossen_mcap_to_lerobot_v2.cpp
+++ b/scripts/trossen_mcap_to_lerobot_v2/trossen_mcap_to_lerobot_v2.cpp
@@ -12,7 +12,7 @@
  *   ./trossen_mcap_to_lerobot_v2 <path_to_mcap_file_or_folder> [dataset_root_dir]
  *
  * Example:
- *   ./trossen_mcap_to_lerobot_v2 ~/datasets/episode_000000.mcap ~/lerobot_v2_datasets
+ *   ./trossen_mcap_to_lerobot_v2 ~/datasets/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap ~/lerobot_v2_datasets
  *   ./trossen_mcap_to_lerobot_v2 ~/datasets/ ~/lerobot_v2_datasets
  */
 
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -32,6 +33,7 @@
 #include <map>
 #include <memory>
 #include <opencv2/opencv.hpp>
+#include <optional>
 #include <regex>
 #include <string>
 #include <vector>
@@ -88,6 +90,41 @@ struct ParquetConfig {
   bool extract_images = true;
   bool create_videos = true;
 };
+
+/**
+ * @brief Read the "recording_start_time" (ns since epoch) from an MCAP file's
+ *        "trossen_sdk_recording" file-level metadata.
+ *
+ * Used to order episodes chronologically. Returns std::nullopt if the file cannot be read
+ * or the field is absent (e.g. older recordings), so callers can fall back to filename order.
+ */
+static std::optional<uint64_t> read_recording_start_time(const std::filesystem::path& path) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open()) return std::nullopt;
+
+  mcap::McapReader reader;
+  if (!reader.open(input).ok()) return std::nullopt;
+  if (!reader.readSummary(mcap::ReadSummaryMethod::AllowFallbackScan).ok()) return std::nullopt;
+
+  auto* data_source = reader.dataSource();
+  const auto& meta_indexes = reader.metadataIndexes();
+  auto range = meta_indexes.equal_range("trossen_sdk_recording");
+  for (auto it = range.first; it != range.second; ++it) {
+    mcap::Record raw_record;
+    if (!mcap::McapReader::ReadRecord(*data_source, it->second.offset, &raw_record).ok()) continue;
+    mcap::Metadata meta_record;
+    if (!mcap::McapReader::ParseMetadata(raw_record, &meta_record).ok()) continue;
+    auto ts_it = meta_record.metadata.find("recording_start_time");
+    if (ts_it != meta_record.metadata.end()) {
+      try {
+        return static_cast<uint64_t>(std::stoull(ts_it->second));
+      } catch (const std::exception&) {
+        return std::nullopt;
+      }
+    }
+  }
+  return std::nullopt;
+}
 
 // ──────────────────────────────────────────────────────────
 // Statistics computation functions
@@ -257,7 +294,7 @@ static void print_usage(const char* program) {
   std::cerr << "  --dump-config                Print resolved config and exit\n";
   std::cerr << "  --help                       Show this help message\n";
   std::cerr << "\nExamples:\n";
-  std::cerr << "  " << program << " ~/datasets/episode_000000.mcap\n";
+  std::cerr << "  " << program << " ~/datasets/0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap\n";
   std::cerr << "  " << program << " ~/datasets/\n";
   std::cerr << "  " << program << " --config my_config.json ~/datasets/\n";
   std::cerr << "  " << program << " ~/datasets/"
@@ -351,7 +388,31 @@ int main(int argc, char** argv) {
       }
     }
 
-    std::sort(mcap_files.begin(), mcap_files.end());
+    // Order episodes by their recorded start time so LeRobot episode indices reflect
+    // collection order and stay stable when new episodes are added and the converter is
+    // re-run: newer recordings have later timestamps and append at the end rather than
+    // shifting existing indices. This uses the recording_start_time metadata (nanosecond
+    // precision, and present on legacy files too) rather than relying on filename order.
+    // Read each file's timestamp once; files missing it (e.g. older recordings) sort last,
+    // with the filename as a deterministic tiebreak throughout.
+    struct KeyedEpisode {
+      uint64_t start_time_ns;
+      std::string filename;
+      fs::path path;
+    };
+    std::vector<KeyedEpisode> keyed;
+    keyed.reserve(mcap_files.size());
+    for (const auto& p : mcap_files) {
+      keyed.push_back({
+        read_recording_start_time(p).value_or(std::numeric_limits<uint64_t>::max()),
+        p.filename().string(), p});
+    }
+    std::sort(keyed.begin(), keyed.end(), [](const KeyedEpisode& a, const KeyedEpisode& b) {
+      if (a.start_time_ns != b.start_time_ns) return a.start_time_ns < b.start_time_ns;
+      return a.filename < b.filename;
+    });
+    mcap_files.clear();
+    for (const auto& k : keyed) mcap_files.push_back(k.path);
 
     if (mcap_files.empty()) {
       std::cerr << "Error: No MCAP files found in directory: " << input_path.string() << "\n";
@@ -378,14 +439,10 @@ int main(int argc, char** argv) {
   for (size_t i = 0; i < mcap_files.size(); ++i) {
     const auto& mcap_path = mcap_files[i];
 
-    std::string filename = mcap_path.stem().string();
-    std::regex episode_pattern(R"(episode_(\d{6}))");
-    std::smatch match;
-    int episode_index = i;
-
-    if (std::regex_search(filename, match, episode_pattern)) {
-      episode_index = std::stoi(match[1].str());
-    }
+    // MCAP filenames are UUIDs, so the episode index is no longer encoded in the
+    // name. Assign LeRobot episode indices from the chronological processing order
+    // established above (by recorded start time).
+    int episode_index = static_cast<int>(i);
 
     // Idempotent: skip episodes whose parquet already exists
     int ep_chunk = episode_index / chunk_size;

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -46,7 +46,6 @@ TrossenMCAPBackend::TrossenMCAPBackend(
   std::cout << "Chunk Size Bytes: " << cfg_->chunk_size_bytes << std::endl;
   std::cout << "Compression: " << cfg_->compression << std::endl;
   std::cout << "Dataset ID: " << cfg_->dataset_id << std::endl;
-  std::cout << "Episode Index: " << cfg_->episode_index << std::endl;
   if (!cfg_->task_description.empty()) {
     std::cout << "Task Description: " << cfg_->task_description << std::endl;
   }
@@ -66,12 +65,11 @@ bool TrossenMCAPBackend::open() {
   if (opened_) {
     return true;
   }
-  std::ostringstream oss;
-  oss << cfg_->root << "/"
-      << cfg_->dataset_id << "/"
-      << "episode_" << std::setw(6) << std::setfill('0') << episode_index_ << ".mcap";
-  // Parse configs
-  path_ = std::filesystem::path(oss.str());
+
+  const std::filesystem::path dataset_dir = std::filesystem::path(cfg_->root) / cfg_->dataset_id;
+  do {
+    path_ = dataset_dir / (trossen::io::backends::generate_episode_id() + ".mcap");
+  } while (std::filesystem::exists(path_));
 
   // Create Foxglove context
   context_ = foxglove::Context::create();
@@ -124,7 +122,9 @@ bool TrossenMCAPBackend::open() {
   metadata["tool_version"] = trossen::core::version();
   metadata["dataset_id"] = cfg_->dataset_id;
   metadata["robot_name"] = cfg_->robot_name;
-  metadata["episode_index"] = std::to_string(episode_index_);
+  // Record the episode's id (the filename without the ".mcap" extension) so a file's
+  // identity is queryable from metadata, not only its name.
+  metadata["episode_id"] = path_.stem().string();
   auto now = trossen::data::now_real();
   metadata["recording_start_time"] = std::to_string(now.to_ns());
   if (!cfg_->task_description.empty()) {
@@ -205,13 +205,25 @@ void TrossenMCAPBackend::discard_episode() {
   std::scoped_lock lk(writer_mutex_);
   close_resources();
 
-  // Construct and delete the episode file (works even if already closed by sink)
-  std::ostringstream oss;
-  oss << cfg_->root << "/"
-      << cfg_->dataset_id << "/"
-      << "episode_" << std::setw(6) << std::setfill('0') << episode_index_ << ".mcap";
+  // Determine which file to delete (works even if already closed by the sink).
+  //
+  // Filenames are UUIDs, so the file cannot be reconstructed from an index.
+  // A live backend that called open() knows its own file via path_. The re-record path
+  // (SessionManager::discard_last_episode) instead spins up a fresh backend that never
+  // opened a file, so path_ is empty; there we delete the most-recently-written episode,
+  // which is the just-finished one this local operation is meant to discard.
+  std::filesystem::path target = path_;
+  if (target.empty()) {
+    target = find_latest_episode_file();
+  }
+
+  if (target.empty()) {
+    std::cerr << "Warning: No MCAP episode file found to discard.\n";
+    return;
+  }
+
   try {
-    std::filesystem::remove(std::filesystem::path(oss.str()));
+    std::filesystem::remove(target);
   } catch (const std::filesystem::filesystem_error& e) {
     std::cerr << "Warning: Failed to remove MCAP file during discard: "
               << e.what() << "\n";
@@ -630,9 +642,49 @@ bool TrossenMCAPBackend::is_depth_encoding(const std::string& enc) {
 }
 
 
+// Pattern for episode filenames: a canonical UUID (the current <uuid>.mcap naming) or the
+// legacy zero-padded episode_NNNNNN.mcap, so resuming/gating/discarding still see episodes
+// written by older SDKs.
+static const std::regex& episode_filename_pattern() {
+  // TODO(lukeschmitt-tr): remove the legacy pattern once no longer needed.
+  static const std::regex pattern(
+    R"(([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|episode_[0-9]{6})\.mcap)");
+  return pattern;
+}
+
+std::filesystem::path TrossenMCAPBackend::find_latest_episode_file() const {
+  // "Latest" is decided by last-write time.
+  std::filesystem::path base_path = std::filesystem::path(cfg_->root) / cfg_->dataset_id;
+  if (!std::filesystem::is_directory(base_path)) {
+    return {};
+  }
+
+  std::filesystem::path latest;
+  std::filesystem::file_time_type latest_time{};
+  try {
+    for (const auto& entry : std::filesystem::directory_iterator(base_path)) {
+      if (!entry.is_regular_file()) {
+        continue;
+      }
+      if (!std::regex_match(entry.path().filename().string(), episode_filename_pattern())) {
+        continue;
+      }
+      auto mtime = entry.last_write_time();
+      if (latest.empty() || mtime > latest_time) {
+        latest = entry.path();
+        latest_time = mtime;
+      }
+    }
+  } catch (const std::filesystem::filesystem_error& e) {
+    std::cerr << "Filesystem error while locating latest episode: " << e.what() << std::endl;
+    return {};
+  }
+  return latest;
+}
+
 uint32_t TrossenMCAPBackend::scan_existing_episodes() {
   std::filesystem::path base_path = std::filesystem::path(cfg_->root) / cfg_->dataset_id;
-  // If directory doesn't exist, return 0
+  // If directory doesn't exist, there are no episodes yet
   if (!std::filesystem::exists(base_path)) {
     return 0;
   }
@@ -643,35 +695,16 @@ uint32_t TrossenMCAPBackend::scan_existing_episodes() {
     return 0;
   }
 
-  // Pattern: episode_NNNNNN.mcap (6-digit zero-padded) Regex to match episode files
-  std::regex episode_pattern(R"(episode_(\d{6})\.mcap)");
-
-  uint32_t max_index = 0;
-  bool found_any = false;
-
+  // Filenames are UUIDs, so there is no index to parse. Count the existing
+  // episode files; SessionManager uses this count to resume and to enforce max_episodes.
+  uint32_t count = 0;
   try {
-    // Iterate through directory entries
     for (const auto& entry : std::filesystem::directory_iterator(base_path)) {
-      // Skip if not a regular file
       if (!entry.is_regular_file()) {
         continue;
       }
-
-      // Get filename only (not full path)
-      std::string filename = entry.path().filename().string();
-
-      // Try to match against episode pattern
-      std::smatch match;
-      if (std::regex_match(filename, match, episode_pattern)) {
-        // Extract the numeric index from capture group 1
-        std::string index_str = match[1].str();
-        uint32_t index = static_cast<uint32_t>(std::stoul(index_str));
-
-        // Track maximum index found
-        if (!found_any || index > max_index) {
-          max_index = index;
-          found_any = true;
-        }
+      if (std::regex_match(entry.path().filename().string(), episode_filename_pattern())) {
+        ++count;
       }
       // Silently ignore non-episode files (as per design doc)
     }
@@ -680,8 +713,7 @@ uint32_t TrossenMCAPBackend::scan_existing_episodes() {
     return 0;
   }
 
-  // Return max_index + 1, or 0 if no episodes found
-  return found_any ? (max_index + 1) : 0;
+  return count;
 }
 
 }  // namespace trossen::io::backends

--- a/src/configuration/sdk_config.cpp
+++ b/src/configuration/sdk_config.cpp
@@ -159,7 +159,6 @@ void SdkConfig::populate_global_config() const {
     bj["chunk_size_bytes"] = b.chunk_size_bytes;
     bj["compression"] = b.compression;
     bj["dataset_id"] = b.dataset_id;
-    bj["episode_index"] = b.episode_index;
     gc_json["trossen_mcap_backend"] = bj;
   }
 

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -279,6 +279,17 @@ bool SessionManager::start_episode() {
     return false;
   }
 
+  // Capture the concrete output path now, while the backend is alive. The backend is
+  // reset during teardown before final stats are built, so we snapshot it here for
+  // reporting (episode filenames are non-deterministic, so callers cannot reconstruct it).
+  // Guard the write with episode_mutex_: start_episode() otherwise runs lock-free, and a
+  // concurrent stats() reads this std::string member under the lock -- an unsynchronized
+  // write would be a data race (UB), unlike the trivially-copyable counters nearby.
+  {
+    std::lock_guard<std::mutex> path_lock(episode_mutex_);
+    current_episode_path_ = current_backend_->current_output_path();
+  }
+
   // Create sink with the backend
   current_sink_ = std::make_shared<io::Sink>(current_backend_);
   current_sink_->start();
@@ -544,6 +555,10 @@ void SessionManager::teardown_episode(bool discard) {
   auto lifecycle_components = collect_lifecycle_components_();
 
   if (discard) {
+    // The episode's file was just deleted, so don't let stats() report a path that no
+    // longer exists on disk. (Runs under episode_mutex_, held from the top of this fn.)
+    current_episode_path_.clear();
+
     // Signal stats emitted so monitor_episode() can exit
     stats_emitted_.store(true);
 
@@ -662,6 +677,10 @@ void SessionManager::discard_last_episode() {
     return;
   }
 
+  // The discarded episode's file was deleted; mirror teardown_episode(discard=true) so
+  // stats() never reports a path that no longer exists on disk.
+  current_episode_path_.clear();
+
   --next_episode_index_;
   if (total_episodes_completed_ > 0) {
     --total_episodes_completed_;
@@ -712,6 +731,7 @@ bool SessionManager::wait_for_auto_stop(std::chrono::milliseconds timeout) {
 SessionManager::Stats SessionManager::stats_unlocked() const {
   Stats s;
   s.current_episode_index = next_episode_index_;
+  s.current_episode_path = current_episode_path_;
   s.episode_active = episode_active_;
 
   if (episode_active_ || !stats_emitted_.load()) {

--- a/src/utils/app_utils.cpp
+++ b/src/utils/app_utils.cpp
@@ -267,17 +267,6 @@ bool interruptible_sleep(std::chrono::duration<double> duration) {
   return true;
 }
 
-std::string generate_episode_path(
-  const std::string& output_dir,
-  uint32_t episode_index,
-  const std::string& extension)
-{
-  std::ostringstream path;
-  path << output_dir << "/episode_"
-       << std::setfill('0') << std::setw(6) << episode_index
-       << "." << extension;
-  return path.str();
-}
 
 void announce(const std::string& message, bool block) {
   if (message.empty()) return;

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -4,8 +4,7 @@
     "robot_name": "trossen_solo_ai",
     "chunk_size_bytes": 4194304,
     "compression": "zstd",
-    "dataset_id": "test_dataset",
-    "episode_index": 0
+    "dataset_id": "test_dataset"
   },
   "lerobot_v2_backend": {
     "type": "lerobot_v2_backend",

--- a/tests/test_session_manager_discard.cpp
+++ b/tests/test_session_manager_discard.cpp
@@ -8,9 +8,11 @@
 
 #include <atomic>
 #include <chrono>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <vector>
 
@@ -225,4 +227,77 @@ TEST_F(SessionManagerDiscardTest, DiscardCurrentEpisode_WithProducer) {
   // Should be able to start another episode after discard
   ASSERT_TRUE(sm.start_episode());
   sm.stop_episode();
+}
+
+// End-to-end: SessionManager wired to the real TrossenMCAP backend, verifying that
+// discard_last_episode() deletes the previous episode's actual .mcap file on disk (the
+// newest one) while leaving earlier episodes intact. This exercises the full path that the
+// null-backend SD-* tests can't: SessionManager -> fresh MCAP backend -> find_latest.
+class SessionManagerMcapDiscardTest : public ::testing::Test {
+protected:
+  std::filesystem::path dataset_dir;
+
+  void SetUp() override {
+    dataset_dir = std::filesystem::temp_directory_path() / "sm_mcap_discard_test";
+    std::filesystem::remove_all(dataset_dir);
+
+    nlohmann::json config = {
+      {"session_manager", {
+        {"type", "session_manager"},
+        {"max_duration", 10.0},
+        {"max_episodes", 100},
+        {"reset_duration", 0.0},
+        {"backend_type", "trossen_mcap"}
+      }},
+      {"trossen_mcap_backend", {
+        {"type", "trossen_mcap_backend"},
+        {"root", std::filesystem::temp_directory_path().string()},
+        {"dataset_id", "sm_mcap_discard_test"},
+        {"robot_name", "trossen_solo_ai"}
+      }}
+    };
+    trossen::configuration::GlobalConfig::instance().load_from_json(config);
+  }
+
+  void TearDown() override {
+    std::filesystem::remove_all(dataset_dir);
+  }
+};
+
+TEST_F(SessionManagerMcapDiscardTest, DiscardLastEpisode_RemovesPreviousMcapFile) {
+  SessionManager sm;
+
+  // Capture each finished episode's on-disk path as episodes complete.
+  std::vector<std::filesystem::path> paths;
+  sm.on_episode_ended([&paths](const SessionManager::Stats& stats) {
+    paths.emplace_back(stats.current_episode_path);
+  });
+
+  // Record two episodes.
+  ASSERT_TRUE(sm.start_episode());
+  sm.stop_episode();
+  ASSERT_TRUE(sm.start_episode());
+  sm.stop_episode();
+
+  ASSERT_EQ(paths.size(), 2u);
+  const std::filesystem::path first = paths[0];
+  const std::filesystem::path second = paths[1];
+  ASSERT_NE(first, second);
+  ASSERT_TRUE(std::filesystem::exists(first));
+  ASSERT_TRUE(std::filesystem::exists(second));
+  ASSERT_EQ(sm.stats().total_episodes_completed, 2u);
+
+  // Make `first` unambiguously older so `second` is deterministically the newest, regardless
+  // of filesystem mtime granularity.
+  std::error_code ec;
+  std::filesystem::last_write_time(
+    first, std::filesystem::file_time_type::clock::now() - std::chrono::seconds(10), ec);
+  ASSERT_FALSE(ec) << "failed to backdate episode mtime: " << ec.message();
+
+  // Discard the previous (last completed) episode.
+  sm.discard_last_episode();
+
+  EXPECT_FALSE(std::filesystem::exists(second)) << "previous episode's file should be deleted";
+  EXPECT_TRUE(std::filesystem::exists(first)) << "earlier episode's file should remain";
+  EXPECT_EQ(sm.stats().total_episodes_completed, 1u);
 }

--- a/tests/test_trossen_mcap_backend.cpp
+++ b/tests/test_trossen_mcap_backend.cpp
@@ -3,10 +3,15 @@
  * @brief Unit tests for TrossenMCAPBackend
  */
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <regex>
+#include <set>
 #include <string>
+#include <system_error>
+#include <thread>
 
 #include "gtest/gtest.h"
 
@@ -69,15 +74,159 @@ TEST_F(TrossenMCAPBackendTest, TaskDescriptionWrittenToMetadata) {
 
   auto backend = BackendRegistry::create("trossen_mcap");
   ASSERT_NE(backend, nullptr);
-  EXPECT_TRUE(backend->open());
+  // ASSERT so we don't fall through to directory_iterator (which throws) if open failed.
+  ASSERT_TRUE(backend->open());
   backend->close();
 
-  const auto mcap_path = episode_dir / "episode_000000.mcap";
-  ASSERT_TRUE(std::filesystem::exists(mcap_path));
+  // Episode filenames are a UUID, so discover the single episode file rather than
+  // asserting a fixed name.
+  std::filesystem::path mcap_path;
+  const std::regex episode_pattern(
+    R"([0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.mcap)");
+  for (const auto& entry : std::filesystem::directory_iterator(episode_dir)) {
+    if (entry.is_regular_file() &&
+        std::regex_match(entry.path().filename().string(), episode_pattern)) {
+      ASSERT_TRUE(mcap_path.empty()) << "More than one episode file was written";
+      mcap_path = entry.path();
+    }
+  }
+  ASSERT_FALSE(mcap_path.empty()) << "No <uuid>.mcap file was written";
 
   std::ifstream mcap_file(mcap_path, std::ios::binary);
   const std::string contents(
     (std::istreambuf_iterator<char>(mcap_file)), std::istreambuf_iterator<char>());
   EXPECT_NE(contents.find("task_description"), std::string::npos);
   EXPECT_NE(contents.find("pick up the cube"), std::string::npos);
+}
+
+// Confirms the episode id is a canonical UUIDv7 (version 7, variant 0b10) and unique.
+TEST(EpisodeId, FormatAndUniqueness) {
+  const std::regex uuid_v7(
+    R"([0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})");
+
+  std::set<std::string> seen;
+  for (int i = 0; i < 1000; ++i) {
+    const std::string id = trossen::io::backends::generate_episode_id();
+    EXPECT_TRUE(std::regex_match(id, uuid_v7)) << "Bad id: " << id;
+    EXPECT_TRUE(seen.insert(id).second) << "Duplicate id: " << id;
+  }
+}
+
+// UUIDv7 leads with a millisecond timestamp, so ids generated later sort lexicographically
+// after earlier ones -- the property the cloud relies on to list episodes chronologically.
+TEST(EpisodeId, IsTimeOrdered) {
+  const std::string earlier = trossen::io::backends::generate_episode_id();
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  const std::string later = trossen::io::backends::generate_episode_id();
+  EXPECT_LT(earlier, later) << earlier << " should sort before " << later;
+}
+
+// Restores GlobalConfig root/dataset_id on scope exit so a test can't leak state.
+namespace {
+struct RootDatasetRestorer {
+  trossen::configuration::TrossenMCAPBackendConfig* cfg;
+  std::string root;
+  std::string dataset_id;
+  ~RootDatasetRestorer() {
+    cfg->root = root;
+    cfg->dataset_id = dataset_id;
+  }
+};
+}  // namespace
+
+// A live backend that opened a file discards exactly that file via its stored path.
+TEST_F(TrossenMCAPBackendTest, DiscardEpisodeRemovesOwnOpenFile) {
+  auto cfg = trossen::configuration::GlobalConfig::instance()
+               .get_as<trossen::configuration::TrossenMCAPBackendConfig>(
+                 "trossen_mcap_backend");
+  ASSERT_NE(cfg, nullptr);
+  RootDatasetRestorer restorer{cfg.get(), cfg->root, cfg->dataset_id};
+
+  cfg->root = std::filesystem::temp_directory_path().string();
+  cfg->dataset_id = "discard_own_test";
+  const auto episode_dir = std::filesystem::path(cfg->root) / cfg->dataset_id;
+  std::filesystem::remove_all(episode_dir);
+
+  auto backend = BackendRegistry::create("trossen_mcap");
+  ASSERT_NE(backend, nullptr);
+  ASSERT_TRUE(backend->open());
+  const std::filesystem::path file = backend->current_output_path();
+  ASSERT_FALSE(file.empty());
+  ASSERT_TRUE(std::filesystem::exists(file));
+
+  backend->discard_episode();
+  EXPECT_FALSE(std::filesystem::exists(file)) << "discard should remove the backend's own file";
+}
+
+// A fresh backend that never opened a file (as SessionManager::discard_last_episode creates
+// for the re-record path) has no stored path, so discard deletes the most recently written
+// episode file -- the just-finished one -- and leaves older episodes untouched.
+TEST_F(TrossenMCAPBackendTest, DiscardEpisodeRemovesLatestEpisodeFile) {
+  auto cfg = trossen::configuration::GlobalConfig::instance()
+               .get_as<trossen::configuration::TrossenMCAPBackendConfig>(
+                 "trossen_mcap_backend");
+  ASSERT_NE(cfg, nullptr);
+  RootDatasetRestorer restorer{cfg.get(), cfg->root, cfg->dataset_id};
+
+  cfg->root = std::filesystem::temp_directory_path().string();
+  cfg->dataset_id = "discard_latest_test";
+  const auto episode_dir = std::filesystem::path(cfg->root) / cfg->dataset_id;
+  std::filesystem::remove_all(episode_dir);
+
+  // Record two completed episodes.
+  auto first_backend = BackendRegistry::create("trossen_mcap");
+  ASSERT_TRUE(first_backend->open());
+  const std::filesystem::path first = first_backend->current_output_path();
+  first_backend->close();
+
+  auto second_backend = BackendRegistry::create("trossen_mcap");
+  ASSERT_TRUE(second_backend->open());
+  const std::filesystem::path second = second_backend->current_output_path();
+  second_backend->close();
+
+  ASSERT_NE(first, second);
+  ASSERT_TRUE(std::filesystem::exists(first));
+  ASSERT_TRUE(std::filesystem::exists(second));
+
+  // Make `first` unambiguously older so `second` is deterministically the latest, regardless
+  // of filesystem timestamp resolution. Use the error_code overload so a filesystem that
+  // rejects the call fails this assertion cleanly instead of throwing out of the test.
+  std::error_code ec;
+  std::filesystem::last_write_time(
+    first, std::filesystem::file_time_type::clock::now() - std::chrono::seconds(10), ec);
+  ASSERT_FALSE(ec) << "failed to backdate episode mtime: " << ec.message();
+
+  // Fresh backend -> empty path_ -> discard falls back to deleting the newest episode.
+  auto discarder = BackendRegistry::create("trossen_mcap");
+  ASSERT_NE(discarder, nullptr);
+  discarder->discard_episode();
+
+  EXPECT_FALSE(std::filesystem::exists(second)) << "latest episode should be removed";
+  EXPECT_TRUE(std::filesystem::exists(first)) << "older episode should be kept";
+}
+
+// scan_existing_episodes() must count both new UUID names and legacy zero-padded
+// names, so resume/max_episodes gating stays correct on datasets recorded by older SDKs.
+TEST_F(TrossenMCAPBackendTest, ScanCountsLegacyAndNewEpisodeFiles) {
+  auto cfg = trossen::configuration::GlobalConfig::instance()
+               .get_as<trossen::configuration::TrossenMCAPBackendConfig>(
+                 "trossen_mcap_backend");
+  ASSERT_NE(cfg, nullptr);
+  RootDatasetRestorer restorer{cfg.get(), cfg->root, cfg->dataset_id};
+
+  cfg->root = std::filesystem::temp_directory_path().string();
+  cfg->dataset_id = "scan_legacy_test";
+  const auto episode_dir = std::filesystem::path(cfg->root) / cfg->dataset_id;
+  std::filesystem::remove_all(episode_dir);
+  std::filesystem::create_directories(episode_dir);
+
+  // Two legacy zero-padded episodes, one new UUID-named episode, and a non-episode file.
+  for (const std::string& name : {"episode_000000.mcap", "episode_000001.mcap",
+                                  "0190b3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f.mcap", "notes.txt"}) {
+    std::ofstream(episode_dir / name).put('x');
+  }
+
+  auto backend = BackendRegistry::create("trossen_mcap");
+  ASSERT_NE(backend, nullptr);
+  EXPECT_EQ(backend->scan_existing_episodes(), 3u);
 }


### PR DESCRIPTION
Names TrossenMCAP episodes with a UUIDv7 instead of a zero-padded index prefixed with episode_.

- Episodes are not universally unique across machines when merging into a single (huge) dataset
- Episodes are chronologically sortable by filename
- Can use client names as an identifier in consuming applications

The following changes were made:
- Episodes are now named <uuid>.mcap
- ID is written to episode metadata
- episode index concept removed from trossenmcap backend
- Adds Session Manager to help it remember the current/last episode path without counting