### PR TITLE
teleop: add a gripper force-feedback channel

### DIFF
--- a/include/trossen_sdk/hw/teleop/teleop_capable.hpp
+++ b/include/trossen_sdk/hw/teleop/teleop_capable.hpp
@@ -97,6 +97,29 @@ public:
   virtual void sync_to_state(const std::vector<float>& state) {
     (void)state;
   }
+
+  // ── Optional gripper force-feedback channel (follower → leader) ──────────
+  //
+  // A reverse channel the controller runs each tick alongside the forward
+  // position mirror: the follower reports its measured gripper effort and the
+  // leader renders a reflected force so the operator feels the grasp. Both
+  // ends are no-ops by default, so hardware that can neither sense nor render
+  // gripper force simply opts out.
+
+  /// Leader role: true if this hardware renders gripper force feedback. Gates
+  /// whether the controller runs the reverse channel at all.
+  virtual bool renders_gripper_feedback() const { return false; }
+
+  /// Follower role: this hardware's measured gripper effort (N), or nullopt if
+  /// it cannot report one. A sensor read — independent of the gripper's mode.
+  virtual std::optional<float> read_gripper_effort() { return std::nullopt; }
+
+  /// Leader role: render gripper force feedback from the follower's measured
+  /// gripper effort (N). Default no-op for hardware without an actuated
+  /// gripper.
+  virtual void apply_gripper_feedback(float follower_gripper_effort) {
+    (void)follower_gripper_effort;
+  }
 };
 
 /**

--- a/src/hw/teleop/teleop_controller.cpp
+++ b/src/hw/teleop/teleop_controller.cpp
@@ -168,6 +168,16 @@ void TeleopController::control_loop() {
         follower_io_->write(cmd);
       }
 
+      // Reverse channel: reflect the follower's measured gripper effort back
+      // onto the leader so the operator feels the grasp. Only runs when the
+      // leader renders feedback — e.g. a passive-arm leader whose gripper is
+      // the one actuated joint; otherwise both calls are skipped.
+      if (follower_io_ && leader_io_->renders_gripper_feedback()) {
+        if (const auto effort = follower_io_->read_gripper_effort()) {
+          leader_io_->apply_gripper_feedback(*effort);
+        }
+      }
+
       std::this_thread::sleep_until(deadline);
     }
   } catch (const std::exception& e) {


### PR DESCRIPTION
Adds a reverse channel alongside the forward position mirror: the follower reports its measured gripper effort and the leader renders a reflected force, so the operator feels the grasp. Stacked on #284.

- **Three virtuals on** **`TeleopTypeIO`**, all no-op by default — `renders_gripper_feedback()` (leader, gates the channel), `read_gripper_effort() `(follower, `nullopt` if it cannot measure), `apply_gripper_feedback(float)` (leader).
Hardware that can neither sense nor render gripper force opts out by doing nothing.
- **The controller runs it right after the forward write**, so the reflected force lands on the same tick as the command that caused the grasp rather than one tick behind.

**No behaviour change on its own** — nothing overrides the gate yet, so the condition is always false and the mirror loop does exactly what it did before. The arm-side implementation (the cubic curve and its tuning keys) lands with the passive-leader PR.

Two details in the loop body that are deliberate:

- The leader's `bool` is checked **before** the follower's `read_gripper_effort()`. On a networked arm that read is a driver call, and this runs at the control rate, so short-circuiting keeps the default path free.
- A follower that cannot measure is **skipped**, not treated as zero. Zero is a meaningful value here — it means "not grasping" — so substituting it would relax the leader gripper instead of holding position.

