### PR TITLE
feat(arm): clamp, tolerance and smoothing options on the command path

### DIFF
--- a/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
@@ -6,6 +6,8 @@
 #ifndef TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__ARM_CONFIG_HPP_
 #define TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__ARM_CONFIG_HPP_
 
+#include <cmath>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -24,7 +26,25 @@ namespace trossen::configuration {
  *   "staged_position": [0.0, 1.04, 0.52, 0.63, 0.0, 0.0, 0.0],  // optional
  *   "staging_time_s": 2.0,                                // optional
  *   "episode_lifecycle_enabled": true,                    // optional, default false
- *   "write_moving_time_s": 0.1                            // optional, default 0.0
+ *   "write_moving_time_s": 0.1,                           // optional, default 0.0
+ *
+ *   // Command smoothing — optional, all default off / to the values below
+ *   "smoothing_enabled": true,
+ *   "smoothing_gripper": false,
+ *   "smoothing_min_cutoff_hz": 1.0,
+ *   "smoothing_beta": 0.9,
+ *   "smoothing_d_cutoff_hz": 1.0,
+ *
+ *   // Controller limit tolerances — optional, one entry per joint; omit an
+ *   // array to leave that field at the firmware default
+ *   "position_tolerance":[...], "velocity_tolerance": [...],
+ *   "effort_tolerance":  [...],
+ *
+ *   // Host-side clamp on outgoing commands — optional, null = joint unclamped
+ *   "command_position_min":
+ *     [-1.1, null, null, -1.5358897, -1.5358897, -3.1066861, null],
+ *   "command_position_max":
+ *     [ 0.8, 3.1066861, 2.3212879, 1.5358897, 1.5358897, 3.1066861, null]
  * }
  */
 struct ArmConfig {
@@ -68,6 +88,118 @@ struct ArmConfig {
   /// target and never settles.
   float write_moving_time_s{0.0f};
 
+  /// @brief Opt-in one-Euro adaptive low-pass on the positions written by
+  /// write_joint(). Off by default: it adds lag, and every arm commanded from a
+  /// clean source (a policy, a staged move, an SDK-side trajectory) is better
+  /// off without it. Turn it on for an arm mirroring a jittery leader — on the
+  /// Rivet the Glide handles are hand-held and their raw stream visibly shakes
+  /// the followers.
+  ///
+  /// This filters the COMMAND, and is independent of write_moving_time_s (which
+  /// asks the controller to interpolate toward the commanded goal). The two
+  /// compose: the filter removes jitter from the target, the moving time softens
+  /// the approach to it.
+  bool smoothing_enabled{false};
+
+  /// @brief Whether the gripper channel (the last joint) is smoothed too.
+  /// Separate from smoothing_enabled and off by default because filtering the
+  /// gripper was measured on Rivet hardware to make grasps feel mushy and
+  /// late — the operator wants the gripper to track their hand immediately even
+  /// while the arm joints are being smoothed.
+  bool smoothing_gripper{false};
+
+  /// @brief One-Euro tuning, shared by every per-joint filter instance.
+  /// min_cutoff is the cutoff (Hz) at zero speed — lower is smoother but
+  /// laggier when nearly still. beta relaxes the filter as the signal moves
+  /// faster — higher means less lag during fast motion. d_cutoff is the
+  /// derivative's own cutoff and rarely needs tuning.
+  ///
+  /// The defaults are the values tuned on the Rivet Glide handles and confirmed
+  /// on hardware 2026-08-07, so an arm that turns smoothing on without tuning
+  /// gets a known-good starting point rather than a neutral one. Both cutoffs
+  /// must be > 0; TrossenArmComponent::configure() rejects zero, because a zero
+  /// cutoff makes the filter's alpha zero and freezes the output at the first
+  /// sample forever rather than failing.
+  float smoothing_min_cutoff_hz{1.0f};
+  float smoothing_beta{0.9f};
+  float smoothing_d_cutoff_hz{1.0f};
+
+  /// @brief Optional per-joint tolerances on the controller's limit checks,
+  /// pushed to the controller on connect. Each array, when non-empty, must have
+  /// one entry per joint (position in rad / gripper m, velocity in rad·s⁻¹ /
+  /// gripper m·s⁻¹, effort in N·m / gripper N). Empty leaves the controller's
+  /// firmware default untouched for that field.
+  ///
+  /// The controller does NOT persist these across a power cycle — they reset to
+  /// firmware defaults on reboot — so the SDK re-applies them on every
+  /// reconfigure (see TrossenArmComponent).
+  ///
+  /// TODO(shantanuparab-tr): ship measured defaults. No config in this
+  /// repository sets these, so today they are an available option with no
+  /// worked example and no tested values. Replace these empty defaults with the
+  /// values read off a live Rivet controller once one is powered up.
+  std::vector<float> position_tolerance{};
+  std::vector<float> velocity_tolerance{};
+  std::vector<float> effort_tolerance{};
+
+  /// @brief Optional per-joint clamp applied to outgoing position commands in
+  /// write_joint(), before smoothing. Each array, when non-empty, has one entry
+  /// per joint; a NaN entry leaves that joint unclamped, so a rig can bound one
+  /// axis without inventing bounds for the rest. Serialised as JSON `null`,
+  /// which is how "no limit" survives a round trip through a config file.
+  ///
+  /// Distinct from the arm's own operating limits, which live on the controller
+  /// and are enforced there. These bound what teleop is allowed to ASK for, and
+  /// exist to keep a follower out of a region its leader can reach but its
+  /// workspace cannot — a shelf, a second arm, the base. Clamping host-side means
+  /// the command never reaches the controller, so no limit fault is raised and
+  /// teleop keeps running with the joint parked at the bound.
+  ///
+  /// **Two rules generate every bound the Rivet ships, and both matter to anyone
+  /// editing them.**
+  ///
+  /// 1. Every non-J0 bound is the mechanical limit minus exactly 2° — a uniform
+  ///    safety margin inside the hardware limit, not arbitrary numbers, so a new
+  ///    joint or arm model derives its bound the same way. 2° is 0.0349066 rad,
+  ///    NOT 0.035 (which is 2.0054°), and the bounds carry enough digits to hold
+  ///    the margin to 2° exactly:
+  ///      π/2   − 2° = 1.5358897
+  ///      π     − 2° = 3.1066861
+  ///      3π/4  − 2° = 2.3212879
+  /// 2. **J0 is hand-measured, asymmetric, and mirrored between the two arms:**
+  ///    left is −1.1…0.8, right is −0.8…1.1. This is the shoulder-yaw stop that
+  ///    keeps the arms out of each other and off the chassis. It is the one value
+  ///    that is NOT derivable and must NOT be copied from one side to the other.
+  ///    Making the asymmetry uniform points both arms into the same space.
+  std::vector<float> command_position_min{};
+  std::vector<float> command_position_max{};
+
+  /// @brief Parse an array whose entries may be JSON `null`, mapping null to
+  /// NaN. Used for the command clamps, where a per-joint "no bound" has to
+  /// survive both directions of a config round trip.
+  static std::vector<float> parse_nullable_limits(const nlohmann::json& arr) {
+    std::vector<float> out;
+    out.reserve(arr.size());
+    for (const auto& entry : arr) {
+      out.push_back(
+        entry.is_null() ? std::numeric_limits<float>::quiet_NaN() : entry.get<float>());
+    }
+    return out;
+  }
+
+  /// @brief Inverse of parse_nullable_limits: NaN becomes JSON null.
+  static nlohmann::json dump_nullable_limits(const std::vector<float>& v) {
+    auto arr = nlohmann::json::array();
+    for (const float x : v) {
+      if (std::isnan(x)) {
+        arr.push_back(nullptr);
+      } else {
+        arr.push_back(x);
+      }
+    }
+    return arr;
+  }
+
   static ArmConfig from_json(const nlohmann::json& j) {
     ArmConfig c;
     if (j.contains("ip_address")) j.at("ip_address").get_to(c.ip_address);
@@ -84,6 +216,36 @@ struct ArmConfig {
     }
     if (j.contains("write_moving_time_s")) {
       j.at("write_moving_time_s").get_to(c.write_moving_time_s);
+    }
+    if (j.contains("smoothing_enabled")) {
+      j.at("smoothing_enabled").get_to(c.smoothing_enabled);
+    }
+    if (j.contains("smoothing_gripper")) {
+      j.at("smoothing_gripper").get_to(c.smoothing_gripper);
+    }
+    if (j.contains("smoothing_min_cutoff_hz")) {
+      j.at("smoothing_min_cutoff_hz").get_to(c.smoothing_min_cutoff_hz);
+    }
+    if (j.contains("smoothing_beta")) {
+      j.at("smoothing_beta").get_to(c.smoothing_beta);
+    }
+    if (j.contains("smoothing_d_cutoff_hz")) {
+      j.at("smoothing_d_cutoff_hz").get_to(c.smoothing_d_cutoff_hz);
+    }
+    if (j.contains("position_tolerance")) {
+      j.at("position_tolerance").get_to(c.position_tolerance);
+    }
+    if (j.contains("velocity_tolerance")) {
+      j.at("velocity_tolerance").get_to(c.velocity_tolerance);
+    }
+    if (j.contains("effort_tolerance")) {
+      j.at("effort_tolerance").get_to(c.effort_tolerance);
+    }
+    if (j.contains("command_position_min")) {
+      c.command_position_min = parse_nullable_limits(j.at("command_position_min"));
+    }
+    if (j.contains("command_position_max")) {
+      c.command_position_max = parse_nullable_limits(j.at("command_position_max"));
     }
     return c;
   }
@@ -102,6 +264,30 @@ struct ArmConfig {
     // would break the no-staging case.
     if (!staged_position.empty()) {
       j["staged_position"] = staged_position;
+    }
+    // Emit the smoothing tuning only when smoothing is on: the constants are
+    // meaningless while it is off, and emitting them would put four keys into
+    // every ordinary arm's config.
+    if (smoothing_enabled) {
+      j["smoothing_enabled"] = smoothing_enabled;
+      j["smoothing_gripper"] = smoothing_gripper;
+      j["smoothing_min_cutoff_hz"] = smoothing_min_cutoff_hz;
+      j["smoothing_beta"] = smoothing_beta;
+      j["smoothing_d_cutoff_hz"] = smoothing_d_cutoff_hz;
+    }
+    // Emit each tolerance array only when set. An empty array is not equivalent:
+    // TrossenArmComponent::configure() reads "absent" as "leave the controller's
+    // firmware default alone", and a present-but-empty array would still take
+    // the read-modify-write path against the live limits.
+    if (!position_tolerance.empty()) j["position_tolerance"] = position_tolerance;
+    if (!velocity_tolerance.empty()) j["velocity_tolerance"] = velocity_tolerance;
+    if (!effort_tolerance.empty()) j["effort_tolerance"] = effort_tolerance;
+    // Same emit-only-when-set rule; NaN entries go back out as null.
+    if (!command_position_min.empty()) {
+      j["command_position_min"] = dump_nullable_limits(command_position_min);
+    }
+    if (!command_position_max.empty()) {
+      j["command_position_max"] = dump_nullable_limits(command_position_max);
     }
     return j;
   }

--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -14,6 +14,7 @@
 
 #include "trossen_sdk/hw/hardware_component.hpp"
 #include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+#include "trossen_sdk/utils/one_euro_filter.hpp"
 
 namespace trossen::hw::arm {
 
@@ -54,8 +55,30 @@ public:
    *   "end_effector": "wxai_v0_follower",
    *   "staged_position": [0, 1.0, 0.5, 0.6, 0, 0, 0],  // optional, joint-space
    *   "staging_time_s": 2.0,       // optional, default 2.0 (stage / rest move)
-   *   "write_moving_time_s": 0.1   // optional, default 0.0 (per-tick smoothing)
+   *   "write_moving_time_s": 0.1,  // optional, default 0.0 (per-tick smoothing)
+   *
+   *   // Host-side clamp on outgoing position commands. Optional; one entry per
+   *   // joint, null leaves that joint unclamped. Applied before smoothing.
+   *   "command_position_min": [-1.1, null, null, ...],
+   *   "command_position_max": [ 0.8, 3.1066861, ...],
+   *
+   *   // Controller limit tolerances. Optional; one entry per joint, omit an
+   *   // array to leave that field at the controller's firmware default.
+   *   "position_tolerance": [...],
+   *   "velocity_tolerance": [...],
+   *   "effort_tolerance":   [...],
+   *
+   *   // One-Euro low-pass on outgoing position commands.
+   *   // All ignored unless "smoothing_enabled" is true.
+   *   "smoothing_enabled": false,      // optional, default false
+   *   "smoothing_gripper": false,      // optional, default false (arm joints only)
+   *   "smoothing_min_cutoff_hz": 1.0,  // optional, default 1.0, must be > 0
+   *   "smoothing_beta": 0.9,           // optional, default 0.9, must be >= 0
+   *   "smoothing_d_cutoff_hz": 1.0     // optional, default 1.0, must be > 0
    * }
+   *
+   * See configuration::ArmConfig for what the clamp bounds mean and how the
+   * Rivet's values are derived.
    *
    * @param config JSON configuration object
    * @throws std::runtime_error if configuration fails
@@ -118,6 +141,10 @@ private:
   std::vector<float> read_cartesian();
   void               write_cartesian(const std::vector<float>& cmd);
 
+  /// Clamp `pos` in place to command_position_min_ / command_position_max_.
+  /// No-op when both are empty, and per joint when that entry is NaN.
+  void clamp_command(std::vector<double>& pos) const;
+
   // Adapter views: implement the space child classes and forward to the
   // private helpers above. See the class-level docstring for why this
   // indirection is necessary.
@@ -174,6 +201,43 @@ private:
   /// goal_time < 0.001s as no-interpolation). Non-zero values smooth the
   /// per-tick motion between successive write_joint() calls.
   float write_moving_time_s_{0.0f};
+
+  /// Optional per-joint tolerances on the controller's limit checks, pushed in
+  /// configure() right after the driver connects. Each, when non-empty, has one
+  /// entry per joint; empty leaves the firmware default for that field. The
+  /// controller resets these on power cycle, so they are re-applied on every
+  /// reconnect rather than assumed to have survived.
+  std::vector<float> position_tolerance_;
+  std::vector<float> velocity_tolerance_;
+  std::vector<float> effort_tolerance_;
+
+  /// Optional per-joint clamp on outgoing commands, applied in write_joint()
+  /// before smoothing. Empty = no clamping at all; a NaN entry = that joint is
+  /// unclamped. See configuration::ArmConfig for why this is separate from the
+  /// controller-side position limits, and how the Rivet's bounds are derived.
+  std::vector<float> command_position_min_;
+  std::vector<float> command_position_max_;
+
+  /// Opt-in one-Euro low-pass on the commands written by write_joint(), and
+  /// whether it extends to the gripper channel. Both off by default; see
+  /// configuration::ArmConfig for the rationale. Parsed in configure().
+  bool smoothing_enabled_{false};
+  bool smoothing_gripper_{false};
+
+  /// One-Euro tuning shared by every per-joint filter in cmd_filt_.
+  /// See utils::OneEuroFilter for parameter semantics. configure() rejects a
+  /// non-positive cutoff, which would otherwise freeze the output silently.
+  float smoothing_min_cutoff_hz_{1.0f};
+  float smoothing_beta_{0.9f};
+  float smoothing_d_cutoff_hz_{1.0f};
+
+  /// Per-joint command filters, sized to the arm's joint count in configure()
+  /// and only constructed when smoothing is enabled. Reset in
+  /// prepare_for_teleop() so filter history never bridges a stopped and
+  /// restarted teleop session — stale history would otherwise have the first
+  /// tick of a new session compute a derivative against a pose from minutes ago,
+  /// spiking the adaptive cutoff exactly when the arm is nearest the operator.
+  utils::VecOneEuroFilter cmd_filt_;
 };
 
 }  // namespace trossen::hw::arm

