### PR TITLE
examples: add trossen_workbench, bimanual Glide teleop

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,6 +12,11 @@ target_link_libraries(trossen_stationary_ai trossen_sdk libtrossen_arm)
 add_executable(trossen_mobile_ai trossen_mobile_ai/trossen_mobile_ai.cpp)
 target_link_libraries(trossen_mobile_ai trossen_sdk libtrossen_arm)
 
+# Trossen Workbench — bimanual Glide teleop, 2 passive leaders + 2 followers + 3 cameras.
+# No mobile base and no private dependency, so it builds in the default configuration.
+add_executable(trossen_workbench trossen_workbench/trossen_workbench.cpp)
+target_link_libraries(trossen_workbench trossen_sdk libtrossen_arm)
+
 # Trossen Stationary AI Policy — 2 followers + 4 cameras, policy-driven leaders.
 # Requires the PolicyClient gate (FetchContent of IXWebSocket + msgpack-cxx).
 #

--- a/examples/trossen_workbench/README.md
+++ b/examples/trossen_workbench/README.md
@@ -1,0 +1,185 @@
+# Workbench Example
+
+Bimanual teleop driven by two Trossen Glide handles, recording both handle and
+follower arms plus three ZED cameras to TrossenMCAP format.
+
+The Workbench is the Rivet layout without the mobile base: the same two Glide
+handles driving the same two follower arms, bolted to a fixed bench instead of a
+drivable platform. Nothing here touches `trossen_base`, so this target builds in
+the default configuration.
+
+---
+
+## Hardware Required
+
+| Device | Quantity | Notes |
+|---|---|---|
+| Trossen Glide handle (`glide_left`, `glide_right`) | 2 | Passive leaders — no actuators |
+| Trossen Pro arm (`pro`) | 2 | Followers |
+| ZED camera | 3 | Main view + one per wrist |
+
+The handles are **passive**: they have no actuators and are moved by hand, so the
+example never commands their joints. Their grippers are the exception — each runs
+in effort mode so it stays back-driveable while rendering the follower's grasp
+force back to the operator's fingers.
+
+---
+
+## Building
+
+The cameras are ZEDs, which are behind a build flag that is off by default:
+
+```bash
+cmake -S . -B build -DTROSSEN_ENABLE_ZED=ON
+cmake --build build -j
+```
+
+The arms need no flag. To try the teleop path without ZED hardware, drop the
+`cameras` and camera `producers` entries from `config.json` and build normally.
+
+---
+
+## Network Setup
+
+The handles and the followers are on **different subnets** — this is deliberate
+and matches the rig wiring, so check both before assuming a fault.
+
+| Arm | Role | Default IP |
+|---|---|---|
+| `glide_left` | Handle (passive leader) | `192.168.0.3` |
+| `glide_right` | Handle (passive leader) | `192.168.0.2` |
+| `follower_left` | Follower | `192.168.1.4` |
+| `follower_right` | Follower | `192.168.1.5` |
+
+Override without editing the file:
+
+```bash
+./build/examples/trossen_workbench \
+  --set hardware.arms.glide_left.ip_address=192.168.0.3 \
+  --set hardware.arms.follower_left.ip_address=192.168.1.4
+```
+
+> Arms do not answer ICMP, so `ping` is not a valid reachability test. Use `arp`
+> or check the controller's own logs.
+
+---
+
+## Handle Controls
+
+Each handle carries four momentary buttons arranged as a **physical cross**, and
+the bit numbering is not the order you would guess:
+
+```
+        0  (top)
+          │
+ 1 ───────┼─────── 3
+(left)    │      (right)
+        2  (bottom)
+```
+
+This example binds three buttons on the **left** handle:
+
+| Button | Bit | Event | Effect |
+|---|---|---|---|
+| Top | 0 | `start` | Begin an episode; while recording, stop and advance; while resetting, skip the wait |
+| Left | 1 | `stop_session` | End the whole session (same as Ctrl+C) |
+| Bottom | 2 | `rerecord` | Discard the current episode (or the last one, while resetting) and go again |
+
+Buttons emit on the **rising edge** after a 40 ms debounce, so a held button is
+one intent rather than a stream of them, and releasing is not an event.
+
+Re-binding is a config edit, not a rebuild — see `hardware.controls.session_control.buttons`
+in [config.json](config.json). The bit layout is not documented anywhere the SDK
+can check, so a wrong bit binds a different physical button silently.
+
+---
+
+## Running
+
+```bash
+# Default config
+./build/examples/trossen_workbench
+
+# Custom config file
+./build/examples/trossen_workbench --config path/to/my_config.json
+
+# Inspect the merged config without running
+./build/examples/trossen_workbench --dump-config
+```
+
+The example will:
+
+1. Connect to all four arms, then bring up the handle input and session control
+2. Enable teleop — each follower mirrors its handle at 1000 Hz
+3. Wait for the operator to press **top-left-handle** to start an episode
+4. Record, then stop, flush, and save the `.mcap` file
+5. Repeat until `max_episodes` is reached, the stop button is pressed, or Ctrl+C
+6. Return the followers to rest — the passive handles need no teardown
+
+---
+
+## Default Session Settings
+
+| Setting | Value |
+|---|---|
+| Episode duration | 50 seconds |
+| Max episodes | 40 |
+| Reset window | 5 seconds |
+| Joint poll rate | 30 Hz |
+| Camera frame rate | 30 Hz @ HD1200 |
+| Teleop rate | 1000 Hz |
+| Output directory | `~/trossen_data` |
+| Dataset ID | `workbench_dataset` |
+
+All settings live in [config.json](config.json) and can be overridden with `--set`.
+
+> **LeRobot V2 note:** keep `poll_rate_hz` for arms and `fps`/`poll_rate_hz` for
+> cameras at the same value. Mismatched rates degrade training performance.
+
+---
+
+## Recorded Streams
+
+| Stream ID | Type | Content |
+|---|---|---|
+| `glide_left`, `glide_right` | JointState | position, velocity, effort × 7 — what the operator did |
+| `follower_left`, `follower_right` | JointState | position, velocity, effort × 7 — what the robot did |
+| `camera_main`, `camera_left`, `camera_right` | Image | BGR8 HD1200 @ 30 fps |
+
+---
+
+## Converting to LeRobot V2
+
+```bash
+./build/scripts/trossen_mcap_to_lerobot_v2 ~/trossen_data/workbench_dataset/ ~/lerobot_datasets
+```
+
+See [scripts/trossen_mcap_to_lerobot_v2/README.md](../../scripts/trossen_mcap_to_lerobot_v2/README.md)
+for full options.
+
+---
+
+## Troubleshooting
+
+**`Unknown model: glide_left`**
+The installed `libtrossen_arm` predates Glide support. Check which driver the
+build linked against; the model names come from the driver's own table.
+
+**A handle connects but its buttons do nothing**
+`glide_arm_input` must name that handle in `hardware.controls.glide_inputs.arms`.
+Only that component publishes handle input; the button mapper reads what it
+publishes and claims nothing on its own.
+
+**`arm 'glide_left' is not a registered trossen_arm`**
+The handle is not declared under `hardware.arms`, or its id is spelled
+differently there. Arms are constructed before controls, so a handle named in
+`hardware.controls` must exist in `hardware.arms`.
+
+**`input joystick on handle ... is already claimed by ...`**
+Two components are bound to the same input. Each stick and button may be read by
+exactly one component; check for a bit bound twice across
+`hardware.controls`.
+
+**Follower jitters or overshoots**
+Raise `write_moving_time_s`, or lower `smoothing_beta` for more smoothing at the
+cost of a little lag. Both are per-arm under `hardware.arms`.

