### PR TITLE
base: Rivet swerve drivetrain as a base-space teleop follower

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,12 @@ option(TROSSEN_ENABLE_RERUN_OBSERVER "Build RerunObserver (depends on rerun-cpp 
 # server bridge flow: cmake -DTROSSEN_SDK_ENABLE_POLICY_CLIENT=ON ...
 option(TROSSEN_SDK_ENABLE_POLICY_CLIENT
   "Build PolicyClient (depends on IXWebSocket + msgpack-cxx)" OFF)
+# OFF by default: it requires the trossen_base drivetrain library to be installed,
+# which most hosts do not have. It gates that LIBRARY, not the robot -- the Glide
+# handle layer needs only libtrossen_arm and is built unconditionally, so a
+# Workbench runs the whole handle path with this off. Enable on a Rivet:
+#   cmake -DTROSSEN_ENABLE_RIVET=ON ...
+option(TROSSEN_ENABLE_RIVET "Enable Rivet mobile base support (requires trossen_base)" OFF)
 
 add_library(trossen_sdk SHARED
   src/backends/backend_registry.cpp
@@ -130,6 +136,17 @@ find_package(BZip2 REQUIRED)
 find_package(Arrow REQUIRED)
 find_package(Parquet REQUIRED)
 find_package(libtrossen_arm REQUIRED)
+
+# Rivet's drivetrain library, consumed the same way as libtrossen_arm above: a
+# Trossen-shipped prebuilt, found rather than built. REQUIRED so a host without
+# it fails at configure time naming the package, instead of at link time naming
+# a symbol.
+if(TROSSEN_ENABLE_RIVET)
+  message(STATUS "Rivet mobile base support enabled")
+  find_package(trossen_base REQUIRED)
+  target_sources(trossen_sdk PRIVATE src/hw/base/trossen_base_component.cpp)
+  target_link_libraries(trossen_sdk PUBLIC trossen_base)
+endif()
 
 include(FetchContent)
 

--- a/include/trossen_sdk/configuration/sdk_config.hpp
+++ b/include/trossen_sdk/configuration/sdk_config.hpp
@@ -29,7 +29,7 @@
  *   "hardware": {
  *     "arms":    { "<id>": { "ip_address": "...", "model": "...", "end_effector": "..." }, ... },
  *     "cameras": [ { "id": "...", "type": "realsense_camera", "serial_number": "...", ... }, ... ],
- *     "mobile_base": { "reset_odometry": false, "enable_torque": false },
+ *     "mobile_base": { "type": "slate_base", "reset_odometry": false, "enable_torque": false },
  *     "controls": { "<id>": { "type": "glide_arm_input", "arms": ["<id>", ...] } }
  *   },
  *   "producers": [

--- a/include/trossen_sdk/configuration/types/hardware/mobile_base_config.hpp
+++ b/include/trossen_sdk/configuration/types/hardware/mobile_base_config.hpp
@@ -6,38 +6,88 @@
 #ifndef TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__MOBILE_BASE_CONFIG_HPP_
 #define TROSSEN_SDK__CONFIGURATION__TYPES__HARDWARE__MOBILE_BASE_CONFIG_HPP_
 
+#include <string>
+
 #include "nlohmann/json.hpp"
 
 namespace trossen::configuration {
 
 /**
- * @brief Configuration for the SLATE mobile base (SlateBaseComponent)
+ * @brief Configuration for the robot's mobile base.
  *
- * JSON format:
+ * The @p type field selects which hardware component is created via
+ * HardwareRegistry, the same way @c CameraConfig::type does. Singular on
+ * purpose: a robot has one base.
+ *
+ * JSON format (SLATE — differential drive, no lift):
+ * @code
  * {
+ *   "type": "slate_base",
  *   "reset_odometry": false,
  *   "enable_torque": false
  * }
+ * @endcode
+ *
+ * JSON format (Rivet — holonomic swerve with a vertical lift):
+ * @code
+ * {
+ *   "type": "trossen_base",
+ *   "max_linear_mps": 0.6,
+ *   "max_angular_rps": 1.2,
+ *   "max_lift_units_per_s": 8000.0,
+ *   "ready_timeout_s": 60.0,
+ *   "home_on_configure": true,
+ *   "command_timeout_ms": 500.0
+ * }
+ * @endcode
+ *
+ * Only the two SLATE keys are modelled as fields, because they are the two the
+ * Python bindings expose. Everything else rides in @p extra and reaches the
+ * component verbatim, so each base keeps its own defaults in one place — its
+ * own configure() — rather than having them restated here to drift apart. See
+ * `TrossenBaseComponent` for what the Rivet keys mean.
  */
 struct MobileBaseConfig {
-  /// @brief Reset base odometry on startup
+  /// @brief Hardware registry key — "slate_base" or "trossen_base"
+  std::string type{"slate_base"};
+
+  /// @brief Reset base odometry on startup (SLATE only)
   bool reset_odometry{false};
 
-  /// @brief Enable torque on startup
+  /// @brief Enable torque on startup (SLATE only)
   bool enable_torque{false};
+
+  /// @brief Passthrough JSON for base-specific settings not modelled above.
+  /// Merged into to_json() output so HardwareComponent::configure() receives
+  /// them transparently.
+  nlohmann::json extra{};
 
   static MobileBaseConfig from_json(const nlohmann::json& j) {
     MobileBaseConfig c;
+    if (j.contains("type")) j.at("type").get_to(c.type);
     if (j.contains("reset_odometry")) j.at("reset_odometry").get_to(c.reset_odometry);
     if (j.contains("enable_torque")) j.at("enable_torque").get_to(c.enable_torque);
+
+    // Parse and erase, so a key added to the struct above cannot also be
+    // duplicated into the passthrough — the failure mode a hand-maintained
+    // known-keys list invites.
+    c.extra = j;
+    c.extra.erase("type");
+    c.extra.erase("reset_odometry");
+    c.extra.erase("enable_torque");
     return c;
   }
 
+  /// @brief Produce JSON suitable for HardwareComponent::configure()
   nlohmann::json to_json() const {
-    return nlohmann::json{
+    nlohmann::json j{
       {"reset_odometry", reset_odometry},
       {"enable_torque", enable_torque}
     };
+    if (!extra.is_null() && extra.is_object()) {
+      j.merge_patch(extra);
+    }
+    return j;
   }
 };
 

--- a/include/trossen_sdk/hw/base/trossen_base_component.hpp
+++ b/include/trossen_sdk/hw/base/trossen_base_component.hpp
@@ -1,0 +1,260 @@
+/**
+ * @file trossen_base_component.hpp
+ * @brief Holonomic swerve base with lift as a base-velocity teleop follower.
+ */
+
+#ifndef TROSSEN_SDK__HW__BASE__TROSSEN_BASE_COMPONENT_HPP_
+#define TROSSEN_SDK__HW__BASE__TROSSEN_BASE_COMPONENT_HPP_
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "trossen_base/trossen_base.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+
+namespace trossen::hw::base {
+
+/**
+ * @brief Rivet's mobile base: holonomic swerve drive plus a vertical lift.
+ *
+ * ### Four different things are called `trossen_base`
+ *
+ * The name is kept for compatibility with shipped rig configs, so the
+ * disambiguation lives here instead:
+ *
+ * | `trossen_base` | is |
+ * | --- | --- |
+ * | `#include "trossen_base/trossen_base.hpp"` | the external drivetrain library |
+ * | the CMake target and FetchContent name | that same library, as a dependency |
+ * | this class | an SDK *consumer* of that library |
+ * | `"type": "trossen_base"` in config | the selector for this component, and the MCAP stream key |
+ *
+ * This component is not the library. It wraps it.
+ *
+ * ### It is not the SLATE base either
+ *
+ * Trossen ships two mobile bases and the names do not distinguish them:
+ *
+ * - **`trossen_base`** (this one) — the Rivet's **holonomic swerve** base with a
+ *   vertical lift. Honours all four `base_axis` axes.
+ * - **`slate_base`** — the other one, **differential drive**, no lift. Honours
+ *   `kLinear` and `kAngular`; it physically cannot strafe.
+ *
+ * A config that names the wrong one connects to hardware that is not there.
+ *
+ * ### `TROSSEN_ENABLE_RIVET` gates the library, not the robot
+ *
+ * That option means "is the `trossen_base` library available to link against",
+ * which is why only this component sits behind it. The Glide input layer is
+ * deliberately **not** gated: it needs `libtrossen_arm` and nothing else, so a
+ * Workbench builds and runs the whole handle path with the option off.
+ *
+ * A `teleop::BaseSpaceTeleop` follower, so any base-space leader can drive it.
+ * Unlike the differential-drive SLATE it honours all four axes of the
+ * `base_axis` layout: `kLinear` and `kLateral` map to the swerve drive's two
+ * translational degrees of freedom and `kLift` to the vertical actuator.
+ *
+ * The driver needs periodic servicing to keep the wheel modules under command,
+ * which does not happen on the teleop write path — a leader that stops writing
+ * must not stall the base mid-motion. So the component owns a thread ticking
+ * `update_base()` at a fixed rate, independent of whether teleop is running.
+ *
+ * ### That servicing thread is why `command_timeout_ms` exists
+ *
+ * The wheels hold their last commanded velocity, and the servicing thread
+ * re-asserts it every tick — so a base told to drive keeps driving until
+ * something says otherwise, whether or not anything is still commanding it. A
+ * mirror loop that dies, a session that ends without `end_teleop()`, a host
+ * process wedged on something else: all of them leave a moving robot with
+ * nobody at the controls, and none of them are visible from here.
+ *
+ * So the servicing thread also checks how old the last accepted command is,
+ * and commands a standstill once it exceeds `command_timeout_ms`. The check
+ * arms on the FIRST `write()` — before that there is nothing to go stale, and a
+ * caller that configures the base without ever driving it (a diagnostic, a
+ * hardware test) should not be told its link is dead.
+ *
+ * This is deliberately independent of `TeleopController`'s leader watchdog.
+ * That one detects a leader that stopped answering and needs the host to react;
+ * this one is local, needs nobody, and holds whatever else fails.
+ *
+ * Expected JSON:
+ * @code
+ * { "id": "rivet_base", "type": "trossen_base",
+ *   "max_linear_mps": 0.6, "max_angular_rps": 1.2,
+ *   "max_lift_units_per_s": 8000.0, "ready_timeout_s": 60.0,
+ *   "home_on_configure": true, "command_timeout_ms": 500.0 }
+ * @endcode
+ */
+class TrossenBaseComponent : public HardwareComponent,
+                             public teleop::BaseSpaceTeleop {
+public:
+  explicit TrossenBaseComponent(std::string identifier)
+    : HardwareComponent(identifier) {}
+
+  /// Stops the base and joins the update thread. Commanding zero here matters:
+  /// the wheels hold their last command until told otherwise, so an
+  /// unceremonious teardown mid-motion would leave the robot driving.
+  ~TrossenBaseComponent() override;
+
+  /**
+   * @brief Connect to the base, wait for it to report ready, start servicing it,
+   *        and (unless `home_on_configure` is false) home the swerve modules.
+   *
+   * @throws std::runtime_error if the base does not become ready within
+   *         `ready_timeout_s`, if homing is requested and does not complete, or
+   *         if any configured limit is not positive.
+   */
+  void configure(const nlohmann::json& config) override;
+
+  /**
+   * @brief Re-zero the swerve modules against their hall sensors.
+   *
+   * Called from configure() when `home_on_configure` is true, which is the
+   * default, so a session never starts against a stale zero. The base does
+   * self-home at power-on, but a pivot can be nudged by hand or lose its
+   * reference to a fault afterwards, and nothing else rechecks it for the rest
+   * of the machine's uptime.
+   *
+   * Blocks until the firmware confirms. The base answers in a second or two in
+   * the normal case; the driver waits up to 120s before giving up.
+   *
+   * `home_on_configure: false` exists for callers that connect to the base for a
+   * reason other than driving it -- a diagnostic, a hardware test -- where the
+   * mechanical re-home is tens of seconds spent for nothing, and the caller
+   * disconnects again without ever commanding a wheel.
+   *
+   * KEEP IT ON for anything that then moves the base. Skipping it means the
+   * modules run on whatever zero they last established, and a pivot that has
+   * drifted will translate a commanded heading into the wrong actual heading --
+   * a robot that drives off at an angle, not one that refuses to drive.
+   *
+   * In particular: do NOT set it false for a recording session on the grounds
+   * that a hardware test homed a moment ago. It is the obvious next saving --
+   * homing dominates what is left of a Rivet's bring-up -- and it is not safe
+   * as things stand, because "the modules are still homed" is an assumption
+   * nothing can check. There is no query for zero validity, so a pivot nudged
+   * between the two bring-ups is undetectable, and the session that inherits it
+   * drives wrong with no error anywhere. Making this safe means exposing that
+   * query from the driver first, not reasoning about how recently we homed.
+   *
+   * @throws std::runtime_error if the base does not confirm homing.
+   */
+  void home_modules();
+
+  std::string get_type() const override { return "trossen_base"; }
+
+  nlohmann::json get_info() const override;
+
+  /// The underlying driver, for the producer to read odometry from.
+  std::shared_ptr<trossen_base::TrossenBase> get_driver() const { return driver_; }
+
+  /// Last velocity actually commanded to the hardware, in `base_axis` order.
+  /// Post-clamp and post-e-stop, so it reflects what the base was told rather
+  /// than what the leader asked for. The producer records this because the base
+  /// reports no measured velocity.
+  std::vector<float> last_command() const;
+
+  // ── teleop::BaseSpaceTeleop ──────────────────────────────────────────────
+
+  /// Returns the last commanded velocity as a full `kMaxSize` vector. The base
+  /// exposes pose but no measured velocity, so this is a command echo, not a
+  /// sensor reading.
+  std::vector<float> read() override;
+
+  /// Apply `[linear, angular, lift, lateral]`, clamping each axis to its
+  /// configured maximum. Axes absent from a shorter vector are treated as zero.
+  /// While the base is e-stopped this commands zero instead of the request.
+  ///
+  /// Also stamps the command clock the freshness watchdog measures against, so
+  /// a rejected write (too short a vector) does NOT count as a live link.
+  void write(const std::vector<float>& cmd) override;
+
+  /// Command zero translation, rotation, and lift. Idempotent.
+  void end_teleop() override;
+
+private:
+  /// Ticks `update_base()` until `update_running_` clears, enforcing command
+  /// freshness on the way.
+  void update_loop();
+
+  /// Command a standstill if the last accepted command is older than
+  /// `command_timeout_ms_`. Called once per servicing tick, from that thread.
+  ///
+  /// No-op while the watchdog is disabled or has never seen a write. Zero is
+  /// re-asserted on every stale tick rather than only on the transition, so
+  /// nothing that pokes the driver behind our back can restart the wheels while
+  /// the link is down.
+  void enforce_command_freshness();
+
+  /// Return the watchdog to its unarmed state, for the paths that stop the base
+  /// on purpose. Not a way to switch the check off — the next write() re-arms.
+  void disarm_command_watchdog();
+
+  /// Send `(linear, lateral, angular, lift)` to the driver and record it as the
+  /// last command. Values must already be clamped.
+  void send(float linear, float angular, float lift, float lateral);
+
+  std::shared_ptr<trossen_base::TrossenBase> driver_;
+
+  /// Rate at which update_loop() services the driver. Matches the rate the base
+  /// was validated at during Rivet bring-up.
+  static constexpr double kUpdateHz = 15.0;
+
+  std::thread update_thread_;
+  std::atomic<bool> update_running_{false};
+
+  /// Guards the last-command echo, written from the teleop thread and read from
+  /// the producer's polling thread.
+  mutable std::mutex command_mutex_;
+  std::array<float, teleop::base_axis::kMaxSize> last_command_{};
+
+  /// One-shot so an e-stop held down does not log at the teleop rate.
+  std::atomic<bool> estop_reported_{false};
+
+  /// steady_clock nanoseconds at the last accepted write(). Zero means the
+  /// watchdog is UNARMED — no command has ever arrived, so none can be late.
+  /// Written by whatever thread drives teleop, read by the servicing thread.
+  std::atomic<std::int64_t> last_command_ns_{0};
+
+  /// Whether the watchdog is currently holding the base stopped. Drives the
+  /// one-shot log lines; the age comparison, not this flag, is
+  /// what decides to zero the wheels, so a lost update cannot leave the base
+  /// driving.
+  std::atomic<bool> command_stale_{false};
+
+  /// How long the base may go without a fresh command before it stops itself,
+  /// in milliseconds. 0 disables the check.
+  ///
+  /// 500 ms by default, against a teleop mirror that writes at 1 kHz — three
+  /// orders of magnitude of headroom, so this cannot fire on a merely busy
+  /// host, and at the 0.6 m/s default limit it bounds an unattended run to
+  /// ~30 cm. Detection granularity is one servicing tick (`kUpdateHz`).
+  ///
+  /// A caller that commands a velocity and then sleeps longer than this will
+  /// now be stopped. That is the intended reading of a velocity command with
+  /// nobody refreshing it; a caller that wants sustained motion must keep
+  /// writing, as the teleop mirror does.
+  double command_timeout_ms_{500.0};
+
+  float max_linear_mps_{0.6f};
+  float max_angular_rps_{1.2f};
+  float max_lift_units_per_s_{8000.0f};
+  double ready_timeout_s_{60.0};
+
+  /// Whether configure() re-zeros the swerve modules. Defaults to true so an
+  /// existing config behaves exactly as it did before this knob existed; see
+  /// home_modules() for when turning it off is legitimate and when it is not.
+  bool home_on_configure_{true};
+};
+
+}  // namespace trossen::hw::base
+
+#endif  // TROSSEN_SDK__HW__BASE__TROSSEN_BASE_COMPONENT_HPP_

--- a/src/hw/base/trossen_base_component.cpp
+++ b/src/hw/base/trossen_base_component.cpp
@@ -1,0 +1,319 @@
+/**
+ * @file trossen_base_component.cpp
+ * @brief Implementation of the Rivet swerve-base teleop follower.
+ */
+
+#include "trossen_sdk/hw/base/trossen_base_component.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "trossen_sdk/hw/hardware_registry.hpp"
+
+namespace trossen::hw::base {
+
+namespace ba = teleop::base_axis;
+
+namespace {
+
+/// Monotonic nanoseconds. steady_clock rather than system_clock on purpose:
+/// this measures an interval, and a wall-clock step (NTP settling on a Jetson
+/// that just booted) must not read as a stale command.
+std::int64_t now_ns() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+/// Clamp to +/-limit, mapping a non-finite request to zero. A NaN reaching
+/// set_cmd_vels would be handed straight to the wheel controllers.
+float clamp_symmetric(float value, float limit) {
+  if (!std::isfinite(value)) return 0.0f;
+  return std::clamp(value, -limit, limit);
+}
+
+/// Read a positive limit, rejecting zero and negatives — a zero limit would
+/// silently pin an axis at standstill, which is worse to debug than a throw.
+float positive_limit(const nlohmann::json& config, const char* key, float fallback,
+                     const std::string& component_id) {
+  if (!config.contains(key)) return fallback;
+  const auto value = config.at(key).get<float>();
+  if (!(value > 0.0f) || !std::isfinite(value)) {
+    throw std::runtime_error(
+      "TrossenBaseComponent '" + component_id + "': '" + key +
+      "' must be a positive, finite number, got " + std::to_string(value));
+  }
+  return value;
+}
+
+}  // namespace
+
+TrossenBaseComponent::~TrossenBaseComponent() {
+  update_running_.store(false, std::memory_order_relaxed);
+  if (update_thread_.joinable()) update_thread_.join();
+
+  // After the servicing thread is down, so the stop cannot be overwritten by a
+  // queued update.
+  if (driver_) {
+    try {
+      send(0.0f, 0.0f, 0.0f, 0.0f);
+      driver_->update_base();
+    } catch (const std::exception& e) {
+      std::cerr << "TrossenBaseComponent '" << get_identifier()
+                << "': failed to stop the base during teardown: " << e.what()
+                << std::endl;
+    }
+  }
+}
+
+void TrossenBaseComponent::configure(const nlohmann::json& config) {
+  const auto& id = get_identifier();
+
+  max_linear_mps_ = positive_limit(config, "max_linear_mps", max_linear_mps_, id);
+  max_angular_rps_ = positive_limit(config, "max_angular_rps", max_angular_rps_, id);
+  max_lift_units_per_s_ =
+    positive_limit(config, "max_lift_units_per_s", max_lift_units_per_s_, id);
+  ready_timeout_s_ = config.value("ready_timeout_s", ready_timeout_s_);
+
+  // Not routed through positive_limit(): zero is the meaningful "disabled"
+  // value here, where for a velocity limit it would be nonsense. Negative is
+  // still rejected, since it could only be a typo and would silently disable a
+  // check the operator believed was armed.
+  command_timeout_ms_ = config.value("command_timeout_ms", command_timeout_ms_);
+  if (!(command_timeout_ms_ >= 0.0) || !std::isfinite(command_timeout_ms_)) {
+    throw std::runtime_error(
+      "TrossenBaseComponent '" + id + "': command_timeout_ms must be a "
+      "non-negative, finite number (0 disables), got " +
+      std::to_string(command_timeout_ms_));
+  }
+
+  // Defaults to true, so an existing config homes exactly as it always has.
+  // Opting out is for the callers that connect for a reason other than driving
+  // the base -- a diagnostic, a hardware test -- where a full mechanical
+  // re-home is tens of seconds spent for nothing. See the header for why it
+  // must stay on for anything that then MOVES the base.
+  home_on_configure_ = config.value("home_on_configure", home_on_configure_);
+
+  driver_ = std::make_shared<trossen_base::TrossenBase>();
+
+  if (!driver_->wait_until_ready(ready_timeout_s_)) {
+    driver_.reset();
+    throw std::runtime_error(
+      "TrossenBaseComponent '" + id + "': base did not report ready within " +
+      std::to_string(ready_timeout_s_) + "s. Check that the base is powered on "
+      "and not e-stopped.");
+  }
+
+  // Start from a known standstill rather than inheriting whatever the previous
+  // process left the wheels doing.
+  send(0.0f, 0.0f, 0.0f, 0.0f);
+
+  update_running_.store(true, std::memory_order_relaxed);
+  update_thread_ = std::thread(&TrossenBaseComponent::update_loop, this);
+
+  if (home_on_configure_) {
+    home_modules();
+  } else {
+    // Said out loud rather than silently skipped: a base that did not home is
+    // running on whatever zero it last established, and someone reading the log
+    // of a session that drove oddly needs to see that this happened.
+    std::cout << "TrossenBaseComponent '" << id
+              << "': skipping swerve homing (home_on_configure=false); the "
+                 "modules keep their existing zero" << std::endl;
+  }
+}
+
+void TrossenBaseComponent::home_modules() {
+  const auto& id = get_identifier();
+
+  // Ordered AFTER the servicing thread starts, and that ordering is load
+  // bearing: home_modules() blocks this thread until the firmware confirms
+  // (its reply timeout is 120s), while the 10Hz connection heartbeat is only
+  // sent from update_base(). Homing first would leave the link silent for the
+  // whole operation and invite a comm-loss fault.
+  std::cout << "TrossenBaseComponent '" << id
+            << "': homing swerve modules, this can take a moment..." << std::endl;
+
+  if (!driver_->home_modules()) {
+    throw std::runtime_error(
+      "TrossenBaseComponent '" + id + "': swerve module homing failed. The base "
+      "reported ready but did not confirm homing. Check that no pivot module is "
+      "obstructed and that the base has no latched fault, then try again.");
+  }
+
+  std::cout << "TrossenBaseComponent '" << id << "': swerve modules homed"
+            << std::endl;
+}
+
+void TrossenBaseComponent::update_loop() {
+  const auto period = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+    std::chrono::duration<double>(1.0 / kUpdateHz));
+  auto next_tick = std::chrono::steady_clock::now();
+
+  while (update_running_.load(std::memory_order_relaxed)) {
+    try {
+      // Ordered BEFORE update_base(), so the tick that notices the link is
+      // stale is also the tick that puts the standstill on the wire. Zeroing
+      // afterwards would transmit the previous velocity one more time.
+      enforce_command_freshness();
+      driver_->update_base();
+    } catch (const std::exception& e) {
+      // Servicing must not die on one bad cycle, or the base stops responding
+      // to commands with no obvious cause.
+      std::cerr << "TrossenBaseComponent '" << get_identifier()
+                << "': update_base() failed: " << e.what() << std::endl;
+    }
+    next_tick += period;
+    std::this_thread::sleep_until(next_tick);
+  }
+}
+
+void TrossenBaseComponent::disarm_command_watchdog() {
+  last_command_ns_.store(0, std::memory_order_relaxed);
+  command_stale_.store(false, std::memory_order_relaxed);
+}
+
+void TrossenBaseComponent::enforce_command_freshness() {
+  if (command_timeout_ms_ <= 0.0) return;
+
+  const auto last = last_command_ns_.load(std::memory_order_relaxed);
+  // Unarmed: nothing has ever commanded this base, so it is already standing
+  // still and there is no link whose silence means anything.
+  if (last == 0) return;
+
+  const auto age_ms = static_cast<double>(now_ns() - last) / 1e6;
+
+  if (age_ms <= command_timeout_ms_) {
+    // Recovery is logged because "the base went dead for a moment and came
+    // back" is the signature of a link dropping in bursts rather than failing
+    // outright, and that distinction is invisible from a stop line alone.
+    if (command_stale_.exchange(false, std::memory_order_relaxed)) {
+      std::cout << "TrossenBaseComponent '" << get_identifier()
+                << "': commands are arriving again, releasing the standstill"
+                << std::endl;
+    }
+    return;
+  }
+
+  if (!command_stale_.exchange(true, std::memory_order_relaxed)) {
+    std::cerr << "TrossenBaseComponent '" << get_identifier()
+              << "': no command for " << static_cast<std::int64_t>(age_ms)
+              << " ms (limit " << static_cast<std::int64_t>(command_timeout_ms_)
+              << " ms) — treating the link as lost and stopping the base"
+              << std::endl;
+  }
+  send(0.0f, 0.0f, 0.0f, 0.0f);
+}
+
+void TrossenBaseComponent::send(float linear, float angular, float lift, float lateral) {
+  if (!driver_) return;
+
+  // set_cmd_vels takes (lin_x, lin_y, ang_vel): forward, lateral, yaw.
+  driver_->set_cmd_vels(linear, lateral, angular);
+
+  // The lift is commanded in integer actuator units per second. Clamp to the
+  // int16 range before narrowing so a large float cannot wrap to full reverse.
+  const float lift_bounded = std::clamp(
+    lift,
+    static_cast<float>(std::numeric_limits<std::int16_t>::min()),
+    static_cast<float>(std::numeric_limits<std::int16_t>::max()));
+  driver_->set_actuator_velocity(static_cast<std::int16_t>(lift_bounded));
+
+  std::lock_guard<std::mutex> lock(command_mutex_);
+  last_command_[ba::kLinear]  = linear;
+  last_command_[ba::kAngular] = angular;
+  last_command_[ba::kLift]    = lift;
+  last_command_[ba::kLateral] = lateral;
+}
+
+void TrossenBaseComponent::write(const std::vector<float>& cmd) {
+  if (!driver_) {
+    std::cerr << "TrossenBaseComponent '" << get_identifier()
+              << "': write() ignored, base is not configured" << std::endl;
+    return;
+  }
+  if (cmd.size() < ba::kMinSize) {
+    std::cerr << "TrossenBaseComponent '" << get_identifier()
+              << "': write() needs at least " << ba::kMinSize
+              << " axes (linear, angular), got " << cmd.size() << std::endl;
+    return;
+  }
+
+  // Stamped before anything is sent, and before the e-stop branch, so the
+  // watchdog sees a live link the instant a valid command arrives. Doing it
+  // last would leave a window where the servicing thread could compute a stale
+  // age against a command it is concurrently being given, and zero the wheels
+  // one tick after they were legitimately told to move.
+  //
+  // A short vector is rejected above and deliberately does not reach here: a
+  // caller sending malformed commands is not a working link.
+  last_command_ns_.store(now_ns(), std::memory_order_relaxed);
+
+  // Honour the e-stop rather than pushing commands against it: keep servicing
+  // the driver, but command a standstill so releasing the e-stop cannot hand
+  // the wheels a stale velocity from before it was pressed.
+  if (driver_->is_e_stopped()) {
+    if (!estop_reported_.exchange(true)) {
+      std::cerr << "TrossenBaseComponent '" << get_identifier()
+                << "': base is e-stopped, commanding zero velocity until it is "
+                << "released" << std::endl;
+    }
+    send(0.0f, 0.0f, 0.0f, 0.0f);
+    return;
+  }
+  estop_reported_.store(false, std::memory_order_relaxed);
+
+  send(clamp_symmetric(ba::get(cmd, ba::kLinear),  max_linear_mps_),
+       clamp_symmetric(ba::get(cmd, ba::kAngular), max_angular_rps_),
+       clamp_symmetric(ba::get(cmd, ba::kLift),    max_lift_units_per_s_),
+       clamp_symmetric(ba::get(cmd, ba::kLateral), max_linear_mps_));
+}
+
+void TrossenBaseComponent::end_teleop() {
+  if (!driver_) return;
+  send(0.0f, 0.0f, 0.0f, 0.0f);
+  // Disarm the freshness watchdog. Teleop ending is not a lost link, and a
+  // watchdog left armed would announce one half a second after every clean
+  // stop — the fastest way to teach an operator to ignore the warning that
+  // matters. It re-arms on the next write().
+  disarm_command_watchdog();
+}
+
+std::vector<float> TrossenBaseComponent::last_command() const {
+  std::lock_guard<std::mutex> lock(command_mutex_);
+  return std::vector<float>(last_command_.begin(), last_command_.end());
+}
+
+std::vector<float> TrossenBaseComponent::read() { return last_command(); }
+
+nlohmann::json TrossenBaseComponent::get_info() const {
+  nlohmann::json info = nlohmann::json::object();
+  info["type"] = get_type();
+  info["id"]   = get_identifier();
+  info["max_linear_mps"] = max_linear_mps_;
+  info["max_angular_rps"] = max_angular_rps_;
+  info["max_lift_units_per_s"] = max_lift_units_per_s_;
+  info["command_timeout_ms"] = command_timeout_ms_;
+  // Reported because "the base drives at the wrong angle" and "this bring-up
+  // skipped homing" are the same bug seen from two ends, and this is the only
+  // place to find out afterwards which one you have.
+  info["home_on_configure"] = home_on_configure_;
+  info["connected"] = static_cast<bool>(driver_);
+  if (driver_) {
+    info["ready"]      = driver_->is_ready();
+    info["e_stopped"]  = driver_->is_e_stopped();
+    info["battery_percent"] = driver_->get_percent();
+  }
+  return info;
+}
+
+REGISTER_HARDWARE(TrossenBaseComponent, "trossen_base")
+
+}  // namespace trossen::hw::base


### PR DESCRIPTION
## Summary

`TrossenBaseComponent` — the Rivet's mobile base as a `teleop::BaseSpaceTeleop` follower. Holonomic swerve drive plus a vertical lift, honouring all four `base_axis` axes where the differential-drive SLATE honours two.

Plus the `TROSSEN_ENABLE_RIVET` option and the `hardware.mobile_base` schema entry that declares this hardware.

## Why there is a servicing thread, and why `command_timeout_ms` exists

This is the part that isn't reconstructable from the code, so it belongs here.

The driver must be ticked whether or not teleop is running — a leader that stops writing must not stall the base mid-motion. So the component owns a thread ticking `update_base()` at a fixed rate, independent of teleop.

That thread is exactly why the timeout is needed. The wheels hold their last commanded velocity and the thread re-asserts it every tick, so **a base told to drive keeps driving until something says otherwise**, whether or not anything is still commanding it. A mirror loop that dies, a session that ends without `end_teleop()`, a host process wedged on something else: all of them leave a moving robot with nobody at the controls, and none of them are visible from here.

So the servicing thread also checks how old the last accepted command is and commands a standstill past `command_timeout_ms` (default 500 ms, against a mirror that writes at 1 kHz — three orders of magnitude of headroom). It arms on the **first** `write()`: before that there is nothing to go stale, and a caller that configures the base without ever driving it shouldn't be told its link is dead.

**It does not cover a handle whose values go stale while still flowing.** That check is deferred; `read()` would keep returning the last stick value, `write()` would keep arriving with fresh timestamps, and this watchdog would never fire. The two are not substitutes.

## Four different things are called `trossen_base`

The name is kept for compatibility with shipped rig configs, so the header carries the disambiguation:

| `trossen_base` | is |
| --- | --- |
| `#include "trossen_base/trossen_base.hpp"` | the external drivetrain library |
| the CMake target | that same library, as a dependency |
| this class | an SDK *consumer* of that library |
| `"type": "trossen_base"` in config | the selector for this component, and the MCAP stream key |

It is also **not** the SLATE base — that one is differential drive with no lift, and a config naming the wrong one connects to hardware that is not there.

## `TROSSEN_ENABLE_RIVET` gates the library, not the robot

The option means "is the `trossen_base` library available to link against", which is why only this component sits behind it. The Glide handle layer needs `libtrossen_arm` and nothing else, so **a Workbench builds and runs the whole handle path with the option off**.

`trossen_base` is consumed with `find_package(trossen_base REQUIRED)` beside `libtrossen_arm` — both Trossen-shipped prebuilts, found rather than built — so a host without it fails at configure time naming the package rather than at link time naming a symbol.

## Schema

`hardware.mobile_base` gains a `type` field defaulting to `"slate_base"`, the way `CameraConfig::type` defaults to `"realsense_camera"`, plus an `extra` passthrough. The base-specific keys ride in `extra` and reach `configure()` verbatim, so each base keeps its defaults in one place — its own `configure()` — rather than having them restated in the config struct where they would drift apart.

## Test Plan

- [x] Default configuration (`TROSSEN_ENABLE_RIVET=OFF`): builds clean, **398/398 tests pass**, zero `TrossenBaseComponent` symbols in the library
- [x] `TROSSEN_ENABLE_RIVET=ON` against an **installed** `trossen_base`: configures, builds, links — 114 symbols present, `ldd` resolves `libtrossen_base.so` from the install prefix
- [x] `TROSSEN_ENABLE_RIVET=ON` with `trossen_base` **absent**: fails at configure with `Could not find a package configuration file provided by "trossen_base"` — no hang, no link-time surprise
- [x] cpplint / pre-commit clean
- [ ] Not exercised on Rivet hardware

## Notes for review

- The e-stop **behaviour** is intact: `write()` commands a standstill while `driver_->is_e_stopped()`, so releasing the e-stop can't hand the wheels a velocity from before it was pressed. What this PR omits is the e-stop/telemetry/battery *read-out* API, which had no in-tree consumer.
- Pre-existing bug found and deliberately **not** fixed here: `MobileBaseConfig::enable_torque` defaults to `false` while `SlateBaseComponent::configure()` defaults it to `true`, and `to_json()` emits it unconditionally — so a SLATE config that omits the key gets torque off through the struct and on through raw JSON. It predates this stack and only affects SLATE.
