### PR TITLE
session_control: add a push-based session-control contract and wire it in

### DIFF
--- a/include/trossen_sdk/hw/session_control/session_control_capable.hpp
+++ b/include/trossen_sdk/hw/session_control/session_control_capable.hpp
@@ -1,0 +1,92 @@
+/**
+ * @file session_control_capable.hpp
+ * @brief Mixin contract for hardware that drives SessionManager state transitions.
+ *
+ * A `SessionControlCapable` component emits a small fixed set of
+ * session-level intents (start episode, stop early, re-record, stop
+ * session). SessionManager attaches exactly one source at a time via
+ * `attach_session_control()` and listens for events through a callback —
+ * there is no polling. The source owns whatever threading it needs to
+ * detect input (dedicated reader thread, piggyback on a hardware I/O
+ * thread, etc.) and is responsible for keeping the callback cheap.
+ *
+ * Interpretation of events is state-dependent and lives entirely in
+ * SessionManager: a `kStart` event means "begin the next episode" in
+ * IDLE, "stop current and advance" in RECORDING, and "skip reset" in
+ * RESETTING. Sources do not need to know the session's current phase.
+ *
+ * Disconnect is a one-shot signal. On disconnect the SessionManager
+ * stops the current episode cleanly (saving the partial recording)
+ * and ends the session — there is no fallback to another source.
+ */
+
+#ifndef TROSSEN_SDK__HW__SESSION_CONTROL__SESSION_CONTROL_CAPABLE_HPP_
+#define TROSSEN_SDK__HW__SESSION_CONTROL__SESSION_CONTROL_CAPABLE_HPP_
+
+#include <functional>
+
+namespace trossen::hw::session_control {
+
+/**
+ * @brief Intent emitted by a session-control source.
+ *
+ * Events are semantic intents, not raw inputs. `kStart` means "advance" —
+ * its concrete effect depends on the current session phase and is
+ * resolved by SessionManager, not the source.
+ */
+enum class SessionControlEvent {
+  kNone,          ///< No event pending. Callbacks never pass this.
+  kStart,         ///< Start / stop-early / skip-reset depending on phase.
+  kStopEarly,     ///< Stop the current recording without advancing.
+  kRerecord,      ///< Discard current (recording) or last (resetting).
+  kStopSession    ///< End the whole session (equivalent to Ctrl+C).
+};
+
+/**
+ * @brief Push-based session-control input contract.
+ *
+ * Implementations call `on_event` once per detected user intent and
+ * `on_disconnect` once if the source becomes permanently unusable.
+ * Both callbacks fire from the source's own thread; implementations
+ * must make them cheap and non-blocking.
+ */
+class SessionControlCapable {
+public:
+  using EventCallback      = std::function<void(SessionControlEvent)>;
+  using DisconnectCallback = std::function<void()>;
+
+  virtual ~SessionControlCapable() = default;
+
+  /**
+   * @brief Install the event and disconnect callbacks.
+   *
+   * Called by `SessionManager::attach_session_control()`. Implementations
+   * store the callbacks for use by their reader thread(s). A subsequent
+   * call replaces the previous callbacks.
+   *
+   * @note Callbacks may be invoked from any thread the source owns.
+   */
+  virtual void set_callbacks(EventCallback on_event,
+                             DisconnectCallback on_disconnect) = 0;
+
+  /**
+   * @brief Begin producing events.
+   *
+   * Typically spawns the source's reader thread (keyboard) or hooks into
+   * an existing one (VR frame callback). Idempotent: calling `start()`
+   * on an already-started source is a no-op.
+   */
+  virtual void start() = 0;
+
+  /**
+   * @brief Stop producing events and join any internal threads.
+   *
+   * Must be safe to call from the source's destructor. Idempotent.
+   * After `stop()` returns, no further callbacks will fire.
+   */
+  virtual void stop() = 0;
+};
+
+}  // namespace trossen::hw::session_control
+
+#endif  // TROSSEN_SDK__HW__SESSION_CONTROL__SESSION_CONTROL_CAPABLE_HPP_

