### PR TITLE
glide: drive a mobile base from Glide handle sticks and buttons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(trossen_sdk SHARED
   src/hw/base/slate_base_component.cpp
   src/hw/base/slate_base_producer.cpp
   src/hw/glide/glide_arm_input_component.cpp
+  src/hw/glide/glide_base_component.cpp
   src/hw/glide/glide_session.cpp
   src/hw/teleop/teleop_controller.cpp
   src/hw/teleop/teleop_factory.cpp

--- a/include/trossen_sdk/hw/glide/glide_base_component.hpp
+++ b/include/trossen_sdk/hw/glide/glide_base_component.hpp
@@ -1,0 +1,185 @@
+/**
+ * @file glide_base_component.hpp
+ * @brief Mobile-base teleop leader driven by Glide handle joysticks and buttons.
+ */
+
+#ifndef TROSSEN_SDK__HW__GLIDE__GLIDE_BASE_COMPONENT_HPP_
+#define TROSSEN_SDK__HW__GLIDE__GLIDE_BASE_COMPONENT_HPP_
+
+#include <array>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/hw/glide/glide_session.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+
+namespace trossen::hw::glide {
+
+/**
+ * @brief Base-space teleop leader that reads Glide handle inputs.
+ *
+ * A separate component from the arms on purpose. The operator's hands are on
+ * two Glide handles that each carry a joystick and buttons alongside the arm
+ * itself, and those inputs drive a different follower (the mobile base) than
+ * the arm joints do (the follower arms). Modelling them as one bundled device
+ * would force a single teleop pair to carry both, so instead each role is its
+ * own pair over the same physical handles, and `GlideSession` guarantees no two
+ * components read the same input.
+ *
+ * Leader-only: `read()` samples the configured inputs, `write()` is a no-op.
+ *
+ * ### Axis mapping is configuration, not code
+ *
+ * Which stick axis drives which base axis, and which button bits raise and
+ * lower the lift, differ per handle revision and per operator preference — and
+ * the button bit assignments are not documented anywhere the SDK can see. So
+ * the whole mapping is declarative: discovering that "raise" is really bit 4 is
+ * a config edit, not a rebuild.
+ *
+ * ### Which axis is which on a Rivet (2026-08-11)
+ *
+ * The driver reports each stick only as "0 to 4095" with no physical direction,
+ * so every one of these flags was arrived at by driving the base and watching
+ * it. What is solid is the axis ASSIGNMENT: on `glide_left` fore/aft lives on
+ * `joystick_x` and left/right on `joystick_y` — swapped from what the config
+ * originally assumed — while on `glide_right` yaw lives on `joystick_x`. The two
+ * handles are different mirrored models and do not agree, so neither can be
+ * inferred from the other; that inference is what produced two wrong signs
+ * before the flags converged on what the Rivet preset ships:
+ *
+ *     angular:  joystick_x, invert true
+ *     forward:  joystick_x, invert false
+ *     lateral:  joystick_y, invert true
+ *
+ * The SIGNS are operator-verified, not probed — nobody has yet read the raw
+ * counts while pushing the stick a known way. So treat them as "what the robot
+ * did" rather than as a derivation, and do not re-derive other flags from them.
+ *
+ * If translation direction ever changes between BRINGUPS with nothing edited,
+ * stop chasing these flags — that is the swerve modules' homed zero landing half
+ * a turn out, and a sign flip will only be right until the next restart.
+ *
+ * Expected JSON:
+ * @code
+ * {
+ *   "axes": {
+ *     "linear":  { "arm_id": "glide_left",  "source": "joystick_x",
+ *                  "invert": false, "max": 1.0, "deadzone": 0.1 },
+ *     "angular": { "arm_id": "glide_right", "source": "joystick_x",
+ *                  "invert": true,  "max": 1.0, "deadzone": 0.1 },
+ *     "lateral": { "arm_id": "glide_left",  "source": "joystick_y",
+ *                  "invert": true,  "max": 1.0, "deadzone": 0.1 },
+ *     "lift":    { "arm_id": "glide_right", "source": "buttons",
+ *                  "up_bit": 0, "down_bit": 2, "max": 8000.0 }
+ *   }
+ * }
+ * @endcode
+ *
+ * Every axis is optional; an omitted axis reads 0. `max` is the value at full
+ * deflection (units depend on the axis — m/s, rad/s, or actuator units/s), and
+ * `deadzone` is applied to the *scaled* value so it is expressed in those same
+ * units rather than raw counts.
+ */
+class GlideBaseComponent : public HardwareComponent, public teleop::BaseSpaceTeleop {
+public:
+  explicit GlideBaseComponent(std::string identifier)
+    : HardwareComponent(std::move(identifier)) {}
+
+  /// Releases this component's input claims via the lease member.
+  ~GlideBaseComponent() override = default;
+
+  GlideBaseComponent(const GlideBaseComponent&)            = delete;
+  GlideBaseComponent& operator=(const GlideBaseComponent&) = delete;
+  GlideBaseComponent(GlideBaseComponent&&)                 = delete;
+  GlideBaseComponent& operator=(GlideBaseComponent&&)      = delete;
+
+  /**
+   * @brief Parse the axis map and claim every input it references.
+   *
+   * @throws std::runtime_error if an input is already claimed by another
+   *         component, or if two axes here map to the same input.
+   * @throws std::invalid_argument on an unknown source name, a buttons axis
+   *         without at least one of up_bit / down_bit, or a max or deadzone
+   *         outside its valid range.
+   */
+  void configure(const nlohmann::json& config) override;
+
+  std::string get_type() const override { return "glide_base"; }
+
+  nlohmann::json get_info() const override;
+
+  /**
+   * @brief Sample the configured inputs.
+   *
+   * @return Always `base_axis::kMaxSize` elements
+   *         `[linear, angular, lift, lateral]`. Unconfigured axes and handles
+   *         with no reader available read 0, which for a velocity command means
+   *         "hold still" — the safe value when input is missing.
+   */
+  std::vector<float> read() override;
+
+  /// No-op: the handles are an input device, not a base.
+  void write(const std::vector<float>& cmd) override { (void)cmd; }
+
+private:
+  /// Where one base axis gets its value.
+  struct AxisMap {
+    enum class Source { kJoystickX, kJoystickY, kButtons };
+
+    bool        configured{false};
+    std::string arm_id;
+    Source      source{Source::kJoystickX};
+
+    /// Flip the sign after scaling — for a stick mounted so that "forward"
+    /// reads as a decreasing count.
+    bool  invert{false};
+
+    /// Output value at full deflection, in the axis's own units.
+    float max{1.0f};
+
+    /// Ignore scaled magnitudes below this, so a stick that does not quite
+    /// recentre does not creep the base.
+    float deadzone{0.0f};
+
+    /// Button bits for a `kButtons` axis. -1 means that direction is unmapped.
+    int up_bit{-1};
+    int down_bit{-1};
+  };
+
+  /// Snapshots for this tick, one entry per distinct handle.
+  ///
+  /// Every axis used to read its handle independently, so a four-axis config
+  /// hit the driver four times and could mix a left-handle reading from one
+  /// driver cycle with a right-handle reading from the next. For a swerve base
+  /// that skew shows up as rotation and translation disagreeing about when the
+  /// operator moved. Reading each handle once per `read()` removes the skew and
+  /// cuts the driver traffic.
+  using SnapshotCache = std::unordered_map<std::string, std::optional<GlideInputSnapshot>>;
+
+  /// Read every handle this component needs, once.
+  SnapshotCache collect_snapshots() const;
+
+  /// Raw stick axis normalised to -1..1 with inversion applied, before scaling.
+  static float normalised_axis(const GlideInputSnapshot& snapshot,
+                               AxisMap::Source source, bool invert);
+
+  /// Evaluate one independent axis. Returns 0 for an unconfigured axis or an
+  /// unavailable handle.
+  float sample_axis(const AxisMap& axis, const SnapshotCache& cache) const;
+
+  /// Indexed by the `base_axis::k*` constants, so the read() vector is built by
+  /// position with no separate ordering to keep in sync.
+  std::array<AxisMap, teleop::base_axis::kMaxSize> axes_{};
+
+  GlideClaimLease lease_;
+};
+
+}  // namespace trossen::hw::glide
+
+#endif  // TROSSEN_SDK__HW__GLIDE__GLIDE_BASE_COMPONENT_HPP_

--- a/src/hw/glide/glide_base_component.cpp
+++ b/src/hw/glide/glide_base_component.cpp
@@ -1,0 +1,300 @@
+/**
+ * @file glide_base_component.cpp
+ * @brief Implementation of GlideBaseComponent.
+ */
+
+#include "trossen_sdk/hw/glide/glide_base_component.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "trossen_sdk/hw/hardware_registry.hpp"
+
+namespace trossen::hw::glide {
+
+namespace ba = teleop::base_axis;
+
+namespace {
+
+/// Axis names as they appear in config, indexed by the base_axis constants so
+/// the JSON key and the vector position cannot drift apart.
+constexpr std::array<const char*, ba::kMaxSize> kAxisNames{
+  "linear",   // ba::kLinear
+  "angular",  // ba::kAngular
+  "lift",     // ba::kLift
+  "lateral",  // ba::kLateral
+};
+
+/**
+ * @brief Recentre a raw joystick count to -1..1.
+ *
+ * The handle reports 0..4095 with centre at the midpoint, so a resting stick is
+ * ~2047 and means nothing until recentred.
+ */
+float normalise_stick(std::uint16_t raw) {
+  constexpr float span = static_cast<float>(kJoystickMax - kJoystickMin);
+  const float centred = (static_cast<float>(raw) - static_cast<float>(kJoystickMin)) / span;
+  return centred * 2.0f - 1.0f;
+}
+
+/**
+ * @brief Scale a single normalised axis, with the deadzone in output units.
+ *
+ * Each axis is treated independently, which is the right model for a
+ * one-dimensional axis: yaw from a stick pushed sideways, or forward speed on a
+ * differential-drive base that cannot strafe anyway.
+ */
+float scale_axis(float normalised, float max, float deadzone) {
+  const float scaled = normalised * max;
+  if (deadzone > 0.0f && std::abs(scaled) < deadzone) return 0.0f;
+  return scaled;
+}
+
+/// Shared by every axis, so one bad number reads the same wherever it appears.
+void validate_range(float max, float deadzone, const std::string& what) {
+  if (!std::isfinite(max) || max <= 0.0f) {
+    throw std::invalid_argument(
+      "GlideBaseComponent: " + what + " 'max' must be finite and positive, got " +
+      std::to_string(max));
+  }
+  if (!std::isfinite(deadzone) || deadzone < 0.0f || deadzone >= max) {
+    throw std::invalid_argument(
+      "GlideBaseComponent: " + what + " 'deadzone' must be in [0, max); a deadzone "
+      "at or above max would zero every command");
+  }
+}
+
+}  // namespace
+
+void GlideBaseComponent::configure(const nlohmann::json& config) {
+  if (!config.contains("axes") || !config.at("axes").is_object()) {
+    throw std::invalid_argument(
+      "GlideBaseComponent '" + get_identifier() +
+      "': config requires an 'axes' object; with nothing mapped the component "
+      "would report zero velocity forever");
+  }
+  const nlohmann::json& axes_json = config.at("axes");
+
+  // Parse fully before claiming anything: a claim failure partway through would
+  // otherwise leave this component holding inputs it never got to use.
+  std::array<AxisMap, ba::kMaxSize> parsed{};
+
+  for (std::size_t i = 0; i < ba::kMaxSize; ++i) {
+    const char* name = kAxisNames[i];
+    if (!axes_json.contains(name)) continue;
+    const auto& j = axes_json.at(name);
+
+    AxisMap axis;
+    axis.configured = true;
+
+    if (!j.contains("arm_id")) {
+      throw std::invalid_argument(
+        std::string("GlideBaseComponent: axis '") + name + "' requires 'arm_id'");
+    }
+    axis.arm_id = j.at("arm_id").get<std::string>();
+
+    const auto source = j.value("source", std::string{"joystick_x"});
+    if (source == "joystick_x") {
+      axis.source = AxisMap::Source::kJoystickX;
+    } else if (source == "joystick_y") {
+      axis.source = AxisMap::Source::kJoystickY;
+    } else if (source == "buttons") {
+      axis.source = AxisMap::Source::kButtons;
+    } else {
+      throw std::invalid_argument(
+        std::string("GlideBaseComponent: axis '") + name + "' has unknown source '" +
+        source + "' (expected joystick_x, joystick_y, or buttons)");
+    }
+
+    axis.invert   = j.value("invert", false);
+    axis.max      = j.value("max", 1.0f);
+    axis.deadzone = j.value("deadzone", 0.0f);
+    axis.up_bit   = j.value("up_bit", -1);
+    axis.down_bit = j.value("down_bit", -1);
+
+    if (axis.source == AxisMap::Source::kButtons) {
+      if (axis.up_bit < 0 && axis.down_bit < 0) {
+        throw std::invalid_argument(
+          std::string("GlideBaseComponent: axis '") + name +
+          "' uses source 'buttons' but maps neither up_bit nor down_bit, so it "
+          "could never produce a non-zero value");
+      }
+      // Fails silently rather than loudly: sample_axis() cancels up against
+      // down, so the axis reads zero however hard the operator presses.
+      // Rejected here rather than at the claim, because two identical claims
+      // from one component are idempotent by design and would not collide.
+      if (axis.up_bit >= 0 && axis.up_bit == axis.down_bit) {
+        throw std::invalid_argument(
+          std::string("GlideBaseComponent: axis '") + name + "' maps up_bit and "
+          "down_bit to the same button (" + std::to_string(axis.up_bit) +
+          "), which cancels to zero whenever it is pressed");
+      }
+    }
+
+    validate_range(axis.max, axis.deadzone, std::string("axis '") + name + "'");
+
+    parsed[i] = std::move(axis);
+  }
+
+  // Two of THIS component's axes binding one button is a mistake the claim table
+  // cannot catch: repeated identical claims from a single component are
+  // idempotent by design, so the lease accepts the second one silently and both
+  // axes then move on the same press. Checked here instead.
+  //
+  // Deliberately buttons only. Several axes sharing one handle's JOYSTICK is the
+  // intended pattern — the stick is claimed as a unit, and linear-on-x plus
+  // lateral-on-y is two axes over one claim.
+  std::vector<std::pair<std::string, int>> claimed_bits;
+  auto claim_bit = [&](const std::string& arm_id, int bit, const char* axis_name) {
+    for (const auto& [held_arm, held_bit] : claimed_bits) {
+      if (held_arm == arm_id && held_bit == bit) {
+        throw std::invalid_argument(
+          std::string("GlideBaseComponent '") + get_identifier() + "': axis '" +
+          axis_name + "' binds button " + std::to_string(bit) + " on handle '" +
+          arm_id + "', which another axis of this component already uses; one "
+          "press would drive both");
+      }
+    }
+    claimed_bits.emplace_back(arm_id, bit);
+  };
+
+  // Claim every referenced input. Overlap with a DIFFERENT component surfaces as
+  // a conflict from the claim table itself.
+  GlideClaimLease lease;
+  for (std::size_t i = 0; i < ba::kMaxSize; ++i) {
+    const AxisMap& axis = parsed[i];
+    if (!axis.configured) continue;
+    switch (axis.source) {
+      case AxisMap::Source::kJoystickX:
+      case AxisMap::Source::kJoystickY:
+        lease.add(axis.arm_id, get_identifier(), {GlideClaim{GlideInput::kJoystick}});
+        break;
+      case AxisMap::Source::kButtons:
+        for (const int bit : {axis.up_bit, axis.down_bit}) {
+          if (bit < 0) continue;
+          claim_bit(axis.arm_id, bit, kAxisNames[i]);
+          lease.add(axis.arm_id, get_identifier(), {glide_button(bit)});
+        }
+        break;
+    }
+  }
+
+  axes_  = std::move(parsed);
+  lease_ = std::move(lease);
+}
+
+float GlideBaseComponent::normalised_axis(const GlideInputSnapshot& snapshot,
+                                          AxisMap::Source source, bool invert) {
+  float value = 0.0f;
+  switch (source) {
+    case AxisMap::Source::kJoystickX:
+      value = normalise_stick(snapshot.joystick_x);
+      break;
+    case AxisMap::Source::kJoystickY:
+      value = normalise_stick(snapshot.joystick_y);
+      break;
+    case AxisMap::Source::kButtons:
+      // Not meaningful as a continuous axis; callers handle buttons separately.
+      value = 0.0f;
+      break;
+  }
+  return invert ? -value : value;
+}
+
+GlideBaseComponent::SnapshotCache GlideBaseComponent::collect_snapshots() const {
+  SnapshotCache cache;
+
+  auto want = [&cache](const std::string& arm_id) {
+    if (arm_id.empty()) return;
+    // Reading once per handle rather than once per axis: emplace leaves an
+    // existing entry alone, so a four-axis config that names two handles makes
+    // two reads.
+    if (cache.find(arm_id) == cache.end()) {
+      cache.emplace(arm_id, GlideSession::instance().read_inputs(arm_id));
+    }
+  };
+
+  for (const auto& axis : axes_) {
+    if (axis.configured) want(axis.arm_id);
+  }
+  return cache;
+}
+
+float GlideBaseComponent::sample_axis(const AxisMap& axis,
+                                      const SnapshotCache& cache) const {
+  if (!axis.configured) return 0.0f;
+
+  const auto it = cache.find(axis.arm_id);
+  if (it == cache.end() || !it->second) return 0.0f;
+  const GlideInputSnapshot& snapshot = *it->second;
+
+  if (axis.source == AxisMap::Source::kButtons) {
+    // Momentary buttons give a three-state axis: full speed either way, or
+    // stopped. Both held cancels rather than picking one, so a stuck button
+    // cannot run the actuator into its end stop.
+    const bool up   = axis.up_bit   >= 0 && snapshot.button(axis.up_bit);
+    const bool down = axis.down_bit >= 0 && snapshot.button(axis.down_bit);
+    const float value = axis.max * (static_cast<float>(up) - static_cast<float>(down));
+    return axis.invert ? -value : value;
+  }
+
+  return scale_axis(normalised_axis(snapshot, axis.source, axis.invert),
+                    axis.max, axis.deadzone);
+}
+
+std::vector<float> GlideBaseComponent::read() {
+  // One read per handle for the whole tick, so rotation and translation cannot
+  // come from different driver cycles.
+  const SnapshotCache cache = collect_snapshots();
+
+  std::vector<float> out(ba::kMaxSize, 0.0f);
+  for (std::size_t i = 0; i < ba::kMaxSize; ++i) {
+    out[i] = sample_axis(axes_[i], cache);
+  }
+
+  return out;
+}
+
+nlohmann::json GlideBaseComponent::get_info() const {
+  nlohmann::json info = nlohmann::json::object();
+  info["type"] = get_type();
+  info["id"]   = get_identifier();
+
+  auto source_name = [](AxisMap::Source s) -> const char* {
+    switch (s) {
+      case AxisMap::Source::kJoystickX: return "joystick_x";
+      case AxisMap::Source::kJoystickY: return "joystick_y";
+      case AxisMap::Source::kButtons:   return "buttons";
+    }
+    return "unknown";
+  };
+
+  nlohmann::json axes = nlohmann::json::object();
+  for (std::size_t i = 0; i < ba::kMaxSize; ++i) {
+    const auto& axis = axes_[i];
+    if (!axis.configured) continue;
+    nlohmann::json entry{
+      {"arm_id", axis.arm_id},
+      {"source", source_name(axis.source)},
+      {"invert", axis.invert},
+      {"max", axis.max},
+      {"deadzone", axis.deadzone},
+    };
+    if (axis.source == AxisMap::Source::kButtons) {
+      entry["up_bit"]   = axis.up_bit;
+      entry["down_bit"] = axis.down_bit;
+    }
+    axes[kAxisNames[i]] = std::move(entry);
+  }
+  info["axes"] = std::move(axes);
+
+  return info;
+}
+
+REGISTER_HARDWARE(GlideBaseComponent, "glide_base")
+
+}  // namespace trossen::hw::glide


### PR DESCRIPTION
`GlideBaseComponent` is a base-space teleop leader — the `BaseSpaceTeleop` interface from #284, now with a leader as well as a follower. `read()` samples the configured handle inputs into `[linear, angular, lift, lateral]`; `write()` is a no-op.

Separate from the arms because the handles drive a different follower than the arm joints do. Modelling them as one bundled device would force a single teleop pair to carry both, so each role is its own pair over the same physical handles, and #289's arbiter keeps them from reading the same input.

**The mapping is entirely declarative, and that is a hardware fact rather than a style preference.** The driver reports each stick only as "0 to 4095" with no physical direction, and the button bit assignments are documented nowhere the SDK can see. Every axis assignment and invert flag was arrived at by driving the base and watching it. So discovering that "raise" is really bit 4 has to be a config edit, not a rebuild. The class docblock records the trap: **the two handles are mirrored models and do not agree**, so neither can be inferred from the other — assuming otherwise produced two wrong signs before the flags converged. It also keeps the bring-up note that if translation direction changes between bring-ups *with nothing edited*, the cause is the swerve modules' homed zero landing half a turn out, and a sign flip will only be right until the next restart.

**One read per handle per tick, not one per axis.** Per-axis reads could mix a left-handle sample from one driver cycle with a right-handle sample from the next, which on a swerve base shows up as rotation and translation disagreeing about when the operator moved. Verified: three axes across two handles produces exactly two reads.

**Buttons are a three-state axis** — full speed either way, or stopped. Both held cancels rather than picking one, so a stuck button cannot run the lift into its end stop.

**Two config mistakes rejected that the claim table cannot catch.** #289 makes repeated identical claims from one component idempotent by design, so the lease is blind to a component overlapping itself:

| Rejected | Why it would otherwise be silent |
| --- | --- |
| `up_bit == down_bit` | `sample_axis()` cancels up against down, so the axis reads zero however hard it is pressed |
| two axes binding one button | one press drives both, and the second claim is accepted as a duplicate |

Deliberately buttons-only. Several axes sharing one handle's **joystick** is the intended pattern — the stick is claimed as a unit, so `linear`-on-x plus `lateral`-on-y is two axes over one claim.

**Deviations from the source branch**

- **Holonomic `translation` is not here** — it lands in the next PR in the stack. A differential-drive base needs only the independent axes in this one, which is what makes this a complete unit. Split because the two together came to 680 lines.
- **No input-freshness gating.** `input_timeout_ms`, the per-handle frame-id record, and the staleness drop in `read()` are all deferred. **Consequence worth knowing before this runs on a rig:** on a Rivet the handles are reached over Wi-Fi sharing a radio with the video feed, and the measured failure is not a clean disconnect — the UDP telemetry loses 60–70% in bursts while the link stays associated and the driver keeps answering *with the last frame it received*. So a read succeeds in microseconds and hands back a joystick position from seconds ago, and the base drives on it. `TeleopController::Config::leader_timeout_ms` does not catch this: the reads keep returning perfectly on time. Change-detection on the axes is not a substitute either — a stick held steady and a stick nobody can see produce identical numbers.
- **No button LEDs.** The `led_*` config keys, `apply_led_effects()` and `update_led_brightness()` are gone with the handle output path, so the lift buttons stay dark instead of lighting while their axis is live.
- **`deadzone` is now validated on independent axes too**, not only on `translation`. Previously `{"max": 1.0, "deadzone": 5.0}` was accepted and then silently zeroed every command — the exact failure the translation check existed to catch. One shared helper now covers both, so a bad number reads the same wherever it appears.
- **`get_info()` reports the resolved axis map** — arm id, source, invert, max, deadzone, and the button bits. The original reported a subset alongside LED state. Given the plan records that the shipped example config disagrees with both rig presets on all three axes, being able to print what actually got parsed is worth having at bring-up.

**Verification.** Build clean, 398/398 ctest. Checked outside the suite with a synthetic reader: centre reads zero, full deflection reads exactly `max`, `invert` flips sign, the output-units deadzone (0.5 of a 2.0 max ⇒ 0.20 travel gives 0 and 0.30 moves), buttons three-state including both-held-cancels and unmapped bits ignored, a handle with no reader contributing zero rather than faulting, claims recorded per handle and released on destruction, one read per handle per tick, and all nine `configure()` rejection paths.

**No tests in this PR.** The Glide suite is deferred with the rest of the extraction's tests. **Coverage note:** neither Workbench config declares a `glide_base` — only the Rivet example does, and that is the one that cannot be built here. So this compiles ungated but no configuration we can run exercises it.
