### PR TITLE
glide: drive session control from Glide handle buttons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(trossen_sdk SHARED
   src/hw/glide/glide_arm_input_component.cpp
   src/hw/glide/glide_base_component.cpp
   src/hw/glide/glide_session.cpp
+  src/hw/glide/glide_session_control_component.cpp
   src/hw/teleop/teleop_controller.cpp
   src/hw/teleop/teleop_factory.cpp
   src/hw/camera/opencv_camera_component.cpp

--- a/include/trossen_sdk/hw/glide/glide_session_control_component.hpp
+++ b/include/trossen_sdk/hw/glide/glide_session_control_component.hpp
@@ -1,0 +1,150 @@
+/**
+ * @file glide_session_control_component.hpp
+ * @brief Session control driven by Glide handle buttons.
+ */
+
+#ifndef TROSSEN_SDK__HW__GLIDE__GLIDE_SESSION_CONTROL_COMPONENT_HPP_
+#define TROSSEN_SDK__HW__GLIDE__GLIDE_SESSION_CONTROL_COMPONENT_HPP_
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+#include "trossen_sdk/hw/glide/glide_session.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/session_control/session_control_capable.hpp"
+
+namespace trossen::hw::glide {
+
+/**
+ * @brief Turns Glide handle button presses into session-control intents.
+ *
+ * The operator teleoperating a Rivet has both hands on the Glide handles, so
+ * reaching for a keyboard to start or re-record an episode means letting go of
+ * the robot mid-task. This component maps handle buttons onto the same
+ * `SessionControlEvent` intents any other source emits, which is what lets the
+ * cockpit display be a read-only heads-up view rather than something the
+ * operator has to drive.
+ *
+ * Push-based, per the `SessionControlCapable` contract: a small poller thread
+ * watches the claimed buttons and emits on the rising edge.
+ *
+ * Expected JSON:
+ * @code
+ * {
+ *   "buttons": [
+ *     { "arm_id": "glide_left", "bit": 0, "event": "start" },
+ *     { "arm_id": "glide_left", "bit": 1, "event": "stop_session" },
+ *     { "arm_id": "glide_left", "bit": 2, "event": "rerecord" }
+ *   ],
+ *   "poll_rate_hz": 50.0,
+ *   "debounce_ms": 40
+ * }
+ * @endcode
+ *
+ * Event names match `SessionControlEvent`: `start`, `stop_early`, `rerecord`,
+ * `stop_session`. Bit assignments are configuration because the handle's button
+ * bitmask layout is not documented anywhere the SDK can see it — see
+ * `GlideBaseComponent` for the same reasoning, and `kGlideButtonCount` for the
+ * physical cross the four bits form.
+ *
+ * ### Ordering requirements
+ *
+ * `set_callbacks()` must be called before `start()`, which is how
+ * `SessionManager::attach_session_control()` drives it. The poller reads the
+ * stored callbacks without synchronisation, so installing them while it is
+ * already running would be a data race.
+ *
+ * The destructor stops the poller **before** the claim lease releases, which
+ * depends on `lease_` being declared after the thread members: a thread still
+ * running would otherwise read inputs this component no longer holds. Reordering
+ * the member declarations breaks that silently.
+ */
+class GlideSessionControlComponent
+  : public HardwareComponent,
+    public session_control::SessionControlCapable {
+public:
+  explicit GlideSessionControlComponent(std::string identifier)
+    : HardwareComponent(std::move(identifier)) {}
+
+  /// Stops the poller before the claim lease releases, so the thread cannot
+  /// read a snapshot for an input this component no longer holds.
+  ~GlideSessionControlComponent() override;
+
+  GlideSessionControlComponent(const GlideSessionControlComponent&)            = delete;
+  GlideSessionControlComponent& operator=(const GlideSessionControlComponent&) = delete;
+  GlideSessionControlComponent(GlideSessionControlComponent&&)                 = delete;
+  GlideSessionControlComponent& operator=(GlideSessionControlComponent&&)      = delete;
+
+  /**
+   * @brief Parse the button map and claim each button.
+   *
+   * @throws std::invalid_argument on an unknown event name, a missing field, a
+   *         non-positive poll rate, or a negative debounce.
+   * @throws std::runtime_error if a button is already claimed elsewhere.
+   */
+  void configure(const nlohmann::json& config) override;
+
+  std::string get_type() const override { return "glide_session_control"; }
+
+  nlohmann::json get_info() const override;
+
+  // ── SessionControlCapable ────────────────────────────────────────────────
+
+  /// Install the event callback. See "Ordering requirements" above.
+  void set_callbacks(EventCallback on_event,
+                     DisconnectCallback on_disconnect) override;
+
+  /// Start the poller thread. Idempotent.
+  void start() override;
+
+  /// Stop and join the poller thread. Idempotent, and safe from the
+  /// destructor.
+  void stop() override;
+
+private:
+  /// One button-to-intent binding.
+  struct ButtonBinding {
+    std::string                            arm_id;
+    int                                    bit{-1};
+    session_control::SessionControlEvent   event{
+      session_control::SessionControlEvent::kNone};
+
+    /// Last observed state, for rising-edge detection. A held button emits
+    /// once, not once per poll.
+    bool was_pressed{false};
+
+    /// When the current reading first differed from `was_pressed`; a change
+    /// must persist through the debounce window before it counts.
+    std::chrono::steady_clock::time_point changed_at{};
+    bool pending{false};
+  };
+
+  /// Evaluate one polling step against the current snapshots. `poll_loop()`
+  /// calls this on a timer; nothing else does.
+  void poll_once();
+
+  void poll_loop();
+
+  std::vector<ButtonBinding> buttons_;
+  double                     poll_rate_hz_{50.0};
+  std::chrono::milliseconds  debounce_{std::chrono::milliseconds(40)};
+
+  EventCallback event_cb_;
+
+  std::thread       poll_thread_;
+  std::atomic<bool> running_{false};
+
+  /// Declared last on purpose: ~GlideSessionControlComponent() joins the poller
+  /// first, and members destruct in reverse declaration order, so this releasing
+  /// after the thread has stopped is what the destructor's guarantee rests on.
+  GlideClaimLease lease_;
+};
+
+}  // namespace trossen::hw::glide
+
+#endif  // TROSSEN_SDK__HW__GLIDE__GLIDE_SESSION_CONTROL_COMPONENT_HPP_

--- a/src/hw/glide/glide_session_control_component.cpp
+++ b/src/hw/glide/glide_session_control_component.cpp
@@ -1,0 +1,206 @@
+/**
+ * @file glide_session_control_component.cpp
+ * @brief Implementation of GlideSessionControlComponent.
+ */
+
+#include "trossen_sdk/hw/glide/glide_session_control_component.hpp"
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "trossen_sdk/hw/hardware_registry.hpp"
+
+namespace trossen::hw::glide {
+
+using session_control::SessionControlEvent;
+
+namespace {
+
+/// Parse a config event name into the intent enum. `kNone` is deliberately not
+/// accepted: binding a button to "no event" is always a mistake, not a way to
+/// disable it (leave the entry out instead).
+SessionControlEvent event_from_name(const std::string& name) {
+  if (name == "start")        return SessionControlEvent::kStart;
+  if (name == "stop_early")   return SessionControlEvent::kStopEarly;
+  if (name == "rerecord")     return SessionControlEvent::kRerecord;
+  if (name == "stop_session") return SessionControlEvent::kStopSession;
+  throw std::invalid_argument(
+    "GlideSessionControlComponent: unknown event '" + name +
+    "' (expected start, stop_early, rerecord, or stop_session)");
+}
+
+std::string event_name(SessionControlEvent event) {
+  switch (event) {
+    case SessionControlEvent::kStart:       return "start";
+    case SessionControlEvent::kStopEarly:   return "stop_early";
+    case SessionControlEvent::kRerecord:    return "rerecord";
+    case SessionControlEvent::kStopSession: return "stop_session";
+    case SessionControlEvent::kNone:        return "none";
+  }
+  return "unknown";
+}
+
+}  // namespace
+
+GlideSessionControlComponent::~GlideSessionControlComponent() {
+  // Stop the poller before the lease member destructs and drops the claims:
+  // the thread reads inputs this component has claimed, so it must be joined
+  // while those claims are still valid.
+  stop();
+}
+
+void GlideSessionControlComponent::configure(const nlohmann::json& config) {
+  if (!config.contains("buttons") || !config.at("buttons").is_array() ||
+      config.at("buttons").empty()) {
+    throw std::invalid_argument(
+      "GlideSessionControlComponent '" + get_identifier() +
+      "': config requires a non-empty 'buttons' array; with none bound the "
+      "component would claim nothing and never emit an event");
+  }
+
+  const double poll_rate_hz = config.value("poll_rate_hz", 50.0);
+  if (!std::isfinite(poll_rate_hz) || poll_rate_hz <= 0.0) {
+    throw std::invalid_argument(
+      "GlideSessionControlComponent: 'poll_rate_hz' must be finite and positive");
+  }
+
+  const auto debounce_ms = config.value("debounce_ms", 40);
+  if (debounce_ms < 0) {
+    throw std::invalid_argument(
+      "GlideSessionControlComponent: 'debounce_ms' must not be negative");
+  }
+
+  // Parse everything before claiming, so a bad entry cannot leave this
+  // component holding buttons it never bound.
+  std::vector<ButtonBinding> parsed;
+  parsed.reserve(config.at("buttons").size());
+
+  for (const auto& j : config.at("buttons")) {
+    if (!j.contains("arm_id") || !j.contains("bit") || !j.contains("event")) {
+      throw std::invalid_argument(
+        "GlideSessionControlComponent: each 'buttons' entry requires arm_id, "
+        "bit, and event");
+    }
+    ButtonBinding binding;
+    binding.arm_id = j.at("arm_id").get<std::string>();
+    binding.bit    = j.at("bit").get<int>();
+    binding.event  = event_from_name(j.at("event").get<std::string>());
+
+    // Two entries on one button would both fire from a single press, and the
+    // claim table cannot see it: repeated identical claims from one component
+    // are idempotent by design, so the second binding is accepted silently.
+    for (const auto& seen : parsed) {
+      if (seen.arm_id == binding.arm_id && seen.bit == binding.bit) {
+        throw std::invalid_argument(
+          "GlideSessionControlComponent '" + get_identifier() + "': button " +
+          std::to_string(binding.bit) + " on handle '" + binding.arm_id +
+          "' is bound to both '" + event_name(seen.event) + "' and '" +
+          event_name(binding.event) + "'; one press would emit both");
+      }
+    }
+    parsed.push_back(std::move(binding));
+  }
+
+  GlideClaimLease lease;
+  for (const auto& binding : parsed) {
+    lease.add(binding.arm_id, get_identifier(), {glide_button(binding.bit)});
+  }
+
+  buttons_      = std::move(parsed);
+  poll_rate_hz_ = poll_rate_hz;
+  debounce_     = std::chrono::milliseconds(debounce_ms);
+  lease_        = std::move(lease);
+}
+
+void GlideSessionControlComponent::set_callbacks(
+  EventCallback on_event, DisconnectCallback on_disconnect)
+{
+  event_cb_ = std::move(on_event);
+
+  // Deliberately unused. The contract asks for this when a source becomes
+  // permanently unusable, and this source cannot tell that from "quiet right
+  // now": a handle read that fails yields nullopt and recovers by itself on the
+  // next frame, so reporting a disconnect would end the session over a dropped
+  // packet. Nothing here should call it until there is a signal that actually
+  // means permanent.
+  (void)on_disconnect;
+}
+
+void GlideSessionControlComponent::start() {
+  if (running_.exchange(true)) return;  // already started
+  poll_thread_ = std::thread(&GlideSessionControlComponent::poll_loop, this);
+}
+
+void GlideSessionControlComponent::stop() {
+  if (!running_.exchange(false)) return;  // already stopped
+  if (poll_thread_.joinable()) poll_thread_.join();
+}
+
+void GlideSessionControlComponent::poll_loop() {
+  const auto period = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+    std::chrono::duration<double>(1.0 / poll_rate_hz_));
+  auto next_tick = std::chrono::steady_clock::now();
+  while (running_.load(std::memory_order_relaxed)) {
+    poll_once();
+    next_tick += period;
+    std::this_thread::sleep_until(next_tick);
+  }
+}
+
+void GlideSessionControlComponent::poll_once() {
+  const auto now = std::chrono::steady_clock::now();
+
+  for (auto& binding : buttons_) {
+    const auto snapshot = GlideSession::instance().read_inputs(binding.arm_id);
+    if (!snapshot) continue;  // handle unavailable; nothing to compare against
+
+    const bool pressed = snapshot->button(binding.bit);
+
+    if (pressed == binding.was_pressed) {
+      // Matches the confirmed state — any in-flight change was a transient.
+      binding.pending = false;
+      continue;
+    }
+
+    if (!binding.pending) {
+      binding.pending    = true;
+      binding.changed_at = now;
+      // A zero debounce window accepts immediately, so the first differing poll
+      // is also the committing one.
+      if (debounce_.count() > 0) continue;
+    } else if (now - binding.changed_at < debounce_) {
+      continue;  // change hasn't held long enough to be real
+    }
+
+    binding.was_pressed = pressed;
+    binding.pending     = false;
+
+    // Rising edge only: a held button is one intent, and release is not an
+    // event of its own.
+    if (pressed && event_cb_) event_cb_(binding.event);
+  }
+}
+
+nlohmann::json GlideSessionControlComponent::get_info() const {
+  nlohmann::json buttons = nlohmann::json::array();
+  for (const auto& binding : buttons_) {
+    buttons.push_back({
+      {"arm_id", binding.arm_id},
+      {"bit", binding.bit},
+      {"event", event_name(binding.event)},
+    });
+  }
+  return {
+    {"type", get_type()},
+    {"id", get_identifier()},
+    {"poll_rate_hz", poll_rate_hz_},
+    {"debounce_ms", debounce_.count()},
+    {"buttons", buttons},
+  };
+}
+
+REGISTER_HARDWARE(GlideSessionControlComponent, "glide_session_control")
+
+}  // namespace trossen::hw::glide


