### PR TITLE
glide: treat one stick as a 2D translation vector for holonomic bases

### DIFF
--- a/include/trossen_sdk/hw/glide/glide_base_component.hpp
+++ b/include/trossen_sdk/hw/glide/glide_base_component.hpp
@@ -85,6 +85,44 @@ namespace trossen::hw::glide {
  * deflection (units depend on the axis — m/s, rad/s, or actuator units/s), and
  * `deadzone` is applied to the *scaled* value so it is expressed in those same
  * units rather than raw counts.
+ *
+ * ### Holonomic bases: use `translation`, not two independent axes
+ *
+ * A swerve or omni base driven by one stick wants that stick treated as a single
+ * 2D vector, which per-axis handling gets wrong in two ways:
+ *
+ *  - **Square deadzone.** Independent per-axis deadzones make the dead region a
+ *    square, so a diagonal nudge inside the corner reads as zero while the same
+ *    magnitude along an axis moves. Direction changes the threshold.
+ *  - **Diagonal overspeed.** Two axes each capped at `max` reach `max * sqrt(2)`
+ *    together, so a full diagonal is ~41% faster than straight ahead.
+ *
+ * The optional `translation` block fixes both by deriving forward and lateral
+ * from one stick with a *radial* deadzone and a magnitude clamp:
+ *
+ * @code
+ * {
+ *   "translation": {
+ *     "arm_id": "glide_right",
+ *     "forward_source": "joystick_y", "forward_invert": true,
+ *     "lateral_source": "joystick_x", "lateral_invert": false,
+ *     "max": 0.6, "deadzone": 0.05
+ *   },
+ *   "axes": {
+ *     "angular": { "arm_id": "glide_left", "source": "joystick_x", "max": 1.2 },
+ *     "lift":    { "arm_id": "glide_right", "source": "buttons",
+ *                  "up_bit": 0, "down_bit": 2, "max": 8000.0 }
+ *   }
+ * }
+ * @endcode
+ *
+ * `translation` and the `linear` / `lateral` entries in `axes` are mutually
+ * exclusive — configuring both for the same axis is rejected rather than
+ * silently letting one win.
+ *
+ * A differential-drive base has no lateral axis to pair, so it keeps using
+ * independent `linear` and `angular` entries; nothing about the existing form
+ * changes.
  */
 class GlideBaseComponent : public HardwareComponent, public teleop::BaseSpaceTeleop {
 public:
@@ -105,8 +143,9 @@ public:
    * @throws std::runtime_error if an input is already claimed by another
    *         component, or if two axes here map to the same input.
    * @throws std::invalid_argument on an unknown source name, a buttons axis
-   *         without at least one of up_bit / down_bit, or a max or deadzone
-   *         outside its valid range.
+   *         without at least one of up_bit / down_bit, a negative max or
+   *         deadzone, or `translation` colliding with a `linear` / `lateral`
+   *         entry.
    */
   void configure(const nlohmann::json& config) override;
 
@@ -152,6 +191,25 @@ private:
     int down_bit{-1};
   };
 
+  /// One stick treated as a 2D translation vector.
+  struct TranslationMap {
+    bool        configured{false};
+    std::string arm_id;
+
+    AxisMap::Source forward_source{AxisMap::Source::kJoystickY};
+    AxisMap::Source lateral_source{AxisMap::Source::kJoystickX};
+    bool            forward_invert{false};
+    bool            lateral_invert{false};
+
+    /// Magnitude at full deflection, in m/s. The clamp is on the *vector*
+    /// magnitude, so a diagonal is no faster than a straight push.
+    float max{1.0f};
+
+    /// Radial dead region, in the same m/s units as `max`. Applied to the
+    /// vector magnitude, making the dead zone a circle.
+    float deadzone{0.0f};
+  };
+
   /// Snapshots for this tick, one entry per distinct handle.
   ///
   /// Every axis used to read its handle independently, so a four-axis config
@@ -173,9 +231,14 @@ private:
   /// unavailable handle.
   float sample_axis(const AxisMap& axis, const SnapshotCache& cache) const;
 
+  /// Evaluate the translation pair into `{forward, lateral}`.
+  std::pair<float, float> sample_translation(const SnapshotCache& cache) const;
+
   /// Indexed by the `base_axis::k*` constants, so the read() vector is built by
   /// position with no separate ordering to keep in sync.
   std::array<AxisMap, teleop::base_axis::kMaxSize> axes_{};
+
+  TranslationMap translation_{};
 
   GlideClaimLease lease_;
 };