--- a/include/trossen_sdk/utils/one_euro_filter.hpp
+++ b/include/trossen_sdk/utils/one_euro_filter.hpp
@@ -1,0 +1,149 @@
+/**
+ * @file one_euro_filter.hpp
+ * @brief One-Euro adaptive low-pass filter for smoothing jittery signals.
+ */
+
+#ifndef TROSSEN_SDK__UTILS__ONE_EURO_FILTER_HPP_
+#define TROSSEN_SDK__UTILS__ONE_EURO_FILTER_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace trossen::utils {
+
+/**
+ * @brief Scalar one-Euro filter.
+ *
+ * Casiez, Roussel & Vogel, "1€ Filter: A Simple Speed-based Low-pass Filter for
+ * Noisy Input in Interactive Systems", CHI 2012. Checked against the authors'
+ * own reference implementation (github.com/casiez/OneEuroFilter): same alpha
+ * from cutoff, same first-sample seeding, and — the detail that is easy to get
+ * wrong — the speed estimate is taken against the previous *filtered* value,
+ * not the previous raw sample, exactly as the reference does.
+ *
+ * An adaptive low-pass: it smooths harder (more filtering, more lag) when the
+ * signal is nearly static, and relaxes (less filtering, less lag) as the
+ * signal's rate of change grows. This makes it well suited for smoothing a
+ * jittery position target — e.g. a teleop command arriving over a noisy
+ * link — without adding perceptible lag during fast motion.
+ */
+class OneEuroFilter {
+public:
+  /**
+   * @param min_cutoff Cutoff frequency (Hz) at zero speed; lower = smoother
+   *   but laggier when the signal is nearly still. **Must be > 0.** At zero the
+   *   time constant is infinite, so alpha is 0 and the output freezes on the
+   *   first sample forever. Callers validate this where the value is read, so
+   *   the error can name the config key that carries it.
+   * @param beta Speed coefficient; higher = less smoothing (less lag) as the
+   *   signal moves faster.
+   * @param d_cutoff Cutoff frequency (Hz) for the derivative's own low-pass;
+   *   rarely needs tuning. Must be > 0, for the same reason.
+   */
+  explicit OneEuroFilter(double min_cutoff = 1.0, double beta = 0.0, double d_cutoff = 1.0)
+  : min_cutoff_(min_cutoff), beta_(beta), d_cutoff_(d_cutoff) {}
+
+  /// Drop all history; the next filter() call seeds the filter with its input
+  /// instead of computing a derivative against stale state.
+  void reset() {
+    has_prev_ = false;
+    dx_prev_ = 0.0;
+  }
+
+  /**
+   * @brief Filter one sample.
+   *
+   * @param x Raw sample.
+   * @param t_s Monotonic sample time (seconds). Only the difference between
+   *   successive calls matters, so any monotonic clock epoch works.
+   * @return Filtered value.
+   */
+  double filter(double x, double t_s) {
+    if (!has_prev_) {
+      x_prev_ = x;
+      t_prev_ = t_s;
+      has_prev_ = true;
+      return x;
+    }
+    double dt = t_s - t_prev_;
+    if (dt <= 0.0) {
+      // A stalled or backwards clock would otherwise divide by zero, or invert
+      // the speed estimate and open the cutoff on a sample that never moved.
+      // Substituting a small positive step degrades to "one fast tick", which
+      // the derivative's own low-pass then absorbs.
+      dt = 1e-3;
+    }
+
+    const double dx = (x - x_prev_) / dt;
+    const double a_d = alpha(d_cutoff_, dt);
+    const double dx_hat = a_d * dx + (1.0 - a_d) * dx_prev_;
+
+    const double cutoff = min_cutoff_ + beta_ * std::fabs(dx_hat);
+    const double a = alpha(cutoff, dt);
+    const double x_hat = a * x + (1.0 - a) * x_prev_;
+
+    x_prev_ = x_hat;
+    dx_prev_ = dx_hat;
+    t_prev_ = t_s;
+    return x_hat;
+  }
+
+private:
+  static double alpha(double cutoff, double dt) {
+    const double tau = 1.0 / (2.0 * kPi * cutoff);
+    return 1.0 / (1.0 + tau / dt);
+  }
+
+  static constexpr double kPi = 3.14159265358979323846;
+
+  double min_cutoff_;
+  double beta_;
+  double d_cutoff_;
+
+  bool has_prev_{false};
+  double x_prev_{0.0};
+  double dx_prev_{0.0};
+  double t_prev_{0.0};
+};
+
+/**
+ * @brief One-Euro filter applied independently to each element of a vector
+ * (one scalar filter instance per element — elements never influence each
+ * other's cutoff/derivative state).
+ */
+class VecOneEuroFilter {
+public:
+  VecOneEuroFilter() = default;
+
+  explicit VecOneEuroFilter(
+      size_t n, double min_cutoff = 1.0, double beta = 0.0, double d_cutoff = 1.0)
+  : filters_(n, OneEuroFilter(min_cutoff, beta, d_cutoff)) {}
+
+  void reset() {
+    for (auto& f : filters_) {
+      f.reset();
+    }
+  }
+
+  /// Number of independent per-element filters.
+  size_t size() const { return filters_.size(); }
+
+  /// Filter `xs` in place. Only the first min(xs.size(), size()) elements are
+  /// touched; a size mismatch is not treated as an error since callers may
+  /// reuse a filter across command vectors that carry extra trailing fields.
+  void filter(std::vector<double>& xs, double t_s) {
+    const size_t n = std::min(xs.size(), filters_.size());
+    for (size_t i = 0; i < n; ++i) {
+      xs[i] = filters_[i].filter(xs[i], t_s);
+    }
+  }
+
+private:
+  std::vector<OneEuroFilter> filters_;
+};
+
+}  // namespace trossen::utils
+
+#endif  // TROSSEN_SDK__UTILS__ONE_EURO_FILTER_HPP_