### PR DESCRIPTION
**This is the implementer #286 has been missing.** `SessionControlCapable` shipped as a seam once `KeyboardComponent` was dropped as a nice-to-have; `GlideSessionControlComponent` fills it. A poller thread watches the claimed handle buttons and emits a semantic intent on the rising edge, so an operator with both hands on the handles can start, re-record or end a session without letting go of the robot — which is what lets the cockpit display stay a read-only heads-up view.

Its stop button emits the same `kStopSession` the webapp's Stop button does, because the same physical button drives both hosts.

**Edge semantics.** Rising edge only: a held button is one intent rather than one per poll, and release is not an event of its own. A change must persist through the debounce window before it counts, so contact bounce on a momentary switch cannot start an episode twice.

**Bit assignments are configuration** for the same reason as #291's axis map — the handle's button bitmask layout is documented nowhere the SDK can see — so re-binding a button is a config edit, not a rebuild. The header cross-references `kGlideButtonCount` for the physical cross the four bits form (0 top, 1 left, 2 bottom, 3 right), since a config author binding bit 1 should know which button they just picked.

**Two ordering requirements, both now stated rather than assumed**

- `set_callbacks()` must precede `start()`. The poller reads the stored callback without synchronisation, so installing one on a running poller is a data race. That is how `attach_session_control()` drives it, but nothing enforced or said it.
- The destructor joins the poller **before** the claim lease releases, so the thread cannot read an input the component no longer holds. That works only because `lease_` is declared after the thread members and destruction runs in reverse. The note is on the member itself, not just the class docblock — a tidy-up reorders members, not comments.

