### PR TITLE
feat(arm): passive leader and gripper force feedback

### DIFF
--- a/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/arm_config.hpp
@@ -27,6 +27,13 @@ namespace trossen::configuration {
  *   "staging_time_s": 2.0,                                // optional
  *   "episode_lifecycle_enabled": true,                    // optional, default false
  *   "write_moving_time_s": 0.1,                           // optional, default 0.0
+ *   "actuated": false,                                    // optional, default true
+ *
+ *   // Leader gripper force feedback — optional, off by default
+ *   "gripper_force_feedback": true,
+ *   "gripper_feedback_leader_max":   27.0,
+ *   "gripper_feedback_follower_max": 87.5,
+ *   "gripper_feedback_offset":        8.0,
  *
  *   // Command smoothing — optional, all default off / to the values below
  *   "smoothing_enabled": true,
@@ -87,6 +94,31 @@ struct ArmConfig {
   /// is superseded before it is reached, so the arm perpetually chases a moving
   /// target and never settles.
   float write_moving_time_s{0.0f};
+
+  /// @brief Whether the arm has actuators. A passive leader (e.g. the
+  /// lightweight Trossen leader) only streams joint positions and cannot be
+  /// commanded, so teleop staging / mode setup / rest moves are skipped.
+  bool actuated{true};
+
+  /// @brief Leader-only: render gripper force feedback. When true, the teleop
+  /// loop reflects the FOLLOWER's measured gripper effort back onto this
+  /// gripper, so the operator feels the grasp. The leader's arm joints may
+  /// still be passive — only the gripper needs a motor. The follower gripper
+  /// stays plain position passthrough.
+  bool gripper_force_feedback{false};
+
+  /// @brief Cubic feedback constants (N), from the bilateral reference:
+  /// leader effort at full grip, the follower effort treated as full grip (the
+  /// normalizer), and a baseline opening offset that keeps the leader gripper
+  /// open when nothing is grasped.
+  ///
+  /// leader = leader_max·norm³ + offset, where
+  /// norm = clamp(|follower_effort| / follower_max, 0, 1). Cubic rather than
+  /// linear so light contact stays light and resistance builds sharply only
+  /// near a firm grip.
+  float gripper_feedback_leader_max{27.0f};
+  float gripper_feedback_follower_max{87.5f};
+  float gripper_feedback_offset{8.0f};
 
   /// @brief Opt-in one-Euro adaptive low-pass on the positions written by
   /// write_joint(). Off by default: it adds lag, and every arm commanded from a
@@ -217,6 +249,19 @@ struct ArmConfig {
     if (j.contains("write_moving_time_s")) {
       j.at("write_moving_time_s").get_to(c.write_moving_time_s);
     }
+    if (j.contains("actuated")) j.at("actuated").get_to(c.actuated);
+    if (j.contains("gripper_force_feedback")) {
+      j.at("gripper_force_feedback").get_to(c.gripper_force_feedback);
+    }
+    if (j.contains("gripper_feedback_leader_max")) {
+      j.at("gripper_feedback_leader_max").get_to(c.gripper_feedback_leader_max);
+    }
+    if (j.contains("gripper_feedback_follower_max")) {
+      j.at("gripper_feedback_follower_max").get_to(c.gripper_feedback_follower_max);
+    }
+    if (j.contains("gripper_feedback_offset")) {
+      j.at("gripper_feedback_offset").get_to(c.gripper_feedback_offset);
+    }
     if (j.contains("smoothing_enabled")) {
       j.at("smoothing_enabled").get_to(c.smoothing_enabled);
     }
@@ -257,8 +302,19 @@ struct ArmConfig {
       {"end_effector", end_effector},
       {"staging_time_s", staging_time_s},
       {"episode_lifecycle_enabled", episode_lifecycle_enabled},
-      {"write_moving_time_s", write_moving_time_s}
+      {"write_moving_time_s", write_moving_time_s},
+      {"actuated", actuated}
     };
+    // Emit the remap only when set, to keep ordinary arm configs clean.
+    // Emit the feedback curve only when the feature is on: the constants are
+    // meaningless while it is off, and emitting them would put four keys into
+    // every ordinary arm's config.
+    if (gripper_force_feedback) {
+      j["gripper_force_feedback"] = gripper_force_feedback;
+      j["gripper_feedback_leader_max"] = gripper_feedback_leader_max;
+      j["gripper_feedback_follower_max"] = gripper_feedback_follower_max;
+      j["gripper_feedback_offset"] = gripper_feedback_offset;
+    }
     // Emit staging only when configured. TrossenArmComponent::configure()
     // rejects a present-but-wrong-length staged_position, so an empty array
     // would break the no-staging case.

--- a/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
+++ b/include/trossen_sdk/hw/arm/trossen_arm_component.hpp
@@ -7,6 +7,7 @@
 #define TROSSEN_SDK__HW__ARM__TROSSEN_ARM_COMPONENT_HPP_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -56,6 +57,7 @@ public:
    *   "staged_position": [0, 1.0, 0.5, 0.6, 0, 0, 0],  // optional, joint-space
    *   "staging_time_s": 2.0,       // optional, default 2.0 (stage / rest move)
    *   "write_moving_time_s": 0.1,  // optional, default 0.0 (per-tick smoothing)
+   *   "actuated": false,           // optional, default true (false = read-only arm)
    *
    *   // Host-side clamp on outgoing position commands. Optional; one entry per
    *   // joint, null leaves that joint unclamped. Applied before smoothing.
@@ -138,6 +140,15 @@ private:
   std::vector<float> read_joint();
   void               write_joint(const std::vector<float>& cmd);
 
+  /// Follower role: current measured gripper effort (N), or nullopt without a
+  /// driver. A sensor read, valid regardless of the gripper's control mode.
+  std::optional<float> read_gripper_effort();
+
+  /// Leader role: render gripper force feedback from the follower's measured
+  /// gripper effort (N) via the cubic curve. Only meaningful when
+  /// gripper_force_feedback_ is set.
+  void apply_gripper_feedback(float follower_gripper_effort);
+
   std::vector<float> read_cartesian();
   void               write_cartesian(const std::vector<float>& cmd);
 
@@ -156,6 +167,17 @@ private:
     }
     void write(const std::vector<float>& cmd) override {
       self->write_joint(cmd);
+    }
+    // Gripper force-feedback channel. Only the joint view carries it: the
+    // reflected force is a gripper effort, which has no cartesian analogue.
+    bool renders_gripper_feedback() const override {
+      return self->gripper_force_feedback_;
+    }
+    std::optional<float> read_gripper_effort() override {
+      return self->read_gripper_effort();
+    }
+    void apply_gripper_feedback(float follower_gripper_effort) override {
+      self->apply_gripper_feedback(follower_gripper_effort);
     }
   };
 
@@ -182,6 +204,27 @@ private:
   /// whether prepare_for_teleop() enters gravity-compensation mode (leader)
   /// or position-mode alignment (follower).
   bool is_leader_{false};
+
+  /// Whether this arm has actuators. A passive leader is read-only: it streams
+  /// joint positions and cannot be commanded, so stage(), the teleop mode
+  /// setup, and the end_teleop() rest move are all skipped. Parsed from
+  /// "actuated" in configure(); defaults true, so every existing arm keeps its
+  /// current behaviour.
+  bool actuated_{true};
+
+  /// Leader-only: whether to reflect the follower's grasp onto this gripper,
+  /// and the cubic curve that shapes it. See configuration::ArmConfig.
+  bool gripper_force_feedback_{false};
+  float gripper_feedback_leader_max_{27.0f};
+  float gripper_feedback_follower_max_{87.5f};
+  float gripper_feedback_offset_{8.0f};
+
+  /// Whether prepare_for_teleop() put this arm's gripper into effort mode, so
+  /// end_teleop() releases it only when it was actually engaged. Not merely
+  /// tidiness: end_teleop() can be called with no preceding
+  /// prepare_for_teleop() — the hardware-test park step does exactly that — and
+  /// commanding effort on a gripper still in idle mode is a controller error.
+  bool gripper_effort_engaged_{false};
 
   /// Joint-space pose this arm moves to at session start (via stage()).
   /// Empty = no staging.

--- a/src/hw/arm/trossen_arm_component.cpp
+++ b/src/hw/arm/trossen_arm_component.cpp
@@ -104,7 +104,31 @@ void TrossenArmComponent::configure(const nlohmann::json& config) {
     }
   }
 