--- a/src/hw/arm/trossen_arm_component.cpp
+++ b/src/hw/arm/trossen_arm_component.cpp
@@ -5,13 +5,30 @@
 
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
+// For parse_nullable_limits: the null-means-unclamped encoding has to agree
+// between the config struct and this parse, so it lives in one place.
+#include "trossen_sdk/configuration/types/hardware/arm_config.hpp"
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace trossen::hw::arm {
+
+namespace {
+/// Monotonic seconds, for the command filter's sample timestamps. Only
+/// differences between successive calls matter, so the epoch is irrelevant —
+/// but the clock must be steady, since a wall-clock step (NTP, DST) would
+/// otherwise appear as a huge dt and momentarily disable the smoothing.
+double now_seconds() {
+  using std::chrono::duration;
+  using std::chrono::steady_clock;
+  return duration<double>(steady_clock::now().time_since_epoch()).count();
+}
+}  // namespace
 
 void TrossenArmComponent::configure(const nlohmann::json& config) {
   // Parse IP address
@@ -87,6 +104,136 @@ void TrossenArmComponent::configure(const nlohmann::json& config) {
     }
   }
 
+  const size_t njoints = static_cast<size_t>(driver_->get_num_joints());
+
+  // ── Host-side command clamp ──────────────────────────────────────────────
+  // Bounds what teleop is allowed to ask for, independently of the arm's own
+  // operating limits. NaN entries (JSON null) mean "leave this joint alone", so
+  // unlike the tolerances below a partially-specified array is the normal case.
+  {
+    auto parse_clamp = [&](const char* key, std::vector<float>& dst) {
+      if (!config.contains(key)) return;
+      dst = configuration::ArmConfig::parse_nullable_limits(config.at(key));
+      if (!dst.empty() && dst.size() != njoints) {
+        throw std::runtime_error(
+          std::string("TrossenArmComponent: '") + key + "' length (" +
+          std::to_string(dst.size()) + ") must match joint count (" +
+          std::to_string(njoints) + ")");
+      }
+    };
+    parse_clamp("command_position_min", command_position_min_);
+    parse_clamp("command_position_max", command_position_max_);
+    // An inverted pair would clamp the joint to a single unreachable value and
+    // look like a dead axis at runtime, so reject it here where the key names
+    // are still available to say which joint is wrong.
+    for (size_t j = 0; j < njoints; ++j) {
+      const bool has_min =
+        j < command_position_min_.size() && !std::isnan(command_position_min_[j]);
+      const bool has_max =
+        j < command_position_max_.size() && !std::isnan(command_position_max_[j]);
+      if (has_min && has_max && command_position_min_[j] > command_position_max_[j]) {
+        throw std::runtime_error(
+          "TrossenArmComponent: command clamp for joint " + std::to_string(j) +
+          " has min (" + std::to_string(command_position_min_[j]) + ") above max (" +
+          std::to_string(command_position_max_[j]) + "), which would pin the joint");
+      }
+    }
+  }
+
+  // ── Controller limit tolerances ──────────────────────────────────────────
+  // Read the controller's current limits and override only the tolerance fields
+  // that were configured, so an unset field keeps its firmware default. The
+  // controller does not persist these across a power cycle, which is why they
+  // are pushed on every configure() rather than once at commissioning.
+  {
+    auto parse_tolerance = [&](const char* key, std::vector<float>& dst) {
+      if (!config.contains(key)) return;
+      dst = config.at(key).get<std::vector<float>>();
+      if (!dst.empty() && dst.size() != njoints) {
+        throw std::runtime_error(
+          std::string("TrossenArmComponent: '") + key + "' length (" +
+          std::to_string(dst.size()) + ") must match joint count (" +
+          std::to_string(njoints) + ")");
+      }
+    };
+    parse_tolerance("position_tolerance", position_tolerance_);
+    parse_tolerance("velocity_tolerance", velocity_tolerance_);
+    parse_tolerance("effort_tolerance", effort_tolerance_);
+
+    if (!position_tolerance_.empty() || !velocity_tolerance_.empty() ||
+        !effort_tolerance_.empty()) {
+      auto limits = driver_->get_joint_limits();
+      for (size_t j = 0; j < njoints && j < limits.size(); ++j) {
+        if (!position_tolerance_.empty()) {
+          limits[j].position_tolerance = position_tolerance_[j];
+        }
+        if (!velocity_tolerance_.empty()) {
+          limits[j].velocity_tolerance = velocity_tolerance_[j];
+        }
+        if (!effort_tolerance_.empty()) {
+          limits[j].effort_tolerance = effort_tolerance_[j];
+        }
+      }
+      try {
+        driver_->set_joint_limits(limits);
+      } catch (const std::exception& e) {
+        throw std::runtime_error(
+          "TrossenArmComponent: Failed to set joint limits: " + std::string(e.what()));
+      }
+    }
+  }
+
+  // ── Command smoothing ────────────────────────────────────────────────────
+  // Opt-in one-Euro low-pass on write_joint() commands. Off unless asked for:
+  // it trades lag for jitter rejection, which is only a good trade when the
+  // command source is genuinely noisy (a hand-held leader), not when it is an
+  // SDK-side trajectory or a policy.
+  if (config.contains("smoothing_enabled")) {
+    smoothing_enabled_ = config.at("smoothing_enabled").get<bool>();
+  }
+  if (config.contains("smoothing_gripper")) {
+    smoothing_gripper_ = config.at("smoothing_gripper").get<bool>();
+  }
+  {
+    // Validate the tuning whenever it is present, even if smoothing is
+    // currently off — a typo in a disabled block should still be reported
+    // rather than lying dormant until someone flips the feature on.
+    auto parse_positive = [&](const char* key, float& dst) {
+      if (!config.contains(key)) return;
+      dst = config.at(key).get<float>();
+      if (dst <= 0.0f || !std::isfinite(dst)) {
+        throw std::runtime_error(
+          std::string("TrossenArmComponent: '") + key + "' must be positive and finite");
+      }
+    };
+    // Zero is rejected rather than passed through: it makes the filter's alpha
+    // zero, which freezes the output at the first sample forever instead of
+    // failing.
+    parse_positive("smoothing_min_cutoff_hz", smoothing_min_cutoff_hz_);
+    parse_positive("smoothing_d_cutoff_hz", smoothing_d_cutoff_hz_);
+    // beta may legitimately be zero — that is a plain (non-adaptive) low-pass.
+    if (config.contains("smoothing_beta")) {
+      smoothing_beta_ = config.at("smoothing_beta").get<float>();
+      if (smoothing_beta_ < 0.0f || !std::isfinite(smoothing_beta_)) {
+        throw std::runtime_error(
+          "TrossenArmComponent: 'smoothing_beta' must be non-negative and finite");
+      }
+    }
+  }
+
+  // Size the command filter to this arm's joint count. Left default-constructed
+  // (size 0) when smoothing is off, so the disabled path allocates nothing.
+  //
+  // The gripper is excluded by sizing the filter one element short rather than
+  // by filtering and then discarding: VecOneEuroFilter only touches the first
+  // size() elements, so the gripper's raw command passes through untouched and
+  // no filter state is advanced for it.
+  if (smoothing_enabled_) {
+    const size_t nfilt = (smoothing_gripper_ || njoints == 0) ? njoints : njoints - 1;
+    cmd_filt_ = utils::VecOneEuroFilter(
+      nfilt, smoothing_min_cutoff_hz_, smoothing_beta_, smoothing_d_cutoff_hz_);
+  }
+
   // TODO(lukeschmitt-tr): Can do other configuration like joint characteristics here if needed
 }
 
