### PR TITLE
base: record Rivet base odometry and commanded velocity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,10 @@ find_package(libtrossen_arm REQUIRED)
 if(TROSSEN_ENABLE_RIVET)
   message(STATUS "Rivet mobile base support enabled")
   find_package(trossen_base REQUIRED)
-  target_sources(trossen_sdk PRIVATE src/hw/base/trossen_base_component.cpp)
+  target_sources(trossen_sdk PRIVATE
+    src/hw/base/trossen_base_component.cpp
+    src/hw/base/trossen_base_producer.cpp
+  )
   target_link_libraries(trossen_sdk PUBLIC trossen_base)
 endif()
 

--- a/include/trossen_sdk/data/record.hpp
+++ b/include/trossen_sdk/data/record.hpp
@@ -112,6 +112,15 @@ struct JointStateRecord : public RecordBase {
 
 /**
  * @brief 2D odometry state (pose + velocity), mirroring nav_msgs/Odometry.
+ *
+ * TODO(shantanuparab-tr): Revisit this record's name and shape. `lift_velocity`
+ * below is not 2D odometry and does not mirror nav_msgs/Odometry either — it is
+ * vertical motion carried here because a base that reports it has nowhere else
+ * to put it, and the same argument would drag in every other non-planar thing a
+ * base measures. Either this becomes a record whose name admits it describes
+ * base state generally, or the non-planar axes move to a record of their own.
+ * Battery telemetry was proposed alongside the lift and deliberately left out
+ * for exactly this reason.
  */
 struct Odometry2DRecord : public RecordBase {
   /// @brief 2D pose in the odom frame.
@@ -133,6 +142,13 @@ struct Odometry2DRecord : public RecordBase {
     /// @brief Angular velocity around z (rad/s)
     float angular_z{0.f};
   } twist;
+
+  /// @brief Vertical lift velocity, in the actuator's own units per second.
+  ///
+  /// Outside the 2D twist above because a lift is not planar motion. Zero on
+  /// bases without one, so a consumer may read it unconditionally. See the TODO
+  /// on this record for why it sitting here at all is provisional.
+  float lift_velocity{0.f};
 };
 
 /**

--- a/include/trossen_sdk/hw/base/trossen_base_producer.hpp
+++ b/include/trossen_sdk/hw/base/trossen_base_producer.hpp
@@ -1,0 +1,105 @@
+/**
+ * @file trossen_base_producer.hpp
+ * @brief Producer that records pose and commanded velocity from the Rivet base.
+ */
+
+#ifndef TROSSEN_SDK__HW__BASE__TROSSEN_BASE_PRODUCER_HPP_
+#define TROSSEN_SDK__HW__BASE__TROSSEN_BASE_PRODUCER_HPP_
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "trossen_base/trossen_base.hpp"
+
+#include "trossen_sdk/data/record.hpp"
+#include "trossen_sdk/data/timestamp.hpp"
+#include "trossen_sdk/hw/base/trossen_base_component.hpp"
+#include "trossen_sdk/hw/hardware_component.hpp"
+#include "trossen_sdk/hw/producer_base.hpp"
+
+namespace trossen::hw::base {
+
+/**
+ * @brief Emits an Odometry2DRecord per poll for the Rivet swerve base.
+ *
+ * Pose comes from the base's own odometry. Twist does not: the base reports no
+ * measured velocity, so the recorded twist is the velocity most recently
+ * *commanded* to it. For a learned policy that distinction matters — the twist
+ * channel is an action echo, not an observation — which is why it is stated here
+ * and in the stream metadata rather than left for a reader to infer.
+ *
+ * The lift rides in `Odometry2DRecord::lift_velocity`, outside the 2D twist,
+ * since vertical motion is not planar. It is a command echo for the same reason.
+ */
+class TrossenBaseProducer : public ::trossen::hw::PolledProducer {
+public:
+  /// @brief Configuration parameters for TrossenBaseProducer
+  struct Config {
+    /// @brief Logical stream identifier.
+    std::string stream_id{"base"};
+
+    /// @brief Prefer a device timestamp when one is available.
+    bool use_device_time{false};
+  };
+
+  /// @brief Metadata specific to TrossenBaseProducer
+  struct TrossenBaseProducerMetadata : public PolledProducer::ProducerMetadata {
+    /// @brief Base model type.
+    std::string base_model;
+
+    nlohmann::ordered_json get_info() const override {
+      return nlohmann::ordered_json{};
+    }
+
+    /// Names the four axes this base actually drives, so a converter does not
+    /// have to assume the 2-axis differential-drive layout the SLATE reports.
+    nlohmann::ordered_json get_stream_info() const override {
+      nlohmann::ordered_json info;
+      info["has_mobile_base"] = true;
+      info["base_velocity_names"] = nlohmann::json::array(
+        {"linear_vel", "angular_vel", "lift_vel", "lateral_vel"});
+      return info;
+    }
+  };
+
+  /**
+   * @brief Construct from a configured TrossenBaseComponent.
+   *
+   * @throws std::invalid_argument if @p hardware is null, is not a
+   *         TrossenBaseComponent, or has no driver.
+   */
+  TrossenBaseProducer(
+    std::shared_ptr<hw::HardwareComponent> hardware,
+    const nlohmann::json& config);
+
+  ~TrossenBaseProducer() override = default;
+
+  /**
+   * @brief Emit one Odometry2DRecord: measured pose, last-commanded twist.
+   *
+   * Runs on the scheduler thread while the component's servicing thread ticks
+   * the same driver, so what it may touch is constrained — see the note in the
+   * implementation before adding a field here.
+   */
+  void poll(const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) override;
+
+  std::shared_ptr<ProducerMetadata> metadata() const override {
+    return std::make_shared<TrossenBaseProducerMetadata>(metadata_);
+  }
+
+private:
+  /// The component rather than the bare driver: the last commanded velocity is
+  /// the component's state, since the base cannot report it back.
+  std::shared_ptr<TrossenBaseComponent> component_;
+
+  std::shared_ptr<trossen_base::TrossenBase> driver_;
+
+  Config cfg_;
+
+  TrossenBaseProducerMetadata metadata_;
+};
+
+}  // namespace trossen::hw::base
+
+#endif  // TROSSEN_SDK__HW__BASE__TROSSEN_BASE_PRODUCER_HPP_

--- a/include/trossen_sdk/io/backends/trossen_mcap/proto/Odometry2D.proto
+++ b/include/trossen_sdk/io/backends/trossen_mcap/proto/Odometry2D.proto
@@ -40,4 +40,9 @@ message Odometry2D {
 
   // Body-frame twist
   Twist2D twist = 4;
+
+  // Vertical lift velocity in actuator units per second (0 on bases with no
+  // lift). Outside Twist2D because a lift is not planar motion; see the TODO on
+  // Odometry2DRecord in data/record.hpp for why carrying it here is provisional.
+  float lift_velocity = 5;
 }

--- a/src/backends/trossen_mcap/trossen_mcap_backend.cpp
+++ b/src/backends/trossen_mcap/trossen_mcap_backend.cpp
@@ -446,6 +446,8 @@ void TrossenMCAPBackend::write_odometry_2d_record(const data::Odometry2DRecord& 
   twist->set_linear_y(odom.twist.linear_y);
   twist->set_angular_z(odom.twist.angular_z);
 
+  out.set_lift_velocity(odom.lift_velocity);
+
   std::string payload;
   out.SerializeToString(&payload);
 

--- a/src/hw/base/trossen_base_producer.cpp
+++ b/src/hw/base/trossen_base_producer.cpp
@@ -1,0 +1,99 @@
+/**
+ * @file trossen_base_producer.cpp
+ * @brief Implementation of TrossenBaseProducer.
+ */
+
+#include "trossen_sdk/hw/base/trossen_base_producer.hpp"
+
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+
+namespace trossen::hw::base {
+
+namespace ba = teleop::base_axis;
+
+TrossenBaseProducer::TrossenBaseProducer(
+  std::shared_ptr<hw::HardwareComponent> hardware,
+  const nlohmann::json& config) {
+  if (!hardware) {
+    throw std::invalid_argument("TrossenBaseProducer: hardware component cannot be null");
+  }
+
+  component_ = std::dynamic_pointer_cast<TrossenBaseComponent>(hardware);
+  if (!component_) {
+    throw std::invalid_argument(
+      "TrossenBaseProducer: hardware must be TrossenBaseComponent, got: " +
+      hardware->get_type());
+  }
+
+  driver_ = component_->get_driver();
+  if (!driver_) {
+    throw std::invalid_argument(
+      "TrossenBaseProducer: TrossenBaseComponent has null driver; configure it first");
+  }
+
+  cfg_.stream_id = config.value("stream_id", "base");
+  cfg_.use_device_time = config.value("use_device_time", false);
+
+  metadata_.type = "base";
+  metadata_.id = cfg_.stream_id;
+  metadata_.name = "Trossen Base Producer";
+  metadata_.description =
+    "Produces odometry and commanded velocity from the Rivet swerve base";
+  metadata_.base_model = "Rivet";
+}
+
+void TrossenBaseProducer::poll(
+  const std::function<void(std::shared_ptr<data::RecordBase>)>& emit) {
+  if (!driver_ || !component_) return;
+
+  // Two threads reach this driver: this one, and the component's servicing
+  // thread ticking update_base() at 15Hz. That is safe only because of which
+  // fields each touches, so check before adding a read here.
+  //
+  // TrossenBase caches into one unsynchronised `base_data_` struct. get_pose()
+  // writes its pose members; update_base() -> refresh_battery_status() writes
+  // the battery members. Disjoint members of a struct are distinct memory
+  // locations, so the two do not race, and the reads underneath both take the
+  // driver's own status_mutex_ against its receive thread.
+  //
+  // The battery accessors are the trap: get_percent(), get_temp() and
+  // get_charging_state() read exactly the members the servicing thread writes,
+  // with nothing between them. Calling one here would be a genuine data race on
+  // a non-atomic float. Battery telemetry is deliberately not recorded — see
+  // Odometry2DRecord — which is what keeps this poll to disjoint state.
+  const auto pose = driver_->get_pose();
+  const auto command = component_->last_command();
+
+  data::Timestamp ts;
+  ts.monotonic = data::now_mono();
+  ts.realtime = data::now_real();
+
+  auto rec = std::make_shared<data::Odometry2DRecord>();
+  rec->ts = ts;
+  rec->seq = seq_++;
+  rec->id = cfg_.stream_id;
+
+  rec->pose.x     = pose[0];
+  rec->pose.y     = pose[1];
+  rec->pose.theta = pose[2];
+
+  // Commanded, not measured — the base reports no velocity feedback. Read
+  // through base_axis::get() so a future change to the echo's length cannot
+  // walk off the end here.
+  rec->twist.linear_x  = ba::get(command, ba::kLinear);
+  rec->twist.linear_y  = ba::get(command, ba::kLateral);
+  rec->twist.angular_z = ba::get(command, ba::kAngular);
+  rec->lift_velocity   = ba::get(command, ba::kLift);
+
+  emit(rec);
+  stats_.produced++;
+}
+
+REGISTER_PRODUCER(TrossenBaseProducer, "trossen_base");
+
+}  // namespace trossen::hw::base

--- a/tests/test_trossen_mcap_backend.cpp
+++ b/tests/test_trossen_mcap_backend.cpp
@@ -16,6 +16,7 @@
 #include "gtest/gtest.h"
 
 #include "trossen_sdk/configuration/global_config.hpp"
+#include "trossen_sdk/data/record.hpp"
 #include "trossen_sdk/configuration/loaders/json_loader.hpp"
 #include "trossen_sdk/io/backend_registry.hpp"
 #include "trossen_sdk/io/backends/trossen_mcap/trossen_mcap_backend.hpp"
@@ -229,4 +230,66 @@ TEST_F(TrossenMCAPBackendTest, ScanCountsLegacyAndNewEpisodeFiles) {
   auto backend = BackendRegistry::create("trossen_mcap");
   ASSERT_NE(backend, nullptr);
   EXPECT_EQ(backend->scan_existing_episodes(), 3u);
+}
+
+// lift_velocity is the one Odometry2D field a SLATE never sets, so a mistake in
+// either half of its path -- the .proto declaration or the write hunk -- is
+// invisible on every existing rig and only shows up as a silently zeroed column
+// in a Rivet dataset. Assert both halves against the bytes on disk.
+TEST_F(TrossenMCAPBackendTest, LiftVelocityReachesTheFile) {
+  auto cfg = trossen::configuration::GlobalConfig::instance()
+               .get_as<trossen::configuration::TrossenMCAPBackendConfig>(
+                 "trossen_mcap_backend");
+  ASSERT_NE(cfg, nullptr);
+  RootDatasetRestorer restorer{cfg.get(), cfg->root, cfg->dataset_id};
+  const std::string saved_compression = cfg->compression;
+
+  cfg->root = std::filesystem::temp_directory_path().string();
+  cfg->dataset_id = "lift_velocity_test";
+  // Uncompressed so the payload bytes below can be searched for directly; the
+  // restorer above does not cover this field. Empty rather than "none": the
+  // backend maps only the empty string to McapCompression::None, and any other
+  // unrecognised value warns before falling back to it.
+  cfg->compression = "";
+
+  const auto episode_dir = std::filesystem::path(cfg->root) / cfg->dataset_id;
+  std::filesystem::remove_all(episode_dir);
+
+  auto backend = BackendRegistry::create("trossen_mcap");
+  ASSERT_NE(backend, nullptr);
+  ASSERT_TRUE(backend->open());
+
+  // A value with no zero bytes in its IEEE-754 encoding, so the byte pattern
+  // searched for below cannot collide with padding or an unset field.
+  constexpr float kLift = 1234.5f;
+  trossen::data::Odometry2DRecord rec;
+  rec.id = "rivet_base";
+  rec.lift_velocity = kLift;
+  backend->write(rec);
+  backend->close();
+  cfg->compression = saved_compression;
+
+  std::filesystem::path mcap_path;
+  for (const auto& entry : std::filesystem::directory_iterator(episode_dir)) {
+    if (entry.is_regular_file() && entry.path().extension() == ".mcap") {
+      mcap_path = entry.path();
+    }
+  }
+  ASSERT_FALSE(mcap_path.empty()) << "No .mcap file was written";
+
+  std::ifstream mcap_file(mcap_path, std::ios::binary);
+  const std::string contents(
+    (std::istreambuf_iterator<char>(mcap_file)), std::istreambuf_iterator<char>());
+
+  // The embedded schema must declare the field, or a consumer cannot decode it
+  // however faithfully we serialise it.
+  EXPECT_NE(contents.find("lift_velocity"), std::string::npos)
+    << "Odometry2D schema in the .mcap does not declare lift_velocity";
+
+  // proto3 field 5, wire type 5 (32-bit) => tag byte 0x2d, then the float
+  // little-endian. Its presence proves write_odometry_2d_record() set it.
+  std::string expected(1, '\x2d');
+  expected.append(reinterpret_cast<const char*>(&kLift), sizeof(kLift));
+  EXPECT_NE(contents.find(expected), std::string::npos)
+    << "serialised Odometry2D message does not carry lift_velocity=" << kLift;
 }


### PR DESCRIPTION
## Summary

`TrossenBaseProducer` — records the Rivet base's odometry and the velocity it was commanded, plus the recording surface that needs: `lift_velocity` on the existing `Odometry2DRecord`, the matching `Odometry2D.proto` field, and the backend write hunk.

Split from PR 14 because recording base telemetry is independent of the teleop path.

## The twist channel is an action echo, not an observation

The base reports **no measured velocity**. Pose comes from its own odometry, but the recorded twist is the velocity most recently *commanded* to it, read back from the component (which is the only thing that knows it).

For a learned policy that distinction is the difference between an observation and an action, so it is stated in the header, at the record, and in the stream metadata rather than left for a dataset consumer to infer.

`base_velocity_names` advertises all four axes the swerve base drives — `linear_vel, angular_vel, lift_vel, lateral_vel` — so a converter does not assume the SLATE's two-axis differential-drive layout.

## `lift_velocity` sits in `Odometry2D`, and that is provisional

A lift is not planar motion, so it goes outside the 2D twist. But a record named `Odometry2D` carrying it at all is a compromise: the same argument would drag in every other non-planar thing a base measures.

A `TODO` on the record says so and names the two ways out — rename to something that admits it describes base state generally, or move the non-planar axes to their own record.

## Battery telemetry is deliberately not recorded — and that removed a data race

It does not belong in a record called `Odometry2D`. Investigating it turned up a second reason.

`TrossenBase` caches everything into **one unsynchronised `base_data_` struct**:

- `get_pose()` writes its *pose* members
- `update_base()` → `refresh_battery_status()` writes its *battery* members

Disjoint members are distinct memory locations, so the producer's `poll()` and the component's 15 Hz servicing thread do **not** race, and the reads underneath both take the driver's own `status_mutex_` against its receive thread.

**But `get_percent()`, `get_temp()` and `get_charging_state()` read exactly the members that servicing thread writes**, with nothing synchronising them. Calling one from `poll()` is a genuine data race on a non-atomic float, in the recording path. Not recording battery is what keeps this poll confined to disjoint state.

The analysis is recorded at `poll()`, framed as a constraint on what may be added there — the next person's instinct will be "the driver exposes battery, why aren't we recording it."

### This answers an open question from the plan

The known SLATE hazard is that `SlateBaseProducer::poll()` drives `update_state()` itself, racing the component's `set_cmd_vel()` on the driver's serial transactions. **This pair is not shaped that way** — the producer never ticks the driver; the component's servicing thread does, unconditionally. The producer is a pure reader, and safe, but only because of which fields it touches.

## Test Plan

- [x] Default configuration: **399/399**, including a new test asserting `lift_velocity` reaches the `.mcap` — both that the embedded schema declares the field and that the serialised payload carries the value
- [x] **Negative control run**: that test fails with the write hunk removed, passes with it restored
- [x] `TROSSEN_ENABLE_RIVET=ON` against an installed `trossen_base`: builds and links, 125 producer symbols
- [x] cpplint / pre-commit clean
- [ ] Not exercised on Rivet hardware

The test matters because a SLATE never sets `lift_velocity`. A mistake in either half of its path is invisible on every existing rig and would surface only as a silently zeroed column in a Rivet dataset, long after recording.

## Notes for review

- `schema_data_odom2d_` is built at runtime from the compiled descriptor pool, not a checked-in blob, so the embedded schema cannot drift from the `.proto`. Verified rather than assumed.
- Pre-existing quirk hit while writing the test: the backend maps only the **empty string** to `McapCompression::None`; `"none"` falls through to the "Unknown compression option" warning and then uses None anyway. The test uses `""` with a comment rather than emitting a spurious warning. Not fixed here.