+  if (config.contains("actuated")) {
+    actuated_ = config.at("actuated").get<bool>();
+  }
+
   const size_t njoints = static_cast<size_t>(driver_->get_num_joints());
+
+  // ── Gripper force feedback ───────────────────────────────────────────────
+  // Leader-only reverse channel: the follower's measured grasp effort is
+  // reflected onto this gripper through a cubic curve. Off by default.
+  if (config.contains("gripper_force_feedback")) {
+    gripper_force_feedback_ = config.at("gripper_force_feedback").get<bool>();
+  }
+  {
+    auto parse_curve = [&](const char* key, float& dst) {
+      if (!config.contains(key)) return;
+      dst = config.at(key).get<float>();
+      if (!std::isfinite(dst)) {
+        throw std::runtime_error(
+          std::string("TrossenArmComponent: '") + key + "' must be finite");
+      }
+    };
+    parse_curve("gripper_feedback_leader_max", gripper_feedback_leader_max_);
+    parse_curve("gripper_feedback_follower_max", gripper_feedback_follower_max_);
+    parse_curve("gripper_feedback_offset", gripper_feedback_offset_);
+  }
 
   // ── Host-side command clamp ──────────────────────────────────────────────
   // Bounds what teleop is allowed to ask for, independently of the arm's own