--- a/include/trossen_sdk/runtime/session_manager.hpp
+++ b/include/trossen_sdk/runtime/session_manager.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "trossen_sdk/hw/producer_base.hpp"
+#include "trossen_sdk/hw/session_control/session_control_capable.hpp"
 #include "trossen_sdk/io/backends/lerobot_v2/lerobot_v2_backend.hpp"
 #include "trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp"
 #include "trossen_sdk/io/sink.hpp"
@@ -458,6 +459,34 @@ public:
    */
   Stats get_async_monitor_stats();
 
+  // =========================================================================
+  // Session-control input (single-source, push-based)
+  // =========================================================================
+
+  /**
+   * @brief Attach the session-control input source.
+   *
+   * Exactly one source may be attached at a time — a hardware component
+   * that implements `SessionControlCapable` (VR controller, keyboard,
+   * foot pedal, etc.). Event and disconnect callbacks are registered on
+   * the source and the source is started; subsequent intents surface
+   * through `monitor_episode()` and `wait_for_reset()` without polling.
+   *
+   * @param source Non-null shared pointer to the source to attach.
+   * @throws std::invalid_argument if `source` is null.
+   * @throws std::runtime_error    if a source is already attached.
+   */
+  void attach_session_control(
+    std::shared_ptr<hw::session_control::SessionControlCapable> source);
+
+  /**
+   * @brief Detach the current session-control source, if any.
+   *
+   * Stops the source, clears the attachment, and resets the internal
+   * pending-event channel. Safe to call if no source is attached.
+   */
+  void detach_session_control();
+
 private:
   /// @brief Configuration
   std::shared_ptr<trossen::configuration::SessionManagerConfig> cfg_;
@@ -631,6 +660,60 @@ private:
    * @return Deduplicated, lifecycle-enabled components backing the producers
    */
   std::vector<std::shared_ptr<hw::HardwareComponent>> collect_lifecycle_components_() const;
+  // ── Session-control internals ──────────────────────────────────────────
+
+  /// @brief Recording-loop phase used to resolve state-dependent events.
+  ///
+  /// `interpret_event()` maps an abstract `SessionControlEvent` (e.g.
+  /// `kStart`) plus the current phase to a concrete `UserAction`. The
+  /// phase is set by `monitor_episode()` / `wait_for_reset()` as they
+  /// enter and leave their loops.
+  enum class Phase { kIdle, kRecording, kResetting };
+
+  /// @brief Attached session-control source (nullable). Single source at
+  /// a time; `attach_session_control()` enforces the invariant.
+  std::shared_ptr<hw::session_control::SessionControlCapable> session_control_;
+
+  /// @brief Event coalescing slot. The last event from the attached
+  /// source overwrites any prior pending event — human-scale input
+  /// should never queue up behind slow loop iterations.
+  std::atomic<hw::session_control::SessionControlEvent> pending_event_{
+    hw::session_control::SessionControlEvent::kNone};
+
+  /// @brief Set by the attached source's disconnect callback. Triggers a
+  /// clean halt in the next loop iteration: the partial episode is discarded,
+  /// then the session exits.
+  std::atomic<bool> source_disconnected_{false};
+
+  /// @brief Discard the in-flight episode, if any, and return `kStop`.
+  ///
+  /// Used on every session-control stop path. Not used for Ctrl+C, which
+  /// keeps its existing save-the-partial behaviour.
+  UserAction stop_discarding_partial();
+
+  /// @brief Mutex + condvar for the event channel. Replaces the prior
+  /// sleep-polling in the recording / reset loops. Also used as the
+  /// wakeup surface for `signal_reset_complete()` (kept backward-compatible).
+  std::mutex event_mutex_;
+  std::condition_variable event_cv_;
+
+  /// @brief Callback the attached source invokes on each detected intent.
+  /// Stores the event and wakes both the event condvar and the legacy
+  /// reset condvar so either loop wakes promptly.
+  void on_source_event(hw::session_control::SessionControlEvent ev);
+
+  /// @brief Callback the attached source invokes when it becomes
+  /// permanently unusable (Quest disconnects, stdin closes, etc.).
+  /// Flags the disconnect; loops observe it and halt cleanly.
+  void on_source_disconnect();
+
+  /// @brief Translate an event + phase into the corresponding UserAction.
+  ///
+  /// The dispatch table lives here so event sources never need to know
+  /// about the session's current phase.
+  UserAction interpret_event(
+    hw::session_control::SessionControlEvent ev,
+    Phase phase);
 };
 
 }  // namespace trossen::runtime

