### PR TITLE
teleop: add a base velocity space and implement it on the SLATE base

### DIFF
--- a/include/trossen_sdk/configuration/types/teleop_config.hpp
+++ b/include/trossen_sdk/configuration/types/teleop_config.hpp
@@ -26,12 +26,12 @@ struct TeleoperationPair {
   /// @brief Key in hardware.arms map for the follower arm
   std::string follower;
 
-  /// @brief Teleop space: "joint" or "cartesian". Defaults to "joint".
+  /// @brief Teleop space: "joint", "cartesian", or "base". Defaults to "joint".
   ///
   /// The factory converts this to teleop::TeleopCapable::Space. The chosen
-  /// space must be implemented (via JointSpaceTeleop / CartesianSpaceTeleop)
-  /// by both the leader and the follower — otherwise the controller throws
-  /// at construction.
+  /// space must be implemented (via JointSpaceTeleop / CartesianSpaceTeleop /
+  /// BaseSpaceTeleop) by both the leader and the follower — otherwise the
+  /// controller throws at construction.
   std::string space{"joint"};
 
   static TeleoperationPair from_json(const nlohmann::json& j) {
@@ -58,8 +58,8 @@ struct TeleoperationPair {
  *
  * The teleop loop mirrors each leader's state to its paired follower at the
  * specified rate. Set "enabled" to false to skip teleop (e.g. replay mode).
- * The "space" field on each pair selects the teleop space ("joint" or
- * "cartesian"); it defaults to "joint" if omitted.
+ * The "space" field on each pair selects the teleop space ("joint",
+ * "cartesian", or "base"); it defaults to "joint" if omitted.
  *
  * Per-arm tuning (staging pose, trajectory time, etc.) lives in each arm's
  * own hardware configuration block.

--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -97,6 +97,8 @@ public:
     switch (space) {
       case Space::Joint:     return &joint_view_;
       case Space::Cartesian: return &cart_view_;
+      case Space::Base:      return nullptr;
+      case Space::Count:     return nullptr;
     }
     return nullptr;
   }

--- a/include/trossen_sdk/hw/base/slate_base_component.hpp
+++ b/include/trossen_sdk/hw/base/slate_base_component.hpp
@@ -8,8 +8,10 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
 #include "trossen_slate/trossen_slate.hpp"
 
 namespace trossen::hw::base {
@@ -17,9 +19,12 @@ namespace trossen::hw::base {
 /**
  * @brief Hardware component for SLATE mobile base
  *
- * Wraps TrossenSlate driver and provides JSON configuration.
+ * Wraps TrossenSlate driver and provides JSON configuration. Implements
+ * teleop::BaseSpaceTeleop so a teleop leader (e.g. VR joystick) can drive the
+ * base with a 2-element `[linear_mps, angular_rps]` vector each tick.
  */
-class SlateBaseComponent : public HardwareComponent {
+class SlateBaseComponent : public HardwareComponent,
+                           public teleop::BaseSpaceTeleop {
 public:
   /**
    * @brief Constructor
@@ -63,6 +68,26 @@ public:
    * @return Shared pointer to driver
    */
   std::shared_ptr<trossen_slate::TrossenSlate> get_driver() const { return driver_; }
+
+  // ── teleop::BaseSpaceTeleop: IO contract ───────────────────────────────
+  // Base-space vector layout is `[linear_mps, angular_rps]`.
+
+  /// Return the base's measured velocity `[linear, angular]`, refreshed from
+  /// the hardware rather than served from the last poll.
+  std::vector<float> read() override;
+
+  /// Forward `[linear, angular]` to the driver's `set_cmd_vel`. Commands
+  /// shorter than two elements are ignored to keep the hot loop silent under
+  /// transient empty reads from a leader that has not synced yet.
+  void write(const std::vector<float>& cmd) override;
+
+  // ── teleop::TeleopCapable: lifecycle ───────────────────────────────────
+
+  /// Ensure motor torque is enabled before the mirror loop starts.
+  void prepare_for_teleop() override;
+
+  /// Zero the commanded velocity so the base coasts to a stop.
+  void end_teleop() override;
 
 private:
   std::shared_ptr<trossen_slate::TrossenSlate> driver_;

--- a/include/trossen_sdk/hw/teleop/teleop_capable.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_capable.hpp
@@ -2,7 +2,7 @@
  * @file teleop_capable.hpp
  * @brief Mixin interfaces for teleop-capable hardware.
  *
- * Teleop capability is structured around four interfaces:
+ * Teleop capability is structured around five interfaces:
  *
  *   - TeleopTypeIO          : pure IO contract (`read()` / `write()`) that
  *                              the controller's hot loop talks to.
@@ -12,6 +12,9 @@
  *                              nullptr if unsupported).
  *   - JointSpaceTeleop       : TeleopCapable + TeleopTypeIO for joint space.
  *   - CartesianSpaceTeleop   : TeleopCapable + TeleopTypeIO for cartesian space.
+ *   - BaseSpaceTeleop        : TeleopCapable + TeleopTypeIO for mobile-base
+ *                              velocity space (append-only axis vector led by
+ *                              [linear, angular] — see `base_axis`).
  *
  * A hardware component must implement at least one space child to be usable
  * by the teleop controller. The controller calls `as_space_io(cfg.space)`
@@ -51,6 +54,7 @@
 #define TROSSEN_SDK__HW__TELEOP__TELEOP_CAPABLE_HPP_
 
 #include <array>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string_view>
@@ -113,7 +117,7 @@ public:
   /// `Count` is a sentinel (not a real space) used to make the descriptor
   /// table's compile-time check meaningful. When adding a new space,
   /// insert it before `Count` and add a matching row to `kSpaceDescriptors`.
-  enum class Space { Joint, Cartesian, Count };
+  enum class Space { Joint, Cartesian, Base, Count };
 
   virtual ~TeleopCapable() = default;
 
@@ -167,9 +171,10 @@ struct SpaceDescriptor {
   std::string_view     iface_name;  ///< C++ interface, e.g. "JointSpaceTeleop".
 };
 
-inline constexpr std::array<SpaceDescriptor, 2> kSpaceDescriptors{{
+inline constexpr std::array<SpaceDescriptor, 3> kSpaceDescriptors{{
   {TeleopCapable::Space::Joint,     "joint",     "JointSpaceTeleop"},
   {TeleopCapable::Space::Cartesian, "cartesian", "CartesianSpaceTeleop"},
+  {TeleopCapable::Space::Base,      "base",      "BaseSpaceTeleop"},
 }};
 
 // Compile-time check: every Space enum value has a descriptor row. The
@@ -231,6 +236,84 @@ class CartesianSpaceTeleop : public virtual TeleopCapable, public TeleopTypeIO {
 public:
   TeleopTypeIO* as_space_io(Space s) override {
     return s == Space::Cartesian ? static_cast<TeleopTypeIO*>(this) : nullptr;
+  }
+};
+
+// ── Base-space axis layout ───────────────────────────────────────────────
+//
+// Base commands are a variable-length vector whose axes are positional and
+// APPEND-ONLY. The first two are required and their meaning is frozen: a
+// differential-drive base (SLATE) and a holonomic base with a lift both start
+// `[linear, angular, ...]`, so a 2-element leader can drive a 4-axis follower
+// and vice versa — each side reads the axes it understands and ignores the rest.
+//
+// Axes are NOT reordered to group "translation" together, even though
+// `lateral` would sit more naturally beside `linear`: index 1 already means
+// angular in shipped SLATE and VR code, and renumbering would silently swap
+// yaw for strafe on hardware that is working today.
+//
+// SIGNS. The frame is right-handed with +x forward and +z up, so every axis
+// below is positive in the LEFT/UP/FORWARD sense: forward, counter-clockwise
+// (turning LEFT), lift up, strafe left. A raw joystick axis carries no
+// convention of its own, so which raw axis and which sign feeds each axis here
+// is a per-device MEASUREMENT, not something to derive — each base component
+// documents its own. Getting it wrong is invisible in code review and reads on
+// hardware as "rotate right turns it left" or "forward drives it sideways".
+namespace base_axis {
+
+/// Forward translational velocity along the base heading (m/s), positive
+/// forward. Required.
+inline constexpr std::size_t kLinear = 0;
+
+/// Yaw rate about the vertical axis (rad/s), positive counter-clockwise seen
+/// from above — i.e. positive turns the robot LEFT. Required.
+inline constexpr std::size_t kAngular = 1;
+
+/// Vertical lift / linear-actuator velocity, in the actuator's own units per
+/// second. Optional — absent on bases without a lift (SLATE).
+inline constexpr std::size_t kLift = 2;
+
+/// Lateral (strafe) velocity, positive left (m/s). Optional — meaningful only
+/// on holonomic bases; a differential-drive base cannot honour it.
+inline constexpr std::size_t kLateral = 3;
+
+/// Smallest valid base command: linear + angular.
+inline constexpr std::size_t kMinSize = 2;
+
+/// Largest layout currently defined. Longer vectors are not an error — a
+/// follower ignores axes past what its hardware supports — but nothing in the
+/// SDK produces them yet.
+inline constexpr std::size_t kMaxSize = 4;
+
+/// Read `axis` from `cmd`, or `fallback` if the vector is too short to carry
+/// it. The safe way to consume optional axes: a follower asks for kLift and
+/// gets 0 from a 2-element differential-drive leader instead of reading past
+/// the end.
+inline float get(const std::vector<float>& cmd, std::size_t axis,
+                 float fallback = 0.0f) {
+  return axis < cmd.size() ? cmd[axis] : fallback;
+}
+
+}  // namespace base_axis
+
+/**
+ * @brief Mobile-base velocity teleop interface.
+ *
+ * Commands carry `[linear_mps, angular_rps]` plus optional trailing axes —
+ * see the `base_axis` constants above for the layout and why it is
+ * append-only. Index by those names rather than by literal, and read optional
+ * axes through `base_axis::get()` so a short vector degrades to zero instead
+ * of reading out of bounds.
+ *
+ * Implementations advertise their own length from `read()` and tolerate any
+ * length in `write()`; there is deliberately no fixed size on this interface,
+ * because a 2-axis differential-drive base and a 4-axis holonomic one are both
+ * valid followers for the same leader.
+ */
+class BaseSpaceTeleop : public virtual TeleopCapable, public TeleopTypeIO {
+public:
+  TeleopTypeIO* as_space_io(Space s) override {
+    return s == Space::Base ? static_cast<TeleopTypeIO*>(this) : nullptr;
   }
 };
 

--- a/python/trossen_sdk.cpp
+++ b/python/trossen_sdk.cpp
@@ -652,6 +652,7 @@ PYBIND11_MODULE(trossen_sdk, m) {
   py::enum_<TeleopCapable::Space>(m, "TeleopSpace")
     .value("Joint", TeleopCapable::Space::Joint)
     .value("Cartesian", TeleopCapable::Space::Cartesian)
+    .value("Base", TeleopCapable::Space::Base)
     .export_values();
 
   py::class_<TeleopTypeIO, PyTeleopTypeIO,

--- a/src/hw/base/slate_base_component.cpp
+++ b/src/hw/base/slate_base_component.cpp
@@ -10,6 +10,8 @@
 
 namespace trossen::hw::base {
 
+namespace ba = teleop::base_axis;
+
 void SlateBaseComponent::configure(const nlohmann::json& config) {
   // Parse optional configuration parameters
   reset_odometry_ = config.value("reset_odometry", false);
@@ -58,6 +60,43 @@ nlohmann::json SlateBaseComponent::get_info() const {
   }
 
   return info;
+}
+
+std::vector<float> SlateBaseComponent::read() {
+  if (!driver_) return std::vector<float>(ba::kMinSize, 0.0f);
+  // Refresh first: get_vel() returns whatever the last poll left behind. The
+  // result is deliberately unchecked — a failed refresh leaves the previous
+  // reading, which is exactly what this call was there to replace, and the
+  // mirror loop must not log per tick.
+  //
+  // The driver is shared with SlateBaseProducer, which also calls
+  // update_state() from a scheduler thread, and TrossenSlate is not documented
+  // as thread-safe. Safe while the base is a teleop follower: read() then runs
+  // once, from prepare_teleop(), before the scheduler starts. A base wired as a
+  // teleop *leader* would call this every tick from the mirror thread and needs
+  // the driver access serialized first.
+  driver_->update_state();
+  // get_vel() is [linear, angular], which is the base_axis order by construction.
+  auto vel = driver_->get_vel();
+  return {vel[ba::kLinear], vel[ba::kAngular]};
+}
+
+void SlateBaseComponent::write(const std::vector<float>& cmd) {
+  if (!driver_ || cmd.size() < ba::kMinSize) return;
+  // Trailing axes (kLift, kLateral) are ignored: SLATE is differential-drive
+  // with no lift, so it cannot honour them.
+  driver_->set_cmd_vel(cmd[ba::kLinear], cmd[ba::kAngular]);
+}
+
+void SlateBaseComponent::prepare_for_teleop() {
+  if (!driver_) return;
+  std::string torque_result;
+  driver_->enable_motor_torque(true, torque_result);
+}
+
+void SlateBaseComponent::end_teleop() {
+  if (!driver_) return;
+  driver_->set_cmd_vel(0.0f, 0.0f);
 }
 
 // Register the hardware component with the hardware registry

--- a/tests/test_teleop_space_helpers.cpp
+++ b/tests/test_teleop_space_helpers.cpp
@@ -25,12 +25,14 @@ using Space = trossen::hw::teleop::TeleopCapable::Space;
 TEST(TeleopSpaceHelpersTest, SpaceNameReturnsLowerCaseJsonName) {
   EXPECT_EQ(space_name(Space::Joint),     "joint");
   EXPECT_EQ(space_name(Space::Cartesian), "cartesian");
+  EXPECT_EQ(space_name(Space::Base),      "base");
 }
 
 // space_iface_name: every Space value returns the expected C++ interface name.
 TEST(TeleopSpaceHelpersTest, IfaceNameReturnsCppClassName) {
   EXPECT_EQ(space_iface_name(Space::Joint),     "JointSpaceTeleop");
   EXPECT_EQ(space_iface_name(Space::Cartesian), "CartesianSpaceTeleop");
+  EXPECT_EQ(space_iface_name(Space::Base),      "BaseSpaceTeleop");
 }
 
 // space_from_name: known names resolve to the matching Space value.
@@ -42,6 +44,10 @@ TEST(TeleopSpaceHelpersTest, FromNameResolvesKnownSpaces) {
   auto cart = space_from_name("cartesian");
   ASSERT_TRUE(cart.has_value());
   EXPECT_EQ(*cart, Space::Cartesian);
+
+  auto base = space_from_name("base");
+  ASSERT_TRUE(base.has_value());
+  EXPECT_EQ(*base, Space::Base);
 }
 
 // space_from_name: unknown inputs return nullopt, never fall through silently.
@@ -54,7 +60,7 @@ TEST(TeleopSpaceHelpersTest, FromNameReturnsNulloptForUnknown) {
 
 // Round-trip: for every known space, name → Space → name returns the same name.
 TEST(TeleopSpaceHelpersTest, RoundTripNameThroughEnum) {
-  for (const auto s : {Space::Joint, Space::Cartesian}) {
+  for (const auto s : {Space::Joint, Space::Cartesian, Space::Base}) {
     auto name = space_name(s);
     auto parsed = space_from_name(std::string{name});
     ASSERT_TRUE(parsed.has_value()) << "Failed to parse " << name;


### PR DESCRIPTION
Adds a third teleop space so a mobile base runs through the same mirror loop as an arm, and implements it on the SLATE base so the interface ships with a consumer rather than as an empty seam. First PR of the Rivet decomposition stack.

- **`Space::Base`** — one enum value, one `kSpaceDescriptors` row, a 5-line `BaseSpaceTeleop`. The `static_assert` against `Space::Count` keeps table and enum in lockstep.
- **Explicit** **`Base`** **/** **`Count`** **cases in** **`TrossenArmComponent::as_space_io`**, both `nullptr`. Listing them rather than falling through means `-Wswitch` flags the _next_ space added.
- **`base_axis`** — `kLinear, kAngular, kLift, kLateral` plus `get()`, because base commands are variable-length: 2 axes for differential drive, 4 for a holonomic base with a lift, both valid followers for the same leader. `get()` yields 0 for an axis a short vector cannot carry instead of reading past the end.
- **`SlateBaseComponent`** **implements it** — `read()`, `write()`,`prepare_for_teleop()`, `end_teleop()`.

**This PR freezes the axis layout, append-only.** `kLateral` is deliberately not beside `kLinear`: index 1 already means angular in shipped SLATE and VR code, so renumbering would silently swap yaw for strafe on working hardware. If the layout should change, it changes here. Signs are measured, not derived — right-handed frame, +x forward, +z up, every axis positive in the left/up/forward sense — so which raw joystick axis and sign feeds each entry is a per-device measurement each component documents itself.

Interface and SLATE implementation are cherry-picked from `experimental/trossen-vr `(already reviewed there) rather than rewritten. That version keeps `prepare_for_teleop()` motor torque — without it the first writes of a session go nowhere — and stays silent on short commands instead of logging per tick in the mirror loop. Layered on top: `base_axis`, and an `update_state()` refresh in `read()` so the
velocity is current rather than the last poll.