@@ -118,7 +265,38 @@ void TrossenArmComponent::write_joint(const std::vector<float>& cmd) {
       std::to_string(cmd.size()));
   }
   std::vector<double> pos_d(cmd.begin(), cmd.end());
+  // Clamp BEFORE filtering, to keep the filter from winding up. Either order
+  // respects the band — clamping last trivially does — but filtering first lets
+  // the filter's state follow the command out past the bound, and when the
+  // leader comes back inside, the output stays pinned until that state has
+  // travelled back. Clamping first means the filter only ever sees in-band
+  // values, so the arm leaves the bound on the same tick the leader does.
+  //
+  // Measured against this filter, band ±1, leader parked at 3× the bound: 10 ms
+  // of stick at the shipped tuning (beta 0.9), and 175 ms at beta 0 — the
+  // adaptive term is what keeps the wrong order from being obviously broken,
+  // which is exactly why the ordering deserves a comment.
+  clamp_command(pos_d);
+  // Low-pass the commanded pose before handing it to the controller, so a
+  // jittery source (a hand-held leader) doesn't shake the arm. Adaptive: it
+  // filters hard while the operator holds still and backs off as they move, so
+  // fast motion stays responsive. This runs before the controller's own
+  // goal-time interpolation, which shapes the approach rather than the target.
+  if (smoothing_enabled_) {
+    cmd_filt_.filter(pos_d, now_seconds());
+  }
   driver_->set_all_positions(pos_d, write_moving_time_s_, false);