--- a/examples/trossen_workbench/config.json
+++ b/examples/trossen_workbench/config.json
@@ -1,0 +1,167 @@
+{
+  "robot_name": "trossen_workbench",
+  "hardware": {
+    "arms": {
+      "glide_left": {
+        "ip_address": "192.168.0.3",
+        "model": "glide_left",
+        "end_effector": "wxai_v0_leader",
+        "actuated": false,
+        "gripper_force_feedback": true,
+        "gripper_feedback_leader_max": 20.0,
+        "gripper_feedback_follower_max": 100.0,
+        "gripper_feedback_offset": 6.5
+      },
+      "glide_right": {
+        "ip_address": "192.168.0.2",
+        "model": "glide_right",
+        "end_effector": "wxai_v0_leader",
+        "actuated": false,
+        "gripper_force_feedback": true,
+        "gripper_feedback_leader_max": 20.0,
+        "gripper_feedback_follower_max": 100.0,
+        "gripper_feedback_offset": 6.5
+      },
+      "follower_left": {
+        "ip_address": "192.168.1.4",
+        "model": "pro",
+        "end_effector": "pro_base",
+        "write_moving_time_s": 0.3,
+        "staging_time_s": 2.0,
+        "smoothing_enabled": true,
+        "smoothing_gripper": false,
+        "smoothing_min_cutoff_hz": 1.0,
+        "smoothing_beta": 0.9,
+        "smoothing_d_cutoff_hz": 1.0
+      },
+      "follower_right": {
+        "ip_address": "192.168.1.5",
+        "model": "pro",
+        "end_effector": "pro_base",
+        "write_moving_time_s": 0.3,
+        "staging_time_s": 2.0,
+        "smoothing_enabled": true,
+        "smoothing_gripper": false,
+        "smoothing_min_cutoff_hz": 1.0,
+        "smoothing_beta": 0.9,
+        "smoothing_d_cutoff_hz": 1.0
+      }
+    },
+    "controls": {
+      "glide_inputs": {
+        "type": "glide_arm_input",
+        "arms": ["glide_left", "glide_right"]
+      },
+      "session_control": {
+        "type": "glide_session_control",
+        "poll_rate_hz": 50.0,
+        "debounce_ms": 40,
+        "buttons": [
+          { "arm_id": "glide_left", "bit": 0, "event": "start" },
+          { "arm_id": "glide_left", "bit": 1, "event": "stop_session" },
+          { "arm_id": "glide_left", "bit": 2, "event": "rerecord" }
+        ]
+      }
+    },
+    "cameras": [
+      {
+        "id": "camera_main",
+        "type": "zed_camera",
+        "serial_number": "51287468",
+        "resolution": "HD1200",
+        "fps": 30,
+        "use_depth": false
+      },
+      {
+        "id": "camera_left",
+        "type": "zed_camera",
+        "serial_number": "97900849",
+        "resolution": "HD1200",
+        "fps": 30,
+        "use_depth": false
+      },
+      {
+        "id": "camera_right",
+        "type": "zed_camera",
+        "serial_number": "97525506",
+        "resolution": "HD1200",
+        "fps": 30,
+        "use_depth": false
+      }
+    ]
+  },
+  "teleop": {
+    "enabled": true,
+    "rate_hz": 1000.0,
+    "pairs": [
+      { "leader": "glide_left", "follower": "follower_left", "space": "joint" },
+      { "leader": "glide_right", "follower": "follower_right", "space": "joint" }
+    ]
+  },
+  "producers": [
+    {
+      "type": "trossen_arm",
+      "hardware_id": "follower_left",
+      "stream_id": "follower_left",
+      "poll_rate_hz": 30.0,
+      "use_device_time": false
+    },
+    {
+      "type": "trossen_arm",
+      "hardware_id": "follower_right",
+      "stream_id": "follower_right",
+      "poll_rate_hz": 30.0,
+      "use_device_time": false
+    },
+    {
+      "type": "trossen_arm",
+      "hardware_id": "glide_left",
+      "stream_id": "glide_left",
+      "poll_rate_hz": 30.0,
+      "use_device_time": false
+    },
+    {
+      "type": "trossen_arm",
+      "hardware_id": "glide_right",
+      "stream_id": "glide_right",
+      "poll_rate_hz": 30.0,
+      "use_device_time": false
+    },
+    {
+      "type": "zed_camera",
+      "hardware_id": "camera_main",
+      "stream_id": "camera_main",
+      "poll_rate_hz": 30.0,
+      "encoding": "bgr8",
+      "use_device_time": true
+    },
+    {
+      "type": "zed_camera",
+      "hardware_id": "camera_left",
+      "stream_id": "camera_left",
+      "poll_rate_hz": 30.0,
+      "encoding": "bgr8",
+      "use_device_time": true
+    },
+    {
+      "type": "zed_camera",
+      "hardware_id": "camera_right",
+      "stream_id": "camera_right",
+      "poll_rate_hz": 30.0,
+      "encoding": "bgr8",
+      "use_device_time": true
+    }
+  ],
+  "backend": {
+    "root": "~/trossen_data",
+    "dataset_id": "workbench_dataset",
+    "compression": "",
+    "chunk_size_bytes": 4194304
+  },
+  "session": {
+    "max_duration": 50.0,
+    "max_episodes": 40,
+    "backend_type": "trossen_mcap",
+    "reset_duration": 5.0
+  }
+}

