### PR TITLE
glide: publish handle joystick and buttons from the arm driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(trossen_sdk SHARED
   src/hw/arm/feetech_bus.cpp
   src/hw/base/slate_base_component.cpp
   src/hw/base/slate_base_producer.cpp
+  src/hw/glide/glide_arm_input_component.cpp
   src/hw/glide/glide_session.cpp
   src/hw/teleop/teleop_controller.cpp
   src/hw/teleop/teleop_factory.cpp

--- a/include/trossen_sdk/configuration/sdk_config.hpp
+++ b/include/trossen_sdk/configuration/sdk_config.hpp
@@ -29,7 +29,8 @@
  *   "hardware": {
  *     "arms":    { "<id>": { "ip_address": "...", "model": "...", "end_effector": "..." }, ... },
  *     "cameras": [ { "id": "...", "type": "realsense_camera", "serial_number": "...", ... }, ... ],
- *     "mobile_base": { "reset_odometry": false, "enable_torque": false }
+ *     "mobile_base": { "reset_odometry": false, "enable_torque": false },
+ *     "controls": { "<id>": { "type": "glide_arm_input", "arms": ["<id>", ...] } }
  *   },
  *   "producers": [
  *     { "type": "trossen_arm",      "hardware_id": "<id>", "stream_id": "<id>", "poll_rate_hz": 30.0, "use_device_time": false },
@@ -65,6 +66,7 @@
 #ifndef TROSSEN_SDK__CONFIGURATION__SDK_CONFIG_HPP_
 #define TROSSEN_SDK__CONFIGURATION__SDK_CONFIG_HPP_
 
+#include <map>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -75,6 +77,7 @@
 #include "trossen_sdk/configuration/types/hardware/arm_config.hpp"
 #include "trossen_sdk/configuration/types/hardware/camera_config.hpp"
 #include "trossen_sdk/configuration/types/hardware/mobile_base_config.hpp"
+#include "trossen_sdk/configuration/types/hardware/control_config.hpp"
 #include "trossen_sdk/configuration/types/hardware/policy_client_config.hpp"
 #include "trossen_sdk/configuration/types/observers/observer_config.hpp"
 #include "trossen_sdk/configuration/types/producers/producer_config.hpp"
@@ -85,7 +88,7 @@
 namespace trossen::configuration {
 
 /**
- * @brief Hardware sub-configuration: arms, cameras, and optional mobile base
+ * @brief Hardware sub-configuration: arms, cameras, controls, and optional mobile base
  */
 struct HardwareConfig {
   /// @brief Named arm configs, keyed by logical id (e.g. "leader_left", "follower_right")
@@ -99,6 +102,13 @@ struct HardwareConfig {
 
   /// @brief Policy-client hardware configs (zero or more)
   std::vector<PolicyClientConfig> policy_clients;
+
+  /// @brief Operator control configs, keyed by logical id (e.g. "glide_inputs")
+  ///
+  /// Ordered rather than hashed, so construction runs in the same sequence on
+  /// every host — bring-up logs stay comparable, and a type that ever does turn
+  /// out to be order-sensitive does not depend on a hash seed.
+  std::map<std::string, ControlConfig> controls;
 
   static HardwareConfig from_json(const nlohmann::json& j);
 };

--- a/include/trossen_sdk/configuration/types/hardware/control_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/control_config.hpp
@@ -1,0 +1,88 @@
+/**
+ * @file control_config.hpp
+ * @brief Configuration for an operator control-surface component
+ */
+
+#ifndef TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__CONTROL_CONFIG_HPP_
+#define TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__CONTROL_CONFIG_HPP_
+
+#include <stdexcept>
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+namespace trossen::configuration {
+
+/**
+ * @brief Configuration for one operator control
+ *
+ * A control binds a physical control surface to a software effect. Three exist:
+ * one publishes a handle's joystick and buttons, one turns a stick into base
+ * velocity, one turns buttons into session events. What they share is not that
+ * they are inputs — the base mapper emits commands — but that each exists
+ * because a human is holding something. None is recorded and none appears in
+ * `producers`, which is why they sit apart from arms and cameras rather than
+ * among them.
+ *
+ * The @p type field selects which component is created via HardwareRegistry,
+ * exactly as CameraConfig::type does. Unlike a camera there is no majority type
+ * to default to, so it is required.
+ *
+ * Every other key is passed through verbatim.
+ *
+ * JSON format, keyed by component id:
+ * @code
+ * "controls": {
+ *   "glide_inputs": {
+ *     "type": "glide_arm_input",
+ *     "arms": ["glide_left", "glide_right"]
+ *   }
+ * }
+ * @endcode
+ */
+struct ControlConfig {
+  /// @brief Hardware registry key — e.g. "glide_arm_input". Required.
+  std::string type{};
+
+  /// @brief Every key other than `type`, forwarded to
+  /// HardwareComponent::configure() untouched.
+  ///
+  /// The three types share no settings beyond the discriminator — one takes a
+  /// list of arm ids, one a pair of nested axis blocks, one a poll rate and a
+  /// button table — so modelling any of them here would mean a member per key of
+  /// one type, unread by the other two.
+  nlohmann::json extra{};
+
+  static ControlConfig from_json(const nlohmann::json& j) {
+    if (!j.is_object()) {
+      throw std::runtime_error("ControlConfig: entry must be an object");
+    }
+    if (!j.contains("type") || !j.at("type").is_string() ||
+        j.at("type").get<std::string>().empty()) {
+      throw std::runtime_error(
+        "ControlConfig: 'type' is required and must be a non-empty string "
+        "naming a registered hardware type (e.g. \"glide_arm_input\")");
+    }
+
+    ControlConfig c;
+    j.at("type").get_to(c.type);
+    // Parse-and-erase rather than a known-keys list: with the discriminator as
+    // the only modelled field, a new control type needs no edit here, and there
+    // is no list to fall out of sync with.
+    c.extra = j;
+    c.extra.erase("type");
+    return c;
+  }
+
+  /// @brief Produce JSON suitable for HardwareComponent::configure()
+  ///
+  /// `type` is omitted, matching CameraConfig: the registry takes it as a
+  /// separate argument, so repeating it here would put two copies in play.
+  nlohmann::json to_json() const {
+    return extra.is_object() ? extra : nlohmann::json::object();
+  }
+};
+
+}  // namespace trossen::configuration
+
+#endif  // TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__CONTROL_CONFIG_HPP_

--- a/include/trossen_sdk/hw/glide/glide_arm_input_component.hpp
+++ b/include/trossen_sdk/hw/glide/glide_arm_input_component.hpp
@@ -1,0 +1,80 @@
+/**
+ * @file glide_arm_input_component.hpp
+ * @brief Publishes Glide handle joystick/button state from the arm driver.
+ */
+
+#ifndef TROSSEN_SDK__HW__GLIDE__GLIDE_ARM_INPUT_COMPONENT_HPP_
+#define TROSSEN_SDK__HW__GLIDE__GLIDE_ARM_INPUT_COMPONENT_HPP_
+
+#include <string>
+#include <vector>
+
+#include "trossen_sdk/hw/glide/glide_session.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+
+namespace trossen::hw::glide {
+
+/**
+ * @brief Fills the GlideSession reader seam from live arm drivers.
+ *
+ * A Glide handle's joystick and buttons arrive over the same libtrossen_arm
+ * driver that streams its joint positions, reported alongside joint state in the
+ * driver's own robot output. This component is the one place that knows that:
+ * for each handle it names, it resolves the already-constructed
+ * `TrossenArmComponent`, borrows its driver, and registers a `GlideInputReader`
+ * that converts the driver's input report into an SDK-owned
+ * `GlideInputSnapshot`. Every mapping component downstream reads snapshots and
+ * never touches the driver.
+ *
+ * That containment is the point of keeping it a separate component rather than a
+ * few lines inside `TrossenArmComponent`: the arm component has no reason to
+ * know a handle exists, and the mappers have no reason to know a driver does.
+ *
+ * It claims nothing. Claims are made by the components that *consume* an input
+ * — the base takes a joystick, session control takes buttons — never by the one
+ * that publishes it, so a handle whose joystick nothing reads is simply unread.
+ *
+ * Ordering: the handles' arm components must already be registered in
+ * `ActiveHardwareRegistry` when this one configures, which holds because
+ * `hardware.arms` is constructed before `hardware.controls`. Nothing
+ * enforces that, so configure() names it in the error when a lookup misses.
+ *
+ * Config as configure() receives it:
+ * @code
+ * { "arms": ["glide_left", "glide_right"] }
+ * @endcode
+ */
+class GlideArmInputComponent : public HardwareComponent {
+public:
+  explicit GlideArmInputComponent(std::string identifier)
+    : HardwareComponent(identifier) {}
+
+  /// Unregisters every reader this component installed, so a stale reader can
+  /// never outlive the driver it reads from.
+  ~GlideArmInputComponent() override;
+
+  /**
+   * @brief Resolve each named handle and register its input reader.
+   *
+   * @throws std::runtime_error if `arms` is missing, empty, or holds anything
+   *         but non-empty strings; or if a named id is not a registered
+   *         `TrossenArmComponent` or has no driver.
+   */
+  void configure(const nlohmann::json& config) override;
+
+  std::string get_type() const override { return "glide_arm_input"; }
+
+  /// Reports the handle ids this component publishes readers for, in config
+  /// order, under "arms".
+  nlohmann::json get_info() const override;
+
+private:
+  /// Drop every registered reader. Idempotent; safe before configure().
+  void unregister_all();
+
+  std::vector<std::string> arm_ids_;
+};
+
+}  // namespace trossen::hw::glide
+
+#endif  // TROSSEN_SDK__HW__GLIDE__GLIDE_ARM_INPUT_COMPONENT_HPP_

--- a/src/configuration/sdk_config.cpp
+++ b/src/configuration/sdk_config.cpp
@@ -35,6 +35,21 @@ HardwareConfig HardwareConfig::from_json(const nlohmann::json& j) {
     c.mobile_base = MobileBaseConfig::from_json(j.at("mobile_base"));
   }
 
+  if (j.contains("controls")) {
+    if (!j.at("controls").is_object()) {
+      throw std::runtime_error(
+        "HardwareConfig: 'controls' must be an object keyed by component id");
+    }
+    for (const auto& [id, ctrl_j] : j.at("controls").items()) {
+      try {
+        c.controls[id] = ControlConfig::from_json(ctrl_j);
+      } catch (const std::exception& e) {
+        throw std::runtime_error(
+          "HardwareConfig: failed to parse controls['" + id + "']: " + e.what());
+      }
+    }
+  }
+
   if (j.contains("policy_clients")) {
     if (!j.at("policy_clients").is_array()) {
       throw std::runtime_error(

--- a/src/hw/glide/glide_arm_input_component.cpp
+++ b/src/hw/glide/glide_arm_input_component.cpp
@@ -1,0 +1,144 @@
+/**
+ * @file glide_arm_input_component.cpp
+ * @brief Arm-driver input report → GlideSession reader.
+ */
+
+#include "trossen_sdk/hw/glide/glide_arm_input_component.hpp"
+
+#include <atomic>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+
+namespace trossen::hw::glide {
+
+GlideArmInputComponent::~GlideArmInputComponent() { unregister_all(); }
+
+void GlideArmInputComponent::unregister_all() {
+  auto& session = GlideSession::instance();
+  for (const auto& id : arm_ids_) {
+    session.unregister_reader(id);
+  }
+  arm_ids_.clear();
+}
+
+void GlideArmInputComponent::configure(const nlohmann::json& config) {
+  if (!config.contains("arms") || !config.at("arms").is_array() ||
+      config.at("arms").empty()) {
+    throw std::runtime_error(
+      "GlideArmInputComponent '" + get_identifier() +
+      "': requires a non-empty 'arms' array naming the handle arm components to "
+      "publish input for");
+  }
+
+  // Validate the whole list before touching anything. A malformed entry is a
+  // pure config error that needs no registry, so checking it up front means a
+  // typo is reported as a typo even when an unrelated handle is also missing —
+  // rather than surfacing as whichever earlier entry failed to resolve first.
+  std::vector<std::string> requested;
+  requested.reserve(config.at("arms").size());
+  for (const auto& entry : config.at("arms")) {
+    if (!entry.is_string() || entry.get<std::string>().empty()) {
+      throw std::runtime_error(
+        "GlideArmInputComponent '" + get_identifier() +
+        "': every 'arms' entry must be a non-empty hardware id string");
+    }
+    requested.push_back(entry.get<std::string>());
+  }
+
+  // Re-configuring should not leave readers behind for handles no longer named.
+  unregister_all();
+
+  auto& session = GlideSession::instance();
+  std::vector<std::string> resolved;
+
+  for (const auto& arm_id : requested) {
+    auto arm = ActiveHardwareRegistry::get_as<arm::TrossenArmComponent>(arm_id);
+    if (!arm) {
+      unregister_all();
+      // Name the construction order, not just the miss. Resolving out of the
+      // active registry works only because hardware.arms is built before
+      // hardware.controls, and that ordering is a property of the call
+      // order in the examples rather than of the config format or the SDK.
+      // Nothing enforces it and nothing else states it, so a config author who
+      // assumes declaration order matters gets this message instead of a bare
+      // "not found" at bring-up.
+      throw std::runtime_error(
+        "GlideArmInputComponent '" + get_identifier() + "': arm '" + arm_id +
+        "' is not a registered trossen_arm. Arms in hardware.arms are "
+        "constructed before hardware.controls, so a handle named here "
+        "must exist there — check the id spelling and that it is declared under "
+        "hardware.arms.");
+    }
+    if (!arm->get_hardware()) {
+      unregister_all();
+      throw std::runtime_error(
+        "GlideArmInputComponent '" + get_identifier() + "': arm '" + arm_id +
+        "' has no driver; it must be configured before this component reads it");
+    }
+
+    // Weak, deliberately. GlideSession is process-global and outlives any one
+    // session, so a reader capturing the arm by shared_ptr would pin the arm —
+    // and its open controller connection — alive past shutdown. Arm controllers
+    // are single-client, so that leak would stall the next run's connect until
+    // the controller times the stale client out.
+    std::weak_ptr<arm::TrossenArmComponent> weak_arm = arm;
+
+    // One-shot so a persistently failing handle logs once instead of at the
+    // teleop rate. Shared because the reader is copied into the session.
+    auto reported = std::make_shared<std::atomic<bool>>(false);
+
+    session.register_reader(
+      arm_id,
+      [weak_arm, arm_id, reported]() -> std::optional<GlideInputSnapshot> {
+        auto component = weak_arm.lock();
+        if (!component) return std::nullopt;
+        auto driver = component->get_hardware();
+        if (!driver) return std::nullopt;
+        try {
+          const auto report = driver->get_input_report();
+          GlideInputSnapshot snapshot;
+          snapshot.joystick_x = report.joystick_x;
+          snapshot.joystick_y = report.joystick_y;
+          snapshot.buttons    = report.buttons;
+          return snapshot;
+        } catch (const std::exception& e) {
+          // Swallowed on purpose: this runs on the teleop mirror and
+          // session-control poll threads, where an escaping throw would take
+          // down teleop over a dropped input frame. Consumers treat nullopt as
+          // "this handle contributed nothing this tick", which for the base
+          // means its axes read zero.
+          if (!reported->exchange(true)) {
+            std::cerr << "GlideArmInputComponent: reading inputs from '" << arm_id
+                      << "' failed, its inputs will read as idle until it "
+                      << "recovers: " << e.what() << std::endl;
+          }
+          return std::nullopt;
+        }
+      });
+
+    resolved.push_back(arm_id);
+  }
+
+  arm_ids_ = std::move(resolved);
+}
+
+nlohmann::json GlideArmInputComponent::get_info() const {
+  nlohmann::json info = nlohmann::json::object();
+  info["type"] = get_type();
+  info["id"]   = get_identifier();
+  info["arms"] = arm_ids_;
+  return info;
+}
+
+REGISTER_HARDWARE(GlideArmInputComponent, "glide_arm_input")
+
+}  // namespace trossen::hw::glide


### PR DESCRIPTION
`GlideArmInputComponent` fills the reader seam added in #289. For each handle it names, it resolves the already-constructed `TrossenArmComponent`, borrows its driver, and registers a `GlideInputReader` that turns the driver's input report into an SDK-owned snapshot. It is the only place that knows handle input arrives over the arm driver — every mapping component downstream reads snapshots and never touches one.

**The reader captures the arm by** **`weak_ptr`, and that is load-bearing.** `GlideSession` is process-global and outlives any one session, so a strong capture would pin the arm and its open controller connection past shutdown. Arm controllers are single-client, so the leak would stall the _next_ run's connect until the controller timed the stale client out. The destructor unregistering every reader is the other half of the same guarantee.

**Read failures are swallowed, logged once per handle.** The reader runs on the teleop mirror and session-control poll threads, where an escaping throw would take teleop down over one dropped input frame. Consumers read `nullopt` as "this handle contributed nothing this tick", which for the base means its axes read zero.

**It claims nothing.** Claims are made by the components that _consume_ an input — never by the one that publishes it — so a handle whose joystick nothing reads is simply unread. That is what lets a solo Glide with no base work unchanged.

**New** **`hardware.controls`** **section**, keyed by component id, declaring this component and PRs 11–12's:

```json
"controls": {
  "glide_inputs": { "type": "glide_arm_input", "arms": ["glide_left", "glide_right"] }
}
```

A control binds a physical control surface to a software effect. The checkable property separating the section from `arms` and `cameras` is that **none of its members is recorded and none appears in** **`producers`**. Three shape decisions, each a deliberate departure from a neighbouring section:

| Decision | Neighbour does | Why different |
| --- | --- | --- |
| keyed map | `cameras` is an array | `merge_overrides()` is object-only, so `--set` cannot reach into an array (`type_error.305`). Verified: `--set hardware.controls.session_control.poll_rate_hz=80.0` works |
| `std::map` | `arms` is `unordered_map` | Deterministic construction order. Ordering here is already implicit and unenforced, so it should not also depend on a hash seed |
| only `type` modelled | `CameraConfig` models width/height/fps | The three control types share no other settings; modelling any would mean a member per key of one type, unread by the other two. Uses the parse-and-erase pattern `camera_config.hpp`'s own TODO recommends rather than its `known_keys` list |

**Resolution depends on** **`hardware.arms`** **being constructed first, and nothing enforces it.** That ordering is a property of the call order in the examples, not of the config format or the SDK. The real fix — the SDK owning construction order, or declared dependencies between components — is a redesign. Instead a lookup miss throws an error naming the cause:

```
GlideArmInputComponent 'glide_inputs': arm 'glide_left' is not a registered
trossen_arm. Arms in hardware.arms are constructed before hardware.controls, so
a handle named here must exist there — check the id spelling and that it is
declared under hardware.arms.
```

