### PR TITLE
build: honor the CMake 4.x policy floor and document policy-client gRPC deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ project(trossen_sdk
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# SCServo (2.8.3) and msgpack-cxx (3.1) declare a cmake_minimum_required below the 3.5
+# floor that CMake 4.x enforces. Raising the floor here covers both fetched dependencies.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 # TODO: Discuss build options - do we want RealSense ON by default? What about other
 # optional hardware (e.g., Zed cameras)? Where do we draw the line between mandatory
 # and opt-in dependencies?
@@ -268,8 +272,6 @@ FetchContent_Declare(
   SYSTEM
   GIT_REPOSITORY https://github.com/ftservo/FTServo_Linux.git
   GIT_TAG 064a6dbf814477b970959b5b01b2fc9bc594afa3
-  CMAKE_ARGS
-    -D CMAKE_POLICY_VERSION_MINIMUM=3.5
   PATCH_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> bash -c "git apply --check ${CMAKE_SOURCE_DIR}/cmake/patches/SCServo.patch && git apply ${CMAKE_SOURCE_DIR}/cmake/patches/SCServo.patch || echo 'Patch already applied'"
 
 )
@@ -296,6 +298,10 @@ set(BUILD_WITH_ROS OFF CACHE BOOL "Build trossen_slate without ROS" FORCE)
 set(BUILD_DEMOS OFF CACHE BOOL "Skip trossen_slate demo executables" FORCE)
 set(TROSSEN_SLATE_BUILD_PYTHON_BINDINGS OFF CACHE BOOL
   "Skip trossen_slate's pybind module; trossen_sdk provides its own" FORCE)
+# trossen_slate probes for ament_cmake regardless of BUILD_WITH_ROS, and its ament_package()
+# path parses package.xml through Python catkin_pkg. Keep it off so a sourced ROS 2
+# environment does not pull ament into this build.
+set(CMAKE_DISABLE_FIND_PACKAGE_ament_cmake ON)
 
 FetchContent_MakeAvailable(trossen_slate)
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ Required for RealSense cameras. Install the RealSense SDK 2.0 by following the [
 
 > **Note:** The two important packages from the RealSense repository are `librealsense2-dev` and `librealsense2-utils`. `realsense-viewer` only needs `librealsense2-utils`, but `find_package(realsense2)` in CMake needs the headers and CMake config from `librealsense2-dev`. If `realsense-viewer` works but the SDK build fails to find RealSense, it means the runtime is installed but the dev package is missing.
 
+### PolicyClient (optional)
+
+Required only when building with `-DTROSSEN_SDK_ENABLE_POLICY_CLIENT=ON`. The gRPC transport is generated from a vendored proto at build time, so the build needs the gRPC development headers and the C++ `protoc` plugin:
+
+```bash
+sudo apt-get install -y \
+    libgrpc++-dev \
+    protobuf-compiler-grpc
+```
+
+> **Note:** As with RealSense, the gRPC *runtime* package (`libgrpc++1.x`) is not sufficient. `pkg_check_modules(grpc++)` needs the `grpc++.pc` file that ships only in `libgrpc++-dev`. `libgrpc-dev` does not need to be installed explicitly; `libgrpc++-dev` depends on it.
+
 ---
 
 ## Building

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -96,6 +96,24 @@ Install the RealSense SDK 2.0 by following the `librealsense distribution guide 
     RealSense depth capture is supported alongside RGB, but enabling it significantly increases USB bandwidth.
     When running multiple cameras, prefer short, high-quality USB 3.0 cables and distribute cameras across independent USB host controllers.
 
+PolicyClient (Optional)
+-----------------------
+
+The PolicyClient is off by default and is built with ``-DTROSSEN_SDK_ENABLE_POLICY_CLIENT=ON``.
+Its gRPC transport is generated from a vendored proto at build time, so the build requires the gRPC development headers and the C++ ``protoc`` plugin.
+
+.. code-block:: bash
+
+    sudo apt-get install -y \
+        libgrpc++-dev \
+        protobuf-compiler-grpc
+
+.. note::
+
+    As with RealSense, the gRPC *runtime* package (``libgrpc++1.x``) is not sufficient.
+    ``pkg_check_modules(grpc++)`` needs the ``grpc++.pc`` file that ships only in ``libgrpc++-dev``.
+    ``libgrpc-dev`` does not need to be installed explicitly; ``libgrpc++-dev`` depends on it.
+
 Audio Announcements (Optional)
 ------------------------------
 


### PR DESCRIPTION
## Why

An external user tried to build the SDK with `-DTROSSEN_SDK_ENABLE_POLICY_CLIENT=ON` and hit three separate failures before getting a successful build. All three were real. This PR fixes the two that belong to us and documents the third.

Their fourth issue — a conda `libcurl.so.4` on `LD_LIBRARY_PATH` shadowing the system one and hiding the `CURL_OPENSSL_4` symbols `libarrow` needs — is deliberately **not** addressed here. It is a property of their shell, and reaching into a user's library path from CMake would be fragile and surprising.

## 1. `CMAKE_POLICY_VERSION_MINIMUM` was set in a way that does nothing

CMake 4.x removed compatibility with `cmake_minimum_required` below 3.5. Two fetched dependencies fall under that floor:

- `SCServo` — `src/CMakeLists.txt:1` declares `2.8.3`
- `msgpack-cxx` — `CMakeLists.txt:1` declares `3.1`

`FetchContent_Declare(SCServo)` already carried `CMAKE_ARGS -D CMAKE_POLICY_VERSION_MINIMUM=3.5`, which reads like the problem was handled. It was not. `CMAKE_ARGS` is an ExternalProject *configure-step* option, and FetchContent only runs the download/update/patch steps before handing the dependency to `add_subdirectory`. The flag was recorded into the download-only sub-build and never applied to anything.

Replaced with a directory-scoped variable set once near the top, which propagates into both dependencies via normal subdirectory inheritance:

```cmake
set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
```

`IXWebSocket` needed no change — it declares the range form `3.4.1...3.17.2`, which is the sanctioned escape from the removal and is accepted as-is.

This was invisible to us because CI and our dev boxes run CMake 3.28, where the pre-4.x behavior applies and nothing errors. CMake 4.x is what current pip and newer distros ship, so this will keep recurring for external users.

## 2. `BUILD_WITH_ROS OFF` did not actually keep ROS out of the build

We configure `trossen_slate` with `BUILD_WITH_ROS OFF`, but that flag does not gate slate's ament lookup. Slate does `find_package(ament_cmake QUIET)` unconditionally (guarded only on `SKBUILD`), and if it finds one, runs `ament_package()` — which parses `package.xml` through Python `catkin_pkg`. A developer with a ROS 2 environment sourced therefore needs `catkin_pkg` installed in whichever interpreter CMake picks, to build a dependency we explicitly asked to skip ROS for.

Added before the slate fetch:

```cmake
set(CMAKE_DISABLE_FIND_PACKAGE_ament_cmake ON)
```

This is the standard CMake mechanism for forcing a `QUIET` lookup to fail. Safe here: we consume slate as a plain CMake target (include dirs + link) and never touch its ament export.

## 3. The policy-client gRPC packages were undocumented

`cmake/policy_client.cmake:50-52` hard-requires `grpc++` via `pkg_check_modules`, plus `protoc` and `grpc_cpp_plugin` via `find_program(... REQUIRED)`. Configure fails outright without them, and neither `README.md` nor `docs/installation.rst` mentioned gRPC anywhere.

Added a **PolicyClient (optional)** section to both, following the existing ZED/RealSense optional-dependency convention:

```bash
sudo apt-get install -y libgrpc++-dev protobuf-compiler-grpc
```

Two details worth stating, both included as notes in the docs:

- The gRPC **runtime** package (`libgrpc++1.x`) is not sufficient — `grpc++.pc` ships only in `libgrpc++-dev`. This is the same runtime-vs-dev trap already documented for RealSense, and it is what the reporting user hit.
- `libgrpc-dev` does **not** need to be installed explicitly; `libgrpc++-dev` depends on it. The user installed it by hand, which was harmless but unnecessary.

Note that CI is already correct here — `.github/workflows/build.yml` installs both packages and `.github/ci-configs.json` builds `POLICY_CLIENT=ON` in 7 of 9 configs. This gap was purely user-facing docs.

## Verification

CMake 4.x behavior could not be checked on a normal dev box (3.28.3), so it was verified against a real CMake 4.1.3 installed in a throwaway venv:

| Check | Result |
| --- | --- |
| Bare `cmake_minimum_required(VERSION 2.8.3)` under CMake 4.1.3 | Fails with `Compatibility with CMake < 3.5 has been removed` — reproduces the report |
| Same, with `set(CMAKE_POLICY_VERSION_MINIMUM 3.5)` in the parent scope | Configures; downgraded to a deprecation warning |
| Range form `3.4.1...3.17.2`, no override | Configures — confirms IXWebSocket needs nothing |
| `find_package(ament_cmake QUIET)` with a stub ament package on `CMAKE_PREFIX_PATH` | Found — reproduces the ROS-sourced trigger |
| Same, with `CMAKE_DISABLE_FIND_PACKAGE_ament_cmake ON` | Not found — fix confirmed |
| Full project configure, `REALSENSE=ON POLICY_CLIENT=ON`, **CMake 4.1.3** | `Configuring done` / `Generating done` |
| Full project configure + `trossen_sdk` build, CMake 3.28.3 | Configures and links; no new warnings (the variable is inert pre-4.x) |

The pre-existing `CMP0048` warnings from SCServo are unchanged — on 3.28 the new variable has no effect, so policies there are still resolved as before.