--- a/src/hw/glide/glide_base_component.cpp
+++ b/src/hw/glide/glide_base_component.cpp
@@ -5,6 +5,7 @@
 
 #include "trossen_sdk/hw/glide/glide_base_component.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <stdexcept>
@@ -44,9 +45,9 @@ float normalise_stick(std::uint16_t raw) {
 /**
  * @brief Scale a single normalised axis, with the deadzone in output units.
  *
- * Each axis is treated independently, which is the right model for a
- * one-dimensional axis: yaw from a stick pushed sideways, or forward speed on a
- * differential-drive base that cannot strafe anyway.
+ * For a one-dimensional axis (yaw from a stick pushed sideways) a scalar
+ * deadzone is the right model. Two-dimensional translation must not use this —
+ * see `sample_translation()` for why.
  */
 float scale_axis(float normalised, float max, float deadzone) {
   const float scaled = normalised * max;
@@ -54,7 +55,8 @@ float scale_axis(float normalised, float max, float deadzone) {
   return scaled;
 }
 
-/// Shared by every axis, so one bad number reads the same wherever it appears.
+/// Shared by the translation block and each independent axis, so one bad number
+/// reads the same either way.
 void validate_range(float max, float deadzone, const std::string& what) {
   if (!std::isfinite(max) || max <= 0.0f) {
     throw std::invalid_argument(
@@ -71,13 +73,72 @@ void validate_range(float max, float deadzone, const std::string& what) {
 }  // namespace
 
 void GlideBaseComponent::configure(const nlohmann::json& config) {
-  if (!config.contains("axes") || !config.at("axes").is_object()) {
+  const bool has_axes = config.contains("axes") && config.at("axes").is_object();
+  const bool has_translation =
+    config.contains("translation") && config.at("translation").is_object();
+
+  if (!has_axes && !has_translation) {
     throw std::invalid_argument(
       "GlideBaseComponent '" + get_identifier() +
-      "': config requires an 'axes' object; with nothing mapped the component "
-      "would report zero velocity forever");
+      "': config requires an 'axes' object, a 'translation' object, or both; "
+      "with nothing mapped the component would report zero velocity forever");
   }
-  const nlohmann::json& axes_json = config.at("axes");
+
+  TranslationMap translation;
+  if (has_translation) {
+    const auto& j = config.at("translation");
+    translation.configured = true;
+
+    if (!j.contains("arm_id")) {
+      throw std::invalid_argument(
+        "GlideBaseComponent: 'translation' requires 'arm_id'");
+    }
+    translation.arm_id = j.at("arm_id").get<std::string>();
+
+    auto parse_source = [](const std::string& name, const char* field) {
+      if (name == "joystick_x") return AxisMap::Source::kJoystickX;
+      if (name == "joystick_y") return AxisMap::Source::kJoystickY;
+      throw std::invalid_argument(
+        std::string("GlideBaseComponent: translation '") + field +
+        "' must be joystick_x or joystick_y (got '" + name +
+        "'); a translation vector cannot come from buttons");
+    };
+    translation.forward_source =
+      parse_source(j.value("forward_source", std::string{"joystick_y"}), "forward_source");
+    translation.lateral_source =
+      parse_source(j.value("lateral_source", std::string{"joystick_x"}), "lateral_source");
+
+    if (translation.forward_source == translation.lateral_source) {
+      throw std::invalid_argument(
+        "GlideBaseComponent: translation forward_source and lateral_source are "
+        "both the same stick axis, which would make the base only ever drive "
+        "diagonally");
+    }
+
+    translation.forward_invert = j.value("forward_invert", false);
+    translation.lateral_invert = j.value("lateral_invert", false);
+    translation.max            = j.value("max", 1.0f);
+    translation.deadzone       = j.value("deadzone", 0.0f);
+
+    validate_range(translation.max, translation.deadzone, "translation");
+  }
+
+  // Bind to a real lvalue in both branches rather than a ternary temporary, so
+  // there is no lifetime subtlety and no copy of the axes object.
+  static const nlohmann::json kNoAxes = nlohmann::json::object();
+  const nlohmann::json& axes_json = has_axes ? config.at("axes") : kNoAxes;
+
+  if (has_translation) {
+    for (const char* owned : {"linear", "lateral"}) {
+      if (axes_json.contains(owned)) {
+        throw std::invalid_argument(
+          std::string("GlideBaseComponent '") + get_identifier() +
+          "': axis '" + owned + "' is set in 'axes' while 'translation' is also "
+          "configured. Translation owns both linear and lateral; remove one so "
+          "it is unambiguous which produces the command.");
+      }
+    }
+  }
 
   // Parse fully before claiming anything: a claim failure partway through would
   // otherwise leave this component holding inputs it never got to use.
@@ -165,6 +226,10 @@ void GlideBaseComponent::configure(const nlohmann::json& config) {
   // Claim every referenced input. Overlap with a DIFFERENT component surfaces as
   // a conflict from the claim table itself.
   GlideClaimLease lease;
+  if (translation.configured) {
+    lease.add(translation.arm_id, get_identifier(),
+              {GlideClaim{GlideInput::kJoystick}});
+  }
   for (std::size_t i = 0; i < ba::kMaxSize; ++i) {
     const AxisMap& axis = parsed[i];
     if (!axis.configured) continue;
@@ -183,8 +248,9 @@ void GlideBaseComponent::configure(const nlohmann::json& config) {
     }
   }
 
-  axes_  = std::move(parsed);
-  lease_ = std::move(lease);
+  axes_        = std::move(parsed);
+  translation_ = std::move(translation);
+  lease_       = std::move(lease);
 }
 
 float GlideBaseComponent::normalised_axis(const GlideInputSnapshot& snapshot,
@@ -218,6 +284,7 @@ GlideBaseComponent::SnapshotCache GlideBaseComponent::collect_snapshots() const 
     }
   };
 
+  if (translation_.configured) want(translation_.arm_id);
   for (const auto& axis : axes_) {
     if (axis.configured) want(axis.arm_id);
   }
@@ -246,6 +313,48 @@ float GlideBaseComponent::sample_axis(const AxisMap& axis,
                     axis.max, axis.deadzone);
 }
 
+std::pair<float, float> GlideBaseComponent::sample_translation(
+  const SnapshotCache& cache) const {
+  if (!translation_.configured) return {0.0f, 0.0f};
+
+  const auto it = cache.find(translation_.arm_id);
+  if (it == cache.end() || !it->second) return {0.0f, 0.0f};
+  const GlideInputSnapshot& snapshot = *it->second;
+
+  const float fwd = normalised_axis(snapshot, translation_.forward_source,
+                                    translation_.forward_invert);
+  const float lat = normalised_axis(snapshot, translation_.lateral_source,
+                                    translation_.lateral_invert);
+
+  // Treat the stick as a vector, not two numbers. Two things fall out of this
+  // that per-axis handling gets wrong on a holonomic base:
+  //
+  //  - The dead region is a circle, so the threshold to start moving is the
+  //    same in every direction. Per-axis deadzones make it a square, where a
+  //    diagonal nudge inside the corner reads as zero.
+  //  - Magnitude is clamped to `max`, so a full diagonal is exactly as fast as
+  //    a full push forward. Independent axes would reach max*sqrt(2) together,
+  //    making diagonals ~41% faster — a real surprise on a swerve base.
+  const float magnitude = std::hypot(fwd, lat);
+  if (magnitude <= 0.0f) return {0.0f, 0.0f};
+
+  // Deadzone is configured in output units (m/s) for consistency with the
+  // scalar axes, so convert to the normalised domain the magnitude lives in.
+  const float dead_norm = translation_.deadzone / translation_.max;
+  if (magnitude <= dead_norm) return {0.0f, 0.0f};
+
+  // Rescale the surviving range back onto 0..1 so output is continuous from
+  // zero at the deadzone edge rather than jumping to the deadzone value.
+  const float usable = 1.0f - dead_norm;
+  float scaled = usable > 0.0f ? (magnitude - dead_norm) / usable : 0.0f;
+  scaled = std::min(scaled, 1.0f);
+
+  // Preserve direction: divide by the original magnitude to get the unit
+  // vector, then apply the clamped speed.
+  const float speed = scaled * translation_.max;
+  return {fwd / magnitude * speed, lat / magnitude * speed};
+}
+
 std::vector<float> GlideBaseComponent::read() {
   // One read per handle for the whole tick, so rotation and translation cannot
   // come from different driver cycles.
@@ -254,6 +363,15 @@ std::vector<float> GlideBaseComponent::read() {
   std::vector<float> out(ba::kMaxSize, 0.0f);
   for (std::size_t i = 0; i < ba::kMaxSize; ++i) {
     out[i] = sample_axis(axes_[i], cache);
+  }
+
+  // After the per-axis pass, because translation owns kLinear and kLateral
+  // outright — configure() rejects a config that sets either alongside it, so
+  // this overwrites two values that are always zero.
+  if (translation_.configured) {
+    const auto [forward, lateral] = sample_translation(cache);
+    out[ba::kLinear]  = forward;
+    out[ba::kLateral] = lateral;
   }
 
   return out;
@@ -292,6 +410,17 @@ nlohmann::json GlideBaseComponent::get_info() const {
   }
   info["axes"] = std::move(axes);
 
+  if (translation_.configured) {
+    info["translation"] = {
+      {"arm_id", translation_.arm_id},
+      {"forward_source", source_name(translation_.forward_source)},
+      {"forward_invert", translation_.forward_invert},
+      {"lateral_source", source_name(translation_.lateral_source)},
+      {"lateral_invert", translation_.lateral_invert},
+      {"max", translation_.max},
+      {"deadzone", translation_.deadzone},
+    };
+  }
   return info;
 }
 


### PR DESCRIPTION
Second half of the Glide base leader, on top of #291. That PR gave every base axis its own independent mapping; this one adds the mode a holonomic base actually wants.

**Why independent axes are wrong for a swerve base.** A stick driving two axes is one 2D input, and treating it as two scalars breaks in two measurable ways:

| | Independent axes | `translation` |
| --- | --- | --- |
| dead region | a **square** — a diagonal nudge inside the corner reads zero while the same magnitude on-axis moves | a **circle** — same threshold in every direction |
| full diagonal | `max * sqrt(2)`, ~41% faster than straight ahead | exactly `max` |

Measured on the shipped tuning (`max: 0.6`, `deadzone: 0.05`):

```
straight = 0.6      diagonal = 0.6      (independent axes would give 0.848528)
on-axis |0.20| = 0.0763638     diagonal |0.20| = 0.0763365
just outside the deadzone -> 0.00443582 m/s
```

Row 2 is the radial deadzone: a diagonal and an on-axis push of equal magnitude produce the same speed to four decimal places. Row 3 is the rescale — the surviving range is mapped back onto 0..1, so output is continuous from zero at the deadzone edge. Without it the base would lurch to 8% of max the instant the stick left the dead region. Direction is preserved by scaling the unit vector, so 45° in gives 45° out through the clamp.

**Mutual exclusion, not precedence.** `translation` owns `linear` and `lateral`, so setting either in `axes` alongside it is rejected rather than letting one silently win — the config author is told to remove one so it is unambiguous which produces the command. `angular` and `lift` are untouched and pair with `translation` normally.

A differential-drive base has no lateral axis to pair, so it keeps using the independent entries from #291 and nothing about that form changes.

**Verification.** Build clean, 398/398 ctest, and #291's two harnesses still green against this build. Additionally checked: centre reads zero on both axes, straight-forward reaches `max`, the eight `translation`-specific rejection paths (missing `arm_id`, a `buttons` source, an unknown source name, both sources on the same stick axis, non-positive `max`, `deadzone >= max`, and the collision with each of `linear` and `lateral`), that `translation` claims the stick as a unit while a second component claiming the same stick is refused by #289's arbiter, and that `translation` alone is a valid config with no `axes` block at all.

**No tests in this PR** — the Glide suite is deferred with the rest of the extraction's tests. And as in #291: no configuration we can build here declares a `glide_base`, so this compiles ungated but is exercised only on a Rivet.