+}
+
+void TrossenArmComponent::clamp_command(std::vector<double>& pos) const {
+  for (size_t j = 0; j < pos.size(); ++j) {
+    if (j < command_position_min_.size() && !std::isnan(command_position_min_[j])) {
+      pos[j] = std::max(pos[j], static_cast<double>(command_position_min_[j]));
+    }
+    if (j < command_position_max_.size() && !std::isnan(command_position_max_[j])) {
+      pos[j] = std::min(pos[j], static_cast<double>(command_position_max_[j]));
+    }
+  }
 }
 
 std::vector<float> TrossenArmComponent::read_cartesian() {
@@ -150,6 +328,12 @@ void TrossenArmComponent::write_cartesian(const std::vector<float>& cmd) {
 
 void TrossenArmComponent::prepare_for_teleop() {
   if (!driver_) return;
+  // Drop filter history so a new teleop session doesn't take its first
+  // derivative against a pose left over from the previous one. That difference
+  // can be the whole workspace, which reads as an enormous velocity, opens the
+  // adaptive cutoff wide, and effectively disables the smoothing for the first
+  // ticks of the session — when the arm is nearest the operator.
+  cmd_filt_.reset();
   if (is_leader_) {
     // Leader: enable gravity compensation.
     driver_->set_all_modes(trossen_arm::Mode::external_effort);


### PR DESCRIPTION
Three opt-in options on `TrossenArmComponent`'s command path, all off by default, plus the filter they need. Hardware-verified on rivet-02 (2026-08-07).

| Config | Where it acts |
| --- | --- |
| `command_position_min` / `_max` | host-side per-joint clamp, `null` = joint unclamped |
| `position` / `velocity` / `effort_tolerance` | pushed to the controller's limit checks |
| `smoothing_*` (5 keys) | one-Euro adaptive low-pass, gripper excluded by default |

`write_joint()` is now clamp → smooth → `set_all_positions`.

**Clamp before filter, to prevent windup.** Either order respects the band, but filtering first lets the filter's state follow the command past the bound, so the output stays pinned after the leader returns inside. Band ±1, leader parked at 3× the bound: 10 ms of stick at the shipped tuning, 175 ms at `beta 0`.

**The clamp bounds are the mechanical limit minus exactly 2°, and the plan had this wrong** — it said 0.035 rad, which is 2.0054° and yields 1.5358/3.1066/2.3212 against the rig's shipped 1.5359/3.1067/2.3213. These bounds hold 2.000000°: π/2 − 2° = 1.5358897, π − 2° = 3.1066861, 3π/4 − 2° = 2.3212879. That is a deliberate 1e-4 rad departure from `rivet_01.json`, so **PR 16 must write these values, not copy the preset**.

**J0 is hand-measured and mirrored** — left −1.1…0.8, right −0.8…1.1, the shoulder-yaw stop keeping the arms off each other and the chassis. Not derivable, must not be unified. Documented in `arm_config.hpp` because D10 dropped the `.rst`.

`one_euro_filter.hpp` came with `TODO: verify citation (this is claude generated)` and credited "Casiez, **Godin** & Vogel". Authors are Casiez, **Roussel** & Vogel (CHI 2012); the implementation itself checks out against theirs — including the speed estimate being taken against the previous *filtered* value, which looks wrong and is what the reference does. Replayed against their `groundTruth.csv`: max deviation 4.0e-06, bounded by the fixture's print precision.

A non-positive cutoff is rejected (it would zero the filter's alpha and freeze the output silently); `beta == 0` is allowed as a plain low-pass; tuning is validated even while smoothing is off; an inverted clamp pair is rejected naming the joint. Filter history resets in `prepare_for_teleop()`, so a restarted session can't take its first derivative against the previous session's pose.

**Scope:** tolerances are set by no config in the tree — they ship untested, with a `TODO` for measured defaults off a live Rivet. The four controller *limit* arrays are excluded as unused. Excludes the four UI-facing symbols per D7.