--- a/src/runtime/session_manager.cpp
+++ b/src/runtime/session_manager.cpp
@@ -78,6 +78,11 @@ SessionManager::SessionManager(){
 }
 
 SessionManager::~SessionManager() {
+  // Release the attached session-control source before tearing down the
+  // rest of the manager so its reader thread stops firing callbacks
+  // into a half-destructed object.
+  detach_session_control();
+
   // Ensure monitoring threads are stopped
   monitoring_active_ = false;
   if (monitor_thread_.joinable()) {
@@ -90,6 +95,111 @@ SessionManager::~SessionManager() {
   }
 
   shutdown();
+}
+
+void SessionManager::attach_session_control(
+  std::shared_ptr<hw::session_control::SessionControlCapable> source)
+{
+  if (!source) {
+    throw std::invalid_argument("attach_session_control: source must not be null");
+  }
+  if (session_control_) {
+    throw std::runtime_error(
+      "attach_session_control: a session-control source is already attached. "
+      "Call detach_session_control() first.");
+  }
+
+  // Reset the event channel so a stale event from a previous attach
+  // does not fire spuriously on the next loop tick.
+  pending_event_.store(hw::session_control::SessionControlEvent::kNone);
+  source_disconnected_.store(false);
+
+  session_control_ = std::move(source);
+  session_control_->set_callbacks(
+    [this](hw::session_control::SessionControlEvent ev) { on_source_event(ev); },
+    [this]() { on_source_disconnect(); });
+  session_control_->start();
+}
+
+void SessionManager::detach_session_control() {
+  if (!session_control_) return;
+  // Stop first so no further callbacks fire into the mutex we are about
+  // to touch.
+  session_control_->stop();
+  session_control_.reset();
+  pending_event_.store(hw::session_control::SessionControlEvent::kNone);
+  source_disconnected_.store(false);
+}
+
+void SessionManager::on_source_event(hw::session_control::SessionControlEvent ev) {
+  // Coalesce: the last intent wins. Queueing human button presses
+  // across slow loop iterations causes confusing cascades (start →
+  // immediate stop-early → start again).
+  pending_event_.store(ev);
+
+  // Wake both condvars. The recording loop waits on `event_cv_`; the
+  // reset loop waits on `reset_cv_` for backward compatibility with
+  // `signal_reset_complete()`.
+  event_cv_.notify_all();
+  reset_cv_.notify_all();
+}
+
+void SessionManager::on_source_disconnect() {
+  source_disconnected_.store(true);
+  event_cv_.notify_all();
+  reset_cv_.notify_all();
+}
+
+UserAction SessionManager::stop_discarding_partial() {
+  // A session-control stop lands wherever the operator happened to be, so the
+  // episode in flight is a fragment of a demonstration. Downstream, a truncated
+  // episode is indistinguishable from a complete one — it just teaches the wrong
+  // thing — so throw it away rather than leave the caller's stop_episode() to
+  // save it. Discarding also ends the episode, so a caller that still does
+  // `if (is_episode_active()) stop_episode();` finds nothing to do.
+  //
+  // Ctrl+C deliberately does NOT come through here: it keeps saving the partial,
+  // because that is what every existing session does today.
+  if (is_episode_active()) {
+    std::cout << "\n[session] stop requested mid-episode; discarding the partial "
+                 "recording." << std::endl;
+    discard_current_episode();
+  }
+  return UserAction::kStop;
+}
+
+UserAction SessionManager::interpret_event(
+  hw::session_control::SessionControlEvent ev,
+  Phase phase)
+{
+  using Event = hw::session_control::SessionControlEvent;
+
+  switch (ev) {
+    case Event::kStopSession:
+      return UserAction::kStop;
+
+    case Event::kRerecord:
+      // In both RECORDING and RESETTING the caller handles the discard
+      // (current vs. last); SessionManager only reports the intent.
+      rerecord_requested_.store(true);
+      return UserAction::kReRecord;
+
+    case Event::kStart:
+      // "Advance" — concrete meaning depends on phase.
+      if (phase == Phase::kResetting) {
+        reset_signaled_.store(true);
+      }
+      return UserAction::kContinue;
+
+    case Event::kStopEarly:
+      // Stop current recording; in RESETTING this is a no-op intent and
+      // we treat it as continue so the reset wait doesn't break oddly.
+      return UserAction::kContinue;
+
+    case Event::kNone:
+    default:
+      return UserAction::kContinue;
+  }
 }
 
 void SessionManager::shutdown() {
@@ -911,19 +1021,29 @@ UserAction SessionManager::wait_for_reset() {
   reset_signaled_.store(false);
   rerecord_requested_.store(false);
 
-  // Enable raw terminal input to detect keypresses without Enter
-  trossen::utils::RawModeGuard raw_mode;
+  // Raw terminal only when no session-control source is attached — an
+  // attached source owns its own terminal / reader.
+  const bool use_inline_keyboard = !static_cast<bool>(session_control_);
+  std::unique_ptr<trossen::utils::RawModeGuard> raw_mode;
+  if (use_inline_keyboard) {
+    raw_mode = std::make_unique<trossen::utils::RawModeGuard>();
+  }
 
-  // Helper: wait up to 100ms, waking early on signal_reset_complete()
+  // Helper: wait up to 100ms, waking early on signal_reset_complete(),
+  // a source event, or a source disconnect.
   auto wait_or_signal = [this]() {
     std::unique_lock<std::mutex> lk(reset_mutex_);
     reset_cv_.wait_for(lk, std::chrono::milliseconds(100), [this]() {
       return reset_signaled_.load() || rerecord_requested_.load() ||
-             trossen::utils::g_stop_requested;
+             trossen::utils::g_stop_requested ||
+             source_disconnected_.load() ||
+             pending_event_.load() !=
+               hw::session_control::SessionControlEvent::kNone;
     });
   };
 
-  auto poll_keys = [this]() -> UserAction {
+  auto poll_keys = [this, use_inline_keyboard]() -> UserAction {
+    if (!use_inline_keyboard) return UserAction::kContinue;
     auto key = trossen::utils::poll_keypress();
     if (key == trossen::utils::KeyPress::kRightArrow) {
       reset_signaled_.store(true);
@@ -934,6 +1054,18 @@ UserAction SessionManager::wait_for_reset() {
       return UserAction::kReRecord;
     }
     return UserAction::kContinue;
+  };
+
+  // Drain any pending event from the attached session-control source.
+  // Returns a non-kContinue action (or sets reset_signaled_) when the
+  // source's latest intent maps to one.
+  auto drain_source_event = [this]() -> UserAction {
+    auto pending = pending_event_.exchange(
+      hw::session_control::SessionControlEvent::kNone);
+    if (pending == hw::session_control::SessionControlEvent::kNone) {
+      return UserAction::kContinue;
+    }
+    return interpret_event(pending, Phase::kResetting);
   };
 
   if (cfg_->reset_duration.has_value()) {
@@ -953,31 +1085,41 @@ UserAction SessionManager::wait_for_reset() {
 
     for (int i = total_seconds; i > 0; --i) {
       if (trossen::utils::g_stop_requested || reset_signaled_.load()) break;
+      if (source_disconnected_.load()) return UserAction::kStop;
       if (rerecord_requested_.load()) return UserAction::kReRecord;
       std::cout << "  " << i << "...\n";
       for (int ms = 0; ms < 10; ++ms) {
         if (trossen::utils::g_stop_requested || reset_signaled_.load()) break;
+        if (source_disconnected_.load()) return UserAction::kStop;
         if (rerecord_requested_.load()) return UserAction::kReRecord;
+        auto source_action = drain_source_event();
+        if (source_action == UserAction::kReRecord) return UserAction::kReRecord;
+        if (source_action == UserAction::kStop) return UserAction::kStop;
         auto action = poll_keys();
         if (action == UserAction::kReRecord) return UserAction::kReRecord;
         wait_or_signal();
       }
     }
   } else {
-    // Infinite wait: block until keypress, signal, or Ctrl+C
+    // Infinite wait: block until keypress, signal, source event, or Ctrl+C
     std::cout << "\nWaiting for input...\n"
               << "  (-> continue | <- re-record)\n";
     trossen::utils::announce("Reset time. Waiting for input.");
 
     while (!trossen::utils::g_stop_requested &&
            !reset_signaled_.load() &&
-           !rerecord_requested_.load()) {
+           !rerecord_requested_.load() &&
+           !source_disconnected_.load()) {
+      auto source_action = drain_source_event();
+      if (source_action == UserAction::kReRecord) return UserAction::kReRecord;
+      if (source_action == UserAction::kStop) return UserAction::kStop;
       auto action = poll_keys();
       if (action == UserAction::kReRecord) return UserAction::kReRecord;
       wait_or_signal();
     }
   }
 
+  if (source_disconnected_.load()) return UserAction::kStop;
   if (trossen::utils::g_stop_requested) return UserAction::kStop;
   if (rerecord_requested_.load()) return UserAction::kReRecord;
   return UserAction::kContinue;
@@ -995,25 +1137,62 @@ UserAction SessionManager::monitor_episode(
 {
   rerecord_requested_.store(false);
 
-  // Enable raw terminal input to detect keypresses during recording
-  trossen::utils::RawModeGuard raw_mode;
+  // Enable raw terminal input to detect keypresses during recording —
+  // but only if no session-control source is attached. When a source is
+  // attached (e.g. a handle-button or VR button component) it owns
+  // the terminal / its own reader thread, and polling stdin in
+  // parallel would race on the same FD.
+  const bool use_inline_keyboard = !static_cast<bool>(session_control_);
+  std::unique_ptr<trossen::utils::RawModeGuard> raw_mode;
+  if (use_inline_keyboard) {
+    raw_mode = std::make_unique<trossen::utils::RawModeGuard>();
+  }
 
   auto last_update = std::chrono::steady_clock::now();
 
   while (!are_final_stats_emitted()) {
-    // Check for re-record request
+    // Halt on disconnect of the attached session-control source, throwing the
+    // partial recording away on the way out.
+    if (source_disconnected_.load()) {
+      return stop_discarding_partial();
+    }
+
+    // Drain any event pushed by the attached source. Coalescing means
+    // we only see the most recent intent — good enough for human-scale
+    // input and avoids cascades on slow loops.
+    auto pending = pending_event_.exchange(
+      hw::session_control::SessionControlEvent::kNone);
+    if (pending != hw::session_control::SessionControlEvent::kNone) {
+      auto action = interpret_event(pending, Phase::kRecording);
+      if (action == UserAction::kStop) return stop_discarding_partial();
+      if (action != UserAction::kContinue) return action;
+      // kStart / kStopEarly in RECORDING both mean "stop current and
+      // move on" — bubble up to the caller as kContinue so it calls
+      // stop_episode() and advances the index.
+      if (pending == hw::session_control::SessionControlEvent::kStart ||
+          pending == hw::session_control::SessionControlEvent::kStopEarly) {
+        return UserAction::kContinue;
+      }
+    }
+
+    // Legacy: re-record flag may be set by request_rerecord() from an
+    // external thread even without an attached source.
     if (rerecord_requested_.load()) {
       return UserAction::kReRecord;
     }
 
-    // Poll for arrow keys: left = re-record, right = early exit to next episode
-    auto key = trossen::utils::poll_keypress();
-    if (key == trossen::utils::KeyPress::kLeftArrow) {
-      rerecord_requested_.store(true);
-      return UserAction::kReRecord;
-    }
-    if (key == trossen::utils::KeyPress::kRightArrow) {
-      return UserAction::kContinue;
+    // Legacy: poll for arrow keys. Left = re-record, right = early exit.
+    // Skipped when a session-control source is attached — that source
+    // owns the terminal / its own reader.
+    if (use_inline_keyboard) {
+      auto key = trossen::utils::poll_keypress();
+      if (key == trossen::utils::KeyPress::kLeftArrow) {
+        rerecord_requested_.store(true);
+        return UserAction::kReRecord;
+      }
+      if (key == trossen::utils::KeyPress::kRightArrow) {
+        return UserAction::kContinue;
+      }
     }
 
     auto now = std::chrono::steady_clock::now();
@@ -1024,7 +1203,18 @@ UserAction SessionManager::monitor_episode(
       }
       last_update = now;
     }
-    std::this_thread::sleep_for(sleep_interval);
+
+    // Sleep on the event condvar rather than a bare sleep_for — an
+    // event or disconnect wakes us immediately; otherwise the stats
+    // tick fires on the timeout.
+    std::unique_lock<std::mutex> lk(event_mutex_);
+    event_cv_.wait_for(lk, sleep_interval, [this] {
+      return pending_event_.load() !=
+               hw::session_control::SessionControlEvent::kNone ||
+             source_disconnected_.load() ||
+             rerecord_requested_.load() ||
+             trossen::utils::g_stop_requested;
+    });
   }
 
   if (trossen::utils::g_stop_requested) return UserAction::kStop;


### PR DESCRIPTION
Lets hardware drive session state transitions. A source detects operator intent on its own thread and pushes it to the manager, instead of the manager polling for it. Stacked on #285.

- **`SessionControlCapable`** — `start()` / `stop()` plus two installed callbacks. Events are semantic intents (`kStart` = "advance"), not raw inputs, so a source needs to know nothing about the session's phase.
- **`interpret_event(event, phase)`** resolves intent plus phase to a `UserAction`: `kStart` means begin an episode when idle, stop-and-advance while recording, skip the wait while resetting.
- Events **wake the loop** through the existing condvars instead of being discovered on the next poll tick.

Two behavioural decisions worth a reviewer's attention:

**Events coalesce in a single slot rather than queueing.** Human-scale input should not stack up behind slow loop iterations — a queue turns two quick presses into a confusing cascade (start, immediate stop-early, start again). Latest intent wins.

**A session-control stop discards the episode in flight.** It lands wherever the operator happened to be, and downstream a truncated episode is indistinguishable from a complete one, so saving it teaches the wrong thing. Since discarding also ends the episode, a caller still doing `if (is_episode_active()) stop_episode();` finds nothing to do and needs no edit. **Ctrl+C is deliberately unchanged** and still saves the partial, because that is what every existing session does today.

Lifetime is handled by ordering rather than by weak pointers: `attach_session_control()` takes a `shared_ptr` and enforces one source at a time, and `~SessionManager()` detaches before tearing anything else down, so a source's reader thread cannot fire a callback into a half-destructed manager.

The legacy arrow-key polling and the `request_rerecord()` / `signal_reset_complete()` API are untouched, so existing sessions behave exactly as before.

Cherry-picked from `experimental/trossen-vr`, where this was already reviewed, rather than rewritten; the partial-discard behaviour is layered on top.