@@ -299,6 +323,33 @@ void TrossenArmComponent::clamp_command(std::vector<double>& pos) const {
   }
 }
 
+std::optional<float> TrossenArmComponent::read_gripper_effort() {
+  if (!driver_) return std::nullopt;
+  return static_cast<float>(driver_->get_gripper_effort());
+}
+
+void TrossenArmComponent::apply_gripper_feedback(float follower_gripper_effort) {
+  if (!driver_) return;
+  // Cubic curve (from the bilateral reference): more resistance at higher grip
+  // efforts, with an offset that keeps the leader gripper open when nothing is
+  // grasped. leader = leader_max·norm^3 + offset.
+  float norm = 0.0f;
+  if (gripper_feedback_follower_max_ != 0.0f) {
+    norm = std::abs(follower_gripper_effort) / gripper_feedback_follower_max_;
+    // std::abs already guarantees norm >= 0, so only the upper bound can fire.
+    norm = std::min(norm, 1.0f);
+  }
+  const double leader_effort =
+    gripper_feedback_leader_max_ * std::pow(norm, 3) + gripper_feedback_offset_;
+  // Ramp the rendered effort over 0.2s (linear interpolation) rather than
+  // applying it instantly. At the contact boundary the follower's measured
+  // effort flips rapidly between no-contact and contact; applying that to the
+  // leader instantly (goal_time 0) sets up a limit-cycle oscillation. The 0.2s
+  // ramp acts as a rate limiter that damps the chatter — matching the bilateral
+  // reference, which uses the same goal_time on this command.
+  driver_->set_gripper_effort(leader_effort, 0.2, false);
+}
+
 std::vector<float> TrossenArmComponent::read_cartesian() {
   if (!driver_) return {};
   const auto& out = driver_->get_robot_output();
@@ -334,6 +385,28 @@ void TrossenArmComponent::prepare_for_teleop() {
   // adaptive cutoff wide, and effectively disables the smoothing for the first
   // ticks of the session — when the arm is nearest the operator.
   cmd_filt_.reset();
+  if (!actuated_) {
+    // Passive leader: the arm joints have no motors, so putting them in
+    // position mode is harmless and keeps their positions readable. What we
+    // must NOT do is the gravity-compensation setup below — commanding
+    // external effort on joints that cannot act on it is a controller error,
+    // not a no-op.
+    driver_->set_all_modes(trossen_arm::Mode::position);
+    // The gripper is the one part of a passive leader that may have a motor,
+    // and it goes to effort mode rather than position: this gripper is an
+    // INPUT, read to drive the follower's, so it has to stay back-driveable.
+    // Position mode would hold its setpoint and fight the operator's hand.
+    // The neutral command is set explicitly, since a mode change alone would
+    // leave whatever setpoint was there before, and a stale non-zero one
+    // squeezes the gripper shut. With feedback on, that neutral value is the
+    // curve's resting offset, so the gripper holds open from before the first
+    // tick instead of going slack and then stiffening.
+    driver_->set_gripper_mode(trossen_arm::Mode::effort);
+    driver_->set_gripper_effort(
+      gripper_force_feedback_ ? gripper_feedback_offset_ : 0.0, 0.0, false);
+    gripper_effort_engaged_ = true;
+    return;
+  }
   if (is_leader_) {
     // Leader: enable gravity compensation.
     driver_->set_all_modes(trossen_arm::Mode::external_effort);
@@ -348,6 +421,26 @@ void TrossenArmComponent::prepare_for_teleop() {
 
 void TrossenArmComponent::end_teleop() {
   if (!driver_) return;
+  if (!actuated_) {
+    // Passive leader: nothing to hold and nowhere to drive it. Skipping
+    // straight to cleanup is not just an optimisation — the hold-and-rest
+    // sequence below commands positions, which a joint with no motor cannot
+    // reach, so the blocking move would wait out its full trajectory time and
+    // then report an arm that never arrived.
+    std::cout << "  [end_teleop] " << get_identifier()
+              << ": passive leader, nothing to rest" << std::endl;
+    // Release the gripper before the driver goes away: back to zero effort,
+    // then braked. Leaving it in effort mode would keep the last commanded
+    // value pressing on the operator's hand after the session has ended.
+    if (gripper_effort_engaged_) {
+      driver_->set_gripper_effort(0.0, 0.0, false);
+      driver_->set_gripper_mode(trossen_arm::Mode::idle);
+      gripper_effort_engaged_ = false;
+    }
+    driver_->cleanup();
+    driver_.reset();
+    return;
+  }
   std::cout << "  [end_teleop] " << get_identifier()
             << ": holding pose, then returning to rest over "
             << staging_time_s_ << "s..." << std::endl;
@@ -381,6 +474,7 @@ void TrossenArmComponent::on_pre_episode() {
 
 void TrossenArmComponent::stage() {
   if (!driver_) return;
+  if (!actuated_) return;  // passive leader cannot move to a staging pose
   if (staged_position_.empty()) {
     std::cout << "  [stage] " << get_identifier()
               << ": no staged_position configured, skipping" << std::endl;


### PR DESCRIPTION
Two opt-in arm options, both defaulting to today's behaviour. The gripper channel implements the reverse seam added in #285, so that contract now has a real implementer.

| Config | Effect |
| --- | --- |
| `actuated: false` | read-only arm: no staging, no teleop mode setup, no rest move |
| `gripper_force_feedback` + 3 curve constants | reflect the follower's grasp onto an actuated leader gripper, plain effort only |

**A passive leader's gripper goes to effort mode, not position.** Both source branches fall back to `Mode::position` whenever feedback is off, which makes a leader gripper hold its setpoint and fight the hand that is supposed to be driving it. It is an input and has to stay back-driveable. Zero effort is commanded explicitly, because a mode change alone leaves the previous setpoint and a stale non-zero one squeezes the gripper shut. Teardown releases it (zero, then idle), guarded by a flag since `end_teleop()` can be called with no preceding `prepare_for_teleop()` — the hardware-test park step does exactly that — and commanding effort on an idle gripper is a controller error.

**No joint frame remapping.** Selecting the `glide_left` / `glide_right` driver model already returns transformed values, so `joint_signs` / `joint_offsets`, `apply_joint_remap()` and `RemapKind` are all gone, and `trossen_arm_producer.{hpp,cpp}` is untouched by this PR.

**Conflict to settle before `experimental/trossen-webapp` merges.** That branch's lightweight leader renders gripper feedback through `set_gripper_external_effort` with no key to switch it; this PR renders through plain effort, matching what all five Rivet configs set and what the Glide handles were tuned on (external effort fights the operator on that hardware). The `gripper_feedback_mode` key is deliberately absent — its only consumer would be out of tree, the same reasoning that dropped four symbols under D7 — so that merge needs to re-add it deliberately rather than discover the difference on hardware.

**Scope:** both options are only settable through `configure()`, which needs a live controller, so nothing here is unit-tested; the curve was checked numerically at both tunings. Excludes `telemetry_frame_id()` (D1), `summon_joint()` (D13), and all haptic code and config (D4).