--- a/examples/trossen_workbench/trossen_workbench.cpp
+++ b/examples/trossen_workbench/trossen_workbench.cpp
@@ -1,0 +1,417 @@
+/**
+ * @file trossen_workbench.cpp
+ * @brief Workbench demo (2 glides, 2 followers, 3 cameras)
+ *
+ * The Workbench is the Rivet layout without the mobile base: the same two Glide
+ * handles driving the same two follower arms, bolted to a fixed bench instead of
+ * a drivable platform. Because nothing here touches trossen_base, this target
+ * builds in the default configuration — no TROSSEN_ENABLE_RIVET, and no access
+ * to the private trossen_base repository.
+ */
+
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "libtrossen_arm/trossen_arm.hpp"
+#include "nlohmann/json.hpp"
+#include "trossen_sdk/configuration/cli_parser.hpp"
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+#include "trossen_sdk/configuration/sdk_config.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/session_control/session_control_capable.hpp"
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
+#include "trossen_sdk/observer/observer_registry.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
+
+#include "trossen_sdk/utils/app_utils.hpp"
+
+static void print_usage(const char* program) {
+  std::cout <<
+    "Usage: " << program << " [OPTIONS]\n"
+    "\n"
+    "Options:\n"
+    "  --config PATH      Path to robot config JSON\n"
+    "                     [default: examples/trossen_workbench/config.json]\n"
+    "  --set KEY=VALUE    Override a config value using dot notation (repeatable)\n"
+    "  --dump-config      Print merged config as JSON and exit\n"
+    "  --help             Show this help and exit\n"
+    "\n"
+    "Examples:\n"
+    "  " << program << "\n"
+    "  " << program << " --config examples/trossen_workbench/config.json\n"
+    "  " << program << " --set hardware.arms.glide_left.ip_address=192.168.1.2\n"
+    "  " << program << " --set session.max_duration=30\n"
+    "  " << program << " --dump-config\n";
+}
+
+int main(int argc, char** argv) {
+  // Flush every line immediately so progress (and the last line before any
+  // stall) is always visible — important for a long-running, hardware-driven
+  // recording loop.
+  std::cout << std::unitbuf;
+
+  trossen::configuration::CliParser cli(argc, argv);
+
+  if (cli.has_flag("help")) {
+    print_usage(argv[0]);
+    return 0;
+  }
+
+  const std::string config_path =
+    cli.get_string("config", "examples/trossen_workbench/config.json");
+
+  if (!std::filesystem::exists(config_path)) {
+    std::cerr << "Error: config file not found: " << config_path << "\n";
+    return 1;
+  }
+
+  // Load JSON and apply CLI overrides
+  auto j = trossen::configuration::JsonLoader::load(config_path);
+  const auto overrides = cli.get_set_overrides();
+  if (!overrides.empty()) {
+    j = trossen::configuration::merge_overrides(j, overrides);
+  }
+
+  if (cli.has_flag("dump-config")) {
+    trossen::configuration::dump_config(j, "Trossen Workbench Config");
+    return 0;
+  }
+
+  // Parse unified robot config
+  auto cfg = trossen::configuration::SdkConfig::from_json(j);
+
+  // Populate GlobalConfig so SessionManager picks up session + backend settings
+  cfg.populate_global_config();
+
+  const std::string root = cfg.mcap_backend.root;
+
+  // Derive per-type rates from the producer list
+  float joint_rate_hz = 30.0f;
+  float camera_fps = 30.0f;
+  for (const auto& p : cfg.producers) {
+    if (p.type == "zed_camera" || p.type == "realsense_camera" ||
+        p.type == "opencv_camera") {
+      camera_fps = p.poll_rate_hz;
+      break;
+    }
+  }
+
+  std::vector<std::string> config_lines = {
+    "Config file:          " + config_path,
+    "Root directory:       " + root,
+    "Backend:              " + cfg.session.backend_type,
+    "Robot name:           " + cfg.robot_name
+  };
+
+  trossen::utils::print_config_banner("Trossen Workbench Demo Usage", config_lines);
+
+  trossen::utils::install_signal_handler();
+  std::filesystem::create_directories(root);
+
+  // ──────────────────────────────────────────────────────────
+  // Initialize arm hardware from config
+  // ──────────────────────────────────────────────────────────
+
+  std::cout << "Initializing hardware...\n";
+
+  // Arms first. Every one is a plain trossen_arm: the two Glide handles are
+  // passive leaders (`actuated: false`) and the two `pro` arms are followers, a
+  // distinction that lives entirely in their config rather than in their type.
+  std::unordered_map<std::string,
+    std::shared_ptr<trossen::hw::arm::TrossenArmComponent>> arm_components;
+
+  for (const auto& [id, arm_cfg] : cfg.hardware.arms) {
+    auto component = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", id, arm_cfg.to_json(), true);
+    arm_components[id] =
+      std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(component);
+    std::cout << "  [ok] Arm [" << id << "] configured (" << arm_cfg.ip_address
+              << ", " << arm_cfg.model
+              << (arm_cfg.actuated ? "" : ", passive leader") << ")\n";
+  }
+
+  // Then the controls — after the arms, because glide_arm_input resolves the
+  // handle arms above by id out of the active registry. Nothing in the SDK
+  // enforces that order; it is this call sequence, which is why a lookup miss
+  // reports the ordering rather than a bare "not found".
+  std::unordered_map<std::string,
+    std::shared_ptr<trossen::hw::HardwareComponent>> controls;
+
+  // Anything that can drive session transitions gets attached to the manager
+  // below. Collected by interface rather than by type so a different button
+  // source needs no change here.
+  std::vector<std::shared_ptr<trossen::hw::session_control::SessionControlCapable>>
+    session_ctrls;
+
+  for (const auto& [id, ctrl_cfg] : cfg.hardware.controls) {
+    auto component = trossen::hw::HardwareRegistry::create(
+      ctrl_cfg.type, id, ctrl_cfg.to_json(), true);
+    controls[id] = component;
+
+    if (auto sc = std::dynamic_pointer_cast<
+          trossen::hw::session_control::SessionControlCapable>(component)) {
+      session_ctrls.push_back(sc);
+    }
+
+    std::cout << "  [ok] Control [" << id << "] configured (type="
+              << ctrl_cfg.type << ")\n";
+  }
+
+  // ──────────────────────────────────────────────────────────
+  // Session Manager + producers
+  // ──────────────────────────────────────────────────────────
+
+  trossen::runtime::SessionManager mgr;
+  std::cout << "\nInitialized Session Manager\n";
+  std::cout << "  Starting episode index: " << mgr.stats().current_episode_index << "\n";
+  if (mgr.stats().current_episode_index > 0) {
+    std::cout << "  (Resuming from existing episodes in directory)\n";
+  }
+  std::cout << "\n";
+
+  // Pre-initialize camera hardware (keyed by camera id for producer lookup)
+  std::unordered_map<std::string,
+    std::shared_ptr<trossen::hw::HardwareComponent>> camera_components;
+  std::unordered_map<std::string,
+    const trossen::configuration::CameraConfig*> camera_cfg_map;
+  for (const auto& cam_cfg : cfg.hardware.cameras) {
+    auto cam_component = trossen::hw::HardwareRegistry::create(
+      cam_cfg.type, cam_cfg.id, cam_cfg.to_json());
+    camera_components[cam_cfg.id] = cam_component;
+    camera_cfg_map[cam_cfg.id] = &cam_cfg;
+    std::cout << "  [ok] Camera [" << cam_cfg.id << "] initialized ("
+              << cam_cfg.serial_number << ")\n";
+  }
+
+  std::cout << "Creating producers...\n";
+
+  // One producer per entry in the producers list
+  for (const auto& prod_cfg : cfg.producers) {
+    const auto period =
+      std::chrono::milliseconds(static_cast<int>(1000.0f / prod_cfg.poll_rate_hz));
+
+    if (arm_components.count(prod_cfg.hardware_id)) {
+      auto prod = trossen::runtime::ProducerRegistry::create(
+        prod_cfg.type,
+        arm_components.at(prod_cfg.hardware_id),
+        prod_cfg.to_registry_json());
+      mgr.add_producer(prod, period);
+      std::cout << "  [ok] Arm producer [" << prod_cfg.stream_id << "] ("
+                << prod_cfg.poll_rate_hz << " Hz)\n";
+    } else if (controls.count(prod_cfg.hardware_id)) {
+      auto prod = trossen::runtime::ProducerRegistry::create(
+        prod_cfg.type,
+        controls.at(prod_cfg.hardware_id),
+        prod_cfg.to_registry_json());
+      mgr.add_producer(prod, period);
+      std::cout << "  [ok] Component producer [" << prod_cfg.stream_id << "] (type="
+                << prod_cfg.type << ", " << prod_cfg.poll_rate_hz << " Hz)\n";
+    } else if (camera_components.count(prod_cfg.hardware_id)) {
+      const auto* cam = camera_cfg_map.at(prod_cfg.hardware_id);
+      if (trossen::runtime::PushProducerRegistry::is_registered(prod_cfg.type)) {
+        auto prod = trossen::runtime::PushProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_push_producer(prod);
+        std::cout << "  [ok] Camera producer (push) [" << prod_cfg.stream_id << "] ("
+                  << cam->width << "x" << cam->height << ")\n";
+      } else {
+        auto prod = trossen::runtime::ProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_producer(prod, period);
+        std::cout << "  [ok] Camera producer [" << prod_cfg.stream_id << "] ("
+                  << prod_cfg.poll_rate_hz << " Hz, "
+                  << cam->width << "x" << cam->height << ")\n";
+      }
+    }
+  }
+
+  std::cout << "\nProducers registered. Ready to record.\n";
+
+  // ──────────────────────────────────────────────────────────
+  // Observers: registered once, started lazily on first episode, persist across episodes.
+  // ──────────────────────────────────────────────────────────
+
+  if (!cfg.observers.empty()) {
+    std::cout << "Creating observers...\n";
+    // Fail loud on construction errors so a typo'd observer type or missing build flag
+    // does not silently leave the operator with an empty viewer. On failure we print a
+    // diagnostic hint (registered types + rerun build flag) and `return 1`. Returning
+    // (rather than rethrowing) keeps `mgr` in scope so its destructor runs ~SessionManager
+    // -> shutdown(), which joins producer threads cleanly; an exception escaping main()
+    // would invoke std::terminate before unwinding on most GCC builds.
+    for (const auto& obs_cfg : cfg.observers) {
+      if (!obs_cfg.enabled) {
+        std::cout << "  [disabled] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " (skipped: enabled=false)\n";
+        continue;
+      }
+      try {
+        auto obs = trossen::observer::ObserverRegistry::create(
+          obs_cfg.type, obs_cfg.raw_json);
+        mgr.add_observer(obs);
+        std::cout << "  [ok] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " subscriptions=" << obs_cfg.subscriptions.size() << "\n";
+      } catch (const std::exception& e) {
+        // Observers are non-essential by design: a missing/misconfigured one logs and
+        // is skipped, so recording continues without the visual stream. The hint below
+        // points at the build flag for the common "type not registered" case.
+        std::cerr << "  [skip] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " failed to construct: " << e.what() << "\n";
+        const auto types =
+          trossen::observer::ObserverRegistry::get_registered_types();
+        std::cerr << "         Registered observer types:";
+        for (const auto& t : types) std::cerr << " " << t;
+        std::cerr << "\n";
+        if (!trossen::observer::ObserverRegistry::is_registered(obs_cfg.type)) {
+          std::cerr << "         Hint: type '" << obs_cfg.type
+                    << "' is not registered. Rebuild with the matching CMake option "
+                    << "(e.g. -DTROSSEN_ENABLE_RERUN_OBSERVER=ON for the 'rerun' type) "
+                    << "or set 'enabled': false on this observer to silence the warning.\n";
+        }
+        continue;
+      }
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────
+  // Teleop controllers
+  // ──────────────────────────────────────────────────────────
+
+  auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+
+  // Hand the controllers to the SessionManager, which owns their per-episode
+  // lifecycle: before each episode it pauses the mirror, re-homes any arm that
+  // opted into the episode lifecycle (episode_lifecycle_enabled in its config),
+  // and re-arms teleop; it starts mirroring when recording goes live, resets
+  // between episodes, and stops teleop at shutdown.
+  const bool has_teleop = !controllers.empty();
+  for (auto& ctrl : controllers) mgr.add_teleop(std::move(ctrl));
+
+  // ──────────────────────────────────────────────────────────
+  // Session control from the Glide handle buttons
+  // ──────────────────────────────────────────────────────────
+
+  // attach_session_control() installs the callbacks and then starts the source,
+  // in that order — after start() the poller reads the callbacks without
+  // locking, so it must not be started first.
+  //
+  // Return rather than let attach throw: the manager holds one source at a time
+  // and rejects a second, and an exception escaping main() would terminate
+  // before `mgr` unwound, leaving its producer threads unjoined.
+  if (session_ctrls.size() > 1) {
+    std::cerr << "Error: " << session_ctrls.size() << " session-control sources in "
+              << "hardware.controls; the session accepts one. Remove the extras.\n";
+    return 1;
+  }
+  for (auto& sc : session_ctrls) {
+    mgr.attach_session_control(sc);
+  }
+  if (!session_ctrls.empty()) {
+    std::cout << "\nSession control live on the Glide buttons: start/next, "
+                 "stop session, re-record.\n";
+  }
+
+  // ──────────────────────────────────────────────────────────
+  // Register lifecycle callbacks
+  // ──────────────────────────────────────────────────────────
+
+  // Count depth-capable cameras once for sanity checks
+  int depth_cameras = 0;
+  for (const auto& cam : cfg.hardware.cameras) {
+    if (cam.use_depth) ++depth_cameras;
+  }
+
+  // After each episode: print a summary and run sanity checks. (Teleop reset and
+  // arm re-homing are owned by the SessionManager.)
+  mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
+    trossen::utils::print_episode_summary(stats.current_episode_path, stats);
+
+    trossen::utils::SanityCheckConfig sanity_cfg{
+      stats.elapsed.count(),
+      static_cast<int>(cfg.hardware.arms.size()),
+      joint_rate_hz,
+      static_cast<int>(cfg.hardware.cameras.size()),
+      static_cast<int>(camera_fps),
+      5.0,
+      depth_cameras
+    };
+    perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
+  });
+
+  // Shutdown: the SessionManager stops teleop and returns those arms to rest.
+  // If teleop is disabled (no controllers), return each arm to rest directly so
+  // they don't stay in their last commanded pose. Unlike the Rivet there is no
+  // base to halt — every follower on a Workbench is an arm.
+  mgr.on_pre_shutdown([&]() {
+    if (!has_teleop) {
+      for (auto& [id, arm] : arm_components) arm->end_teleop();
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Episode loop
+  // ──────────────────────────────────────────────────────────
+
+  while (true) {
+    if (trossen::utils::g_stop_requested) {
+      std::cout << "\n\nStopping at user request (Ctrl+C).\n";
+      break;
+    }
+
+    mgr.print_episode_header();
+
+    if (!mgr.start_episode()) {
+      break;
+    }
+
+    std::cout << "Recording...\n";
+
+    auto action = mgr.monitor_episode();
+
+    if (action == trossen::runtime::UserAction::kReRecord) {
+      continue;
+    }
+
+    if (mgr.is_episode_active()) {
+      mgr.stop_episode();
+    }
+
+    if (trossen::utils::g_stop_requested) {
+      std::cout << "\nStopping at user request (Ctrl+C).\n";
+      break;
+    }
+
+    action = mgr.wait_for_reset();
+    if (action == trossen::runtime::UserAction::kStop) break;
+    if (action == trossen::runtime::UserAction::kReRecord) {
+      continue;
+    }
+  }
+
+  // shutdown() calls stop_episode() (no-op if already stopped) then on_pre_shutdown
+  mgr.shutdown();
+
+  const auto final_stats = mgr.stats();
+  std::vector<std::string> extra_info = {
+    "Data streams:         " + std::to_string(cfg.hardware.arms.size()) + " arms + " +
+      std::to_string(cfg.hardware.cameras.size()) + " cameras + " +
+      std::to_string(cfg.hardware.controls.size()) + " controls"
+  };
+  trossen::utils::print_final_summary(
+    final_stats.total_episodes_completed, root, extra_info);
+
+  return 0;
+}

--- a/examples/trossen_workbench/trossen_workbench.cpp
+++ b/examples/trossen_workbench/trossen_workbench.cpp
@@ -23,6 +23,7 @@
 #include "trossen_sdk/configuration/cli_parser.hpp"
 #include "trossen_sdk/configuration/loaders/json_loader.hpp"
 #include "trossen_sdk/configuration/sdk_config.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
 #include "trossen_sdk/hw/session_control/session_control_capable.hpp"
@@ -412,6 +413,14 @@ int main(int argc, char** argv) {
   };
   trossen::utils::print_final_summary(
     final_stats.total_episodes_completed, root, extra_info);
+
+  // HardwareRegistry::create() registered every component in the ActiveHardwareRegistry,
+  // whose backing map is a function-local static. Returning without this leaves that map
+  // holding the last shared_ptr to each component, so the destructors run during static
+  // destruction — after libcudart has unloaded. A ZED camera closing there fails every
+  // CUDA call with cudaErrorCudartUnloading and may leave the Argus provider claimed,
+  // which then breaks the *next* run's stream start. Release them while CUDA is alive.
+  trossen::hw::ActiveHardwareRegistry::clear();
 
   return 0;
 }


### PR DESCRIPTION
**The first end-to-end exercise of the Glide input layer that can be built here.** The Workbench is the Rivet layout without the mobile base — two Glide handles driving two follower arms, bolted to a fixed bench. Nothing touches `trossen_base`, so it builds in the default configuration with no private dependency, unlike the Rivet example further up the stack.

Three files, matching the house style every other example follows: the main, a config, and a README. No `BRINGUP.md`, no second config — `main` has neither anywhere.

It exercises, on one binary: the arbiter (#289), the input publisher (#290), the base leader's absence, the button mapper (#293), the arm command shaping from #287, and the passive-leader path from #288.

**The handles are passive leaders.** No actuators, moved by hand, joints never commanded. Their grippers are the exception — effort mode, so they stay back-driveable while rendering the follower's grasp force to the operator's fingers.

**Buttons drive the session**, bound in config rather than code because the button bitmask layout is documented nowhere the SDK can check:

| Button | Bit | Event |
|---|---|---|
| Top | 0 | `start` |
| Left | 1 | `stop_session` |
| Bottom | 2 | `rerecord` |

**Deviations from the source branch**

- **`hardware.controls`, not `hardware.components`** — the keyed section from #290 rather than the generic bucket that was dropped. Verified `--set hardware.controls.session_control.debounce_ms=80` reaches it, which is what the map shape bought.
- **`attach_control(*sc); sc->start();` → `attach_session_control(sc);`** — the double start goes, and #286's `shared_ptr` signature lands. `attach_session_control()` calls `set_callbacks()` then `start()` in that order, which is exactly the ordering #293's header requires, so the example gets it right by construction.
- **Added a guard for more than one session-control source.** The manager rejects a second by throwing, and an exception escaping `main()` terminates before `mgr` unwinds, leaving producer threads unjoined. Prints and returns 1 instead, matching the observer-failure pattern already in the file.
- **`joint_signs` / `joint_offsets` and `gripper_feedback_mode` dropped from the config.** The first pair went with the driver-side remap; `gripper_feedback_mode` has no consumer in tree. Worth stating because `ArmConfig` has **no `extra` passthrough**: leaving any of them in would be silently discarded while looking meaningful. A check asserts the config carries none of the five keys this stack removed.
- **Two comment corrections.** `has_actuators=false` was never the key name — it is `actuated: false`. And the ordering comment now says *nothing in the SDK enforces* arms-before-controls; it is this call sequence, which is why #290's lookup miss reports the ordering rather than a bare "not found".
- **Drops `config_solo_glide.json` and `BRINGUP.md`.**

**The README carries two things that exist nowhere else for an operator**, since no `.rst` ships in this stack: the physical cross the four button bits form (`0` top, `1` left, `2` bottom, `3` right — bits 1 and 3 were documented backwards until 2026-08-07), and that the handles sit on `192.168.0.x` while the followers sit on `192.168.1.x`, which reads as a typo until you have seen the rig. Its five troubleshooting entries are all errors this stack produces verbatim.

**Verification.** Builds and links in the default configuration; 398/398 ctest. Run without hardware, it now reaches a real TCP connect to each arm — `[glide_right@192.168.0.2] Connecting to the arm controller's TCP server` — which is as far as a machine with no arms can go. Config parses to 4 arms / 2 controls / 3 cameras / 7 producers / 2 teleop pairs, `--help` and `--dump-config` both work, and every factual claim in the README is cross-checked against `config.json`. The documented camera-free fallback was run too.

**Requires ZED support** for the cameras (`-DTROSSEN_ENABLE_ZED=ON`, off by default) because the Workbench rig has ZEDs and these configs are meant to match the rig rather than be hand-ported — that is what let the Rivet config drift. The README states the flag and the camera-free fallback.