**Deviations from the source branch**

- **`emit_event()` does not exist.** The extraction called a base-class helper; #286's contract is `set_callbacks(on_event, on_disconnect)` with the implementation storing the callbacks. So the component gains an `EventCallback` member and the override.
- **`summon` is gone** from `event_from_name()` / `event_name()` and from the documented event list — it is not in the shipped enum.
- **`poll_once()` is private.** It was public purely as a test seam ("inject a snapshot, call this, assert what was emitted"), and #289 removed `GlideSession::set_test_snapshot()`, so nothing can drive it. Its docblock no longer advertises a workflow that does not exist.
- **`on_disconnect` is accepted and deliberately never called.** This source cannot distinguish "permanently unusable" from "quiet right now": a failed handle read yields `nullopt` and recovers on the next frame, so reporting a disconnect would end the session over a dropped packet. `(void)` with the reason in a comment, rather than a stored member nothing reads.
- **Duplicate bindings rejected** — new. The claim table cannot see it, because repeated identical claims from one component are idempotent by design. Worse here than in #291, since the two events can contradict: `button 0 on handle 'glide_left' is bound to both 'start' and 'stop_session'; one press would emit both`.
- **`configure()` commits all state at the end** — new. The original assigned `poll_rate_hz_` and `debounce_` to the members before parsing the button list, so a config rejected on a bad event name left the component with a new poll rate and its old buttons.

**Verification.** Build clean, 398/398 ctest, and **ThreadSanitizer clean** with the poller live — the first PR in this stack to ship a thread of its own. Behaviour checked against the built library:

| Checked | Result |
| --- | --- |
| held button | emits once, not per poll |
| release | not an event |
| second press | emits again |
| per-bit mapping / unbound bits | correct / ignored |
| two bits rising together | both emit |
| debounce 80 ms | nothing at 30 ms, one event by 150 ms |
| 10 ms transient | swallowed |
| `start()` / `stop()` twice | idempotent; no events after stop |
| destructor | poller joined, then claim released |
| absent handle | silent, no fault |
| no callback installed | survives |

Plus all nine `configure()` rejection paths, including a bit outside the four physical buttons, which #289's claim validation catches.

**No tests in this PR** — the Glide suite is deferred with the rest of the extraction's tests, so the checks above are not in ctest. This completes the Glide input layer: the arbiter (#289), the publisher (#290), the base leader (#291/#292), and now the session-control consumer.
