### PR TITLE
examples: trossen_rivet, the Workbench plus a mobile base

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,6 +17,14 @@ target_link_libraries(trossen_mobile_ai trossen_sdk libtrossen_arm)
 add_executable(trossen_workbench trossen_workbench/trossen_workbench.cpp)
 target_link_libraries(trossen_workbench trossen_sdk libtrossen_arm)
 
+# Trossen Rivet — the Workbench plus a holonomic swerve base with a lift.
+# Gated because the base needs the trossen_base library; the Glide handle layer
+# it shares with the Workbench is not gated and builds either way.
+if(TROSSEN_ENABLE_RIVET)
+  add_executable(trossen_rivet trossen_rivet/trossen_rivet.cpp)
+  target_link_libraries(trossen_rivet trossen_sdk libtrossen_arm)
+endif()
+
 # Trossen Stationary AI Policy — 2 followers + 4 cameras, policy-driven leaders.
 # Requires the PolicyClient gate (FetchContent of IXWebSocket + msgpack-cxx).
 #

--- a/examples/trossen_rivet/README.md
+++ b/examples/trossen_rivet/README.md
@@ -179,23 +179,25 @@ chase it by flipping signs; a flip will only be right until the next restart.
 The handles and the followers are on **different subnets** — deliberate, and it
 matches the rig wiring, so check both before assuming a fault.
 
-| Arm | Role | Default IP |
-|---|---|---|
-| `glide_left` | Handle (passive leader) | `192.168.0.3` |
-| `glide_right` | Handle (passive leader) | `192.168.0.2` |
-| `follower_left` | Follower | `192.168.1.4` |
-| `follower_right` | Follower | `192.168.1.5` |
+| Arm | Role | Default IP | Interface |
+|---|---|---|---|
+| `glide_left` | Handle (passive leader) | `192.168.5.13` | wireless |
+| `glide_right` | Handle (passive leader) | `192.168.5.12` | wireless |
+| `follower_left` | Follower | `192.168.1.15` | wired |
+| `follower_right` | Follower | `192.168.1.14` | wired |
 
-These match `rivet-01`. **Other rigs differ** — `rivet-02` uses a different
-assignment — so confirm against the rig rather than assuming, and override
-without editing the file:
+These match `rivet-02`, the rig this example was brought up on. **Other rigs
+differ** — `rivet-01` uses a different assignment — so confirm against the rig
+rather than assuming, and override without editing the file:
 
 ```bash
 ./build/examples/trossen_rivet \
-  --set hardware.arms.glide_left.ip_address=192.168.5.13
+  --set hardware.arms.glide_left.ip_address=192.168.5.3
 ```
 
 > Arms do not answer ICMP, so `ping` is not a valid reachability test. Use `arp`.
+> On the wireless subnet the access point proxy-ARPs, so an ARP reply there
+> proves the address is routed, not that the handle is powered.
 
 The base is not on the network at all — it is reached over CAN.
 

--- a/examples/trossen_rivet/README.md
+++ b/examples/trossen_rivet/README.md
@@ -1,0 +1,302 @@
+# Rivet Example
+
+Bimanual teleop on a drivable platform: two Trossen Glide handles driving two
+follower arms **and** a holonomic swerve base with a vertical lift, recording
+handles, followers, base and three ZED cameras to TrossenMCAP format.
+
+The Rivet is the Workbench on wheels. Everything in
+[trossen_workbench](../trossen_workbench/README.md) applies here; this page
+covers what the base adds.
+
+---
+
+## Two teleop roles, two physical handles
+
+The part worth understanding before anything else: each handle drives **two
+different followers at once**.
+
+| The handle's… | drives | via |
+|---|---|---|
+| joint motion | the follower arm on that side | a joint-space teleop pair |
+| joystick and buttons | the mobile base | a base-space teleop pair |
+
+Arm motion and base motion are independent — you can drive while manipulating.
+`GlideSession` arbitrates the inputs so no two components read the same stick or
+button; a config that double-binds one is rejected at startup rather than
+producing two things moving from one press.
+
+---
+
+## Hardware Required
+
+| Device | Quantity | Notes |
+|---|---|---|
+| Trossen Glide handle (`glide_left`, `glide_right`) | 2 | Passive leaders — no actuators |
+| Trossen Pro arm (`pro`) | 2 | Followers |
+| Trossen swerve base with lift | 1 | Holonomic drive + vertical actuator |
+| ZED camera | 3 | Main view + one per wrist |
+
+---
+
+## Building
+
+The base needs the `trossen_base` library, which is behind a build flag. The
+cameras are ZEDs, behind another:
+
+```bash
+cmake -S . -B build -DTROSSEN_ENABLE_RIVET=ON -DTROSSEN_ENABLE_ZED=ON
+cmake --build build -j
+```
+
+`TROSSEN_ENABLE_RIVET` gates the **library**, not the robot. `trossen_base` must
+be installed — it is consumed with `find_package`, the same way `libtrossen_arm`
+is, so a host without it fails at configure time naming the package. The Glide
+handle layer is not gated and builds either way, which is why the Workbench
+example needs neither flag.
+
+---
+
+## Handle Controls
+
+**Operators: this is the section to keep next to the robot.**
+
+You hold one handle in each hand. Moving a handle moves the follower arm on that
+side; the joysticks drive the base.
+
+```
+        LEFT HANDLE                              RIGHT HANDLE
+
+     ( 0 ) start / next                            ( 0 ) lift ↑
+ ( 1 ) end        ( 3 )                        ( 1 )        ( 3 )
+     ( 2 ) re-record                              ( 2 ) lift ↓
+
+        [ joystick ]                             [ joystick ]
+     drive forward / back                       turn left / right
+       and strafe L/R                            (rotate in place)
+
+     handle motion → LEFT follower arm       handle motion → RIGHT follower arm
+     trigger       → LEFT gripper            trigger       → RIGHT gripper
+```
+
+The four buttons form a **physical cross**, and the bit numbering is not the
+order you would guess: **0 = top, 1 = left, 2 = bottom, 3 = right.** Bits 1 and 3
+were documented the wrong way round until 2026-08-07, so a config written against
+the old note binds left and right swapped. Nothing validates a bit beyond its
+range, so that mistake is silent.
+
+### Picking up a handle — twist it in
+
+The handles sit on a **magnetic mount**. Do not let one snap on or rip off.
+
+- **To take a handle off:** twist it out of the mount. Rotate as you pull, so the
+  magnet lets go gradually.
+- **To put it back:** bring it close, then **twist it in** — let the magnet take
+  hold as you rotate, rather than dropping it straight on.
+
+Snapping the magnet on hard shocks the handle and the arm behind it.
+
+### Driving the base
+
+| Control | What it does | Limit |
+|---|---|---|
+| **Left joystick** | Drives the base: forward / back, and strafe left / right. Holonomic — a diagonal push moves diagonally, at the same speed as straight ahead. | 0.6 m/s |
+| **Right joystick** | Turns the base in place. | 1.2 rad/s |
+
+Both sticks have a dead zone, so the base will not creep when you let go. If it
+does creep, stop and tell an engineer — do not drive it.
+
+The diagonal behaving like straight ahead is deliberate: the left stick is
+configured as a `translation` block, which treats it as one 2D vector with a
+*radial* dead zone and a magnitude clamp. Two independent axes would instead give
+a square dead region and a diagonal ~41% faster than straight ahead.
+
+### The lift
+
+| Button | What it does |
+|---|---|
+| **Right handle, top (bit 0)** | Raises the lift. Moves while held. |
+| **Right handle, bottom (bit 2)** | Lowers the lift. Moves while held. |
+
+### Session control
+
+| Button | Bit | Event | Effect |
+|---|---|---|---|
+| Left handle, top | 0 | `start` | Begin an episode; while recording, stop and advance; while resetting, skip the wait |
+| Left handle, left | 1 | `stop_session` | End the whole session (same as Ctrl+C) |
+| Left handle, bottom | 2 | `rerecord` | Discard the current episode (or the last one, while resetting) and go again |
+
+Buttons emit on the **rising edge** after a 40 ms debounce, so a held button is
+one intent rather than a stream of them.
+
+Unbound in this config: bit 3 on both handles, and bit 1 on the right. Pressing
+them does nothing. Re-binding any of this is a config edit, not a rebuild — see
+`hardware.controls` in [config.json](config.json).
+
+---
+
+## The base stops itself if commands stop arriving
+
+Worth knowing before debugging a base that halted on its own.
+
+The wheels **hold their last commanded velocity**, and the component's servicing
+thread re-asserts it every tick — so a base told to drive keeps driving until
+something says otherwise. A teleop loop that dies, or a host wedged on something
+else, would otherwise leave a moving robot with nobody at the controls.
+
+So the base commands a standstill if no fresh command arrives within
+`command_timeout_ms` (default 500 ms, against a teleop mirror writing at 1 kHz).
+It logs when it fires and again when commands resume. The check arms on the first
+command, so connecting without ever driving does not trip it.
+
+**It does not catch a handle that goes quiet while still reporting.** A blackholed
+handle keeps returning its last stick value, so commands keep arriving and this
+check never fires. Handle-side freshness gating is not implemented.
+
+---
+
+## Homing
+
+`configure()` re-homes the swerve modules on every startup, which takes tens of
+seconds and is the slowest part of bring-up. It is on by default and should stay
+that way for anything that then moves the base: the modules otherwise run on
+whatever zero they last established, and a pivot nudged by hand translates a
+commanded heading into the wrong actual heading — a robot that drives off at an
+angle, not one that refuses to drive.
+
+`"home_on_configure": false` exists for connecting to the base for some other
+reason. Do **not** set it to skip homing in a recording session on the grounds
+that something homed recently: there is no query for zero validity, so "still
+homed" is an assumption nothing can check.
+
+If translation direction changes between bring-ups with nothing edited, that is
+the homed zero landing half a turn out — not an axis-inversion config bug. Do not
+chase it by flipping signs; a flip will only be right until the next restart.
+
+---
+
+## Network Setup
+
+The handles and the followers are on **different subnets** — deliberate, and it
+matches the rig wiring, so check both before assuming a fault.
+
+| Arm | Role | Default IP |
+|---|---|---|
+| `glide_left` | Handle (passive leader) | `192.168.0.3` |
+| `glide_right` | Handle (passive leader) | `192.168.0.2` |
+| `follower_left` | Follower | `192.168.1.4` |
+| `follower_right` | Follower | `192.168.1.5` |
+
+These match `rivet-01`. **Other rigs differ** — `rivet-02` uses a different
+assignment — so confirm against the rig rather than assuming, and override
+without editing the file:
+
+```bash
+./build/examples/trossen_rivet \
+  --set hardware.arms.glide_left.ip_address=192.168.5.13
+```
+
+> Arms do not answer ICMP, so `ping` is not a valid reachability test. Use `arp`.
+
+The base is not on the network at all — it is reached over CAN.
+
+---
+
+## Running
+
+```bash
+./build/examples/trossen_rivet                       # default config
+./build/examples/trossen_rivet --config path/to.json # custom config
+./build/examples/trossen_rivet --dump-config         # inspect merged config, don't run
+```
+
+The example will:
+
+1. Connect to all four arms, then bring up the handle input, base leader and session control
+2. Connect to the base and home its swerve modules — the slow step
+3. Enable teleop: each follower mirrors its handle at 1000 Hz, and the base follows the joysticks
+4. Wait for **top of the left handle** to start an episode
+5. Record, then stop, flush, and save the `.mcap`
+6. Repeat until `max_episodes`, the stop button, or Ctrl+C
+7. Return the followers to rest and halt the base
+
+Step 7 matters more for the base than the arms: halting it is what stops the
+wheels re-asserting their last command.
+
+---
+
+## Default Session Settings
+
+| Setting | Value |
+|---|---|
+| Episode duration | 50 seconds |
+| Max episodes | 40 |
+| Reset window | 5 seconds |
+| Joint / base poll rate | 30 Hz |
+| Camera frame rate | 30 Hz @ HD1200 |
+| Teleop rate | 1000 Hz |
+| Output directory | `~/trossen_data` |
+| Dataset ID | `rivet_dataset` |
+
+> **LeRobot V2 note:** keep `poll_rate_hz` for arms and `fps`/`poll_rate_hz` for
+> cameras at the same value. Mismatched rates degrade training performance.
+
+---
+
+## Recorded Streams
+
+| Stream ID | Type | Content |
+|---|---|---|
+| `glide_left`, `glide_right` | JointState | position, velocity, effort × 7 — what the operator did |
+| `follower_left`, `follower_right` | JointState | position, velocity, effort × 7 — what the robot did |
+| `trossen_base` | Odometry2D | pose, twist, lift velocity |
+| `camera_main`, `camera_left`, `camera_right` | Image | BGR8 HD1200 @ 30 fps |
+
+**The base's twist is a command echo, not a measurement.** The base reports no
+measured velocity, so the recorded twist and lift velocity are what the base was
+*told* to do. For a learned policy that makes them action channels, not
+observations. Pose is genuine odometry.
+
+---
+
+## Converting to LeRobot V2
+
+```bash
+./build/scripts/trossen_mcap_to_lerobot_v2 ~/trossen_data/rivet_dataset/ ~/lerobot_datasets
+```
+
+---
+
+## Troubleshooting
+
+**`Could not find a package configuration file provided by "trossen_base"`**
+Configure-time failure: the library is not installed. It is a private dependency
+and is not fetched automatically.
+
+**`base did not report ready within 60s`**
+The base is powered off, e-stopped, or its CAN link is down. Not an arm problem —
+the arms connect over Ethernet and will have succeeded already.
+
+**`swerve module homing failed`**
+The base reported ready but did not confirm homing. Check that no pivot module is
+obstructed and that there is no latched fault, then try again.
+
+**`no command for N ms … stopping the base`**
+The command stream stopped. Look at what was driving it, not at the base.
+
+**`Unknown model: glide_left`**
+The installed `libtrossen_arm` predates Glide support.
+
+**`arm 'glide_left' is not a registered trossen_arm`**
+The handle is not declared under `hardware.arms`, or its id is spelled
+differently there. Arms are constructed before controls.
+
+**`input joystick on handle ... is already claimed by ...`**
+Two components bound to the same input. Each stick and button may be read by
+exactly one component; check for a bit bound twice across `hardware.controls`.
+
+**The base drives at an angle**
+Suspect homing before suspecting the axis config — see [Homing](#homing).
+
+**Follower jitters or overshoots**
+Raise `write_moving_time_s`, or lower `smoothing_beta` for more smoothing at the
+cost of a little lag. Both are per-arm under `hardware.arms`.

--- a/examples/trossen_rivet/config.json
+++ b/examples/trossen_rivet/config.json
@@ -95,10 +95,10 @@
         "type": "glide_base",
         "translation": {
           "arm_id": "glide_left",
-          "forward_source": "joystick_x",
+          "forward_source": "joystick_y",
           "forward_invert": true,
-          "lateral_source": "joystick_y",
-          "lateral_invert": false,
+          "lateral_source": "joystick_x",
+          "lateral_invert": true,
           "max": 0.6,
           "deadzone": 0.05
         },

--- a/examples/trossen_rivet/config.json
+++ b/examples/trossen_rivet/config.json
@@ -3,7 +3,7 @@
   "hardware": {
     "arms": {
       "glide_left": {
-        "ip_address": "192.168.0.3",
+        "ip_address": "192.168.5.13",
         "model": "glide_left",
         "end_effector": "wxai_v0_leader",
         "actuated": false,
@@ -13,7 +13,7 @@
         "gripper_feedback_offset": 6.5
       },
       "glide_right": {
-        "ip_address": "192.168.0.2",
+        "ip_address": "192.168.5.12",
         "model": "glide_right",
         "end_effector": "wxai_v0_leader",
         "actuated": false,
@@ -23,7 +23,7 @@
         "gripper_feedback_offset": 6.5
       },
       "follower_left": {
-        "ip_address": "192.168.1.4",
+        "ip_address": "192.168.1.15",
         "model": "pro",
         "end_effector": "pro_base",
         "write_moving_time_s": 0.3,
@@ -53,7 +53,7 @@
         ]
       },
       "follower_right": {
-        "ip_address": "192.168.1.5",
+        "ip_address": "192.168.1.14",
         "model": "pro",
         "end_effector": "pro_base",
         "write_moving_time_s": 0.3,
@@ -96,9 +96,9 @@
         "translation": {
           "arm_id": "glide_left",
           "forward_source": "joystick_x",
-          "forward_invert": false,
+          "forward_invert": true,
           "lateral_source": "joystick_y",
-          "lateral_invert": true,
+          "lateral_invert": false,
           "max": 0.6,
           "deadzone": 0.05
         },
@@ -106,7 +106,7 @@
           "angular": {
             "arm_id": "glide_right",
             "source": "joystick_x",
-            "invert": true,
+            "invert": false,
             "max": 1.2,
             "deadzone": 0.08
           },
@@ -154,7 +154,7 @@
       {
         "id": "camera_main",
         "type": "zed_camera",
-        "serial_number": "51287468",
+        "serial_number": "56066260",
         "resolution": "HD1200",
         "fps": 30,
         "use_depth": false
@@ -162,7 +162,7 @@
       {
         "id": "camera_left",
         "type": "zed_camera",
-        "serial_number": "97900849",
+        "serial_number": "99078701",
         "resolution": "HD1200",
         "fps": 30,
         "use_depth": false
@@ -170,7 +170,7 @@
       {
         "id": "camera_right",
         "type": "zed_camera",
-        "serial_number": "97525506",
+        "serial_number": "97839053",
         "resolution": "HD1200",
         "fps": 30,
         "use_depth": false

--- a/examples/trossen_rivet/config.json
+++ b/examples/trossen_rivet/config.json
@@ -1,0 +1,274 @@
+{
+  "robot_name": "trossen_rivet",
+  "hardware": {
+    "arms": {
+      "glide_left": {
+        "ip_address": "192.168.0.3",
+        "model": "glide_left",
+        "end_effector": "wxai_v0_leader",
+        "actuated": false,
+        "gripper_force_feedback": true,
+        "gripper_feedback_leader_max": 20.0,
+        "gripper_feedback_follower_max": 100.0,
+        "gripper_feedback_offset": 6.5
+      },
+      "glide_right": {
+        "ip_address": "192.168.0.2",
+        "model": "glide_right",
+        "end_effector": "wxai_v0_leader",
+        "actuated": false,
+        "gripper_force_feedback": true,
+        "gripper_feedback_leader_max": 20.0,
+        "gripper_feedback_follower_max": 100.0,
+        "gripper_feedback_offset": 6.5
+      },
+      "follower_left": {
+        "ip_address": "192.168.1.4",
+        "model": "pro",
+        "end_effector": "pro_base",
+        "write_moving_time_s": 0.3,
+        "staging_time_s": 2.0,
+        "smoothing_enabled": true,
+        "smoothing_gripper": false,
+        "smoothing_min_cutoff_hz": 1.0,
+        "smoothing_beta": 0.9,
+        "smoothing_d_cutoff_hz": 1.0,
+        "command_position_min": [
+          -1.1,
+          null,
+          null,
+          -1.5358897,
+          -1.5358897,
+          -3.1066861,
+          null
+        ],
+        "command_position_max": [
+          0.8,
+          3.1066861,
+          2.3212879,
+          1.5358897,
+          1.5358897,
+          3.1066861,
+          null
+        ]
+      },
+      "follower_right": {
+        "ip_address": "192.168.1.5",
+        "model": "pro",
+        "end_effector": "pro_base",
+        "write_moving_time_s": 0.3,
+        "staging_time_s": 2.0,
+        "smoothing_enabled": true,
+        "smoothing_gripper": false,
+        "smoothing_min_cutoff_hz": 1.0,
+        "smoothing_beta": 0.9,
+        "smoothing_d_cutoff_hz": 1.0,
+        "command_position_min": [
+          -0.8,
+          null,
+          null,
+          -1.5358897,
+          -1.5358897,
+          -3.1066861,
+          null
+        ],
+        "command_position_max": [
+          1.1,
+          3.1066861,
+          2.3212879,
+          1.5358897,
+          1.5358897,
+          3.1066861,
+          null
+        ]
+      }
+    },
+    "controls": {
+      "glide_inputs": {
+        "type": "glide_arm_input",
+        "arms": [
+          "glide_left",
+          "glide_right"
+        ]
+      },
+      "base_leader": {
+        "type": "glide_base",
+        "translation": {
+          "arm_id": "glide_left",
+          "forward_source": "joystick_x",
+          "forward_invert": false,
+          "lateral_source": "joystick_y",
+          "lateral_invert": true,
+          "max": 0.6,
+          "deadzone": 0.05
+        },
+        "axes": {
+          "angular": {
+            "arm_id": "glide_right",
+            "source": "joystick_x",
+            "invert": true,
+            "max": 1.2,
+            "deadzone": 0.08
+          },
+          "lift": {
+            "arm_id": "glide_right",
+            "source": "buttons",
+            "up_bit": 0,
+            "down_bit": 2,
+            "max": 8000.0
+          }
+        }
+      },
+      "session_control": {
+        "type": "glide_session_control",
+        "poll_rate_hz": 50.0,
+        "debounce_ms": 40,
+        "buttons": [
+          {
+            "arm_id": "glide_left",
+            "bit": 0,
+            "event": "start"
+          },
+          {
+            "arm_id": "glide_left",
+            "bit": 1,
+            "event": "stop_session"
+          },
+          {
+            "arm_id": "glide_left",
+            "bit": 2,
+            "event": "rerecord"
+          }
+        ]
+      }
+    },
+    "mobile_base": {
+      "type": "trossen_base",
+      "max_linear_mps": 0.6,
+      "max_angular_rps": 1.2,
+      "max_lift_units_per_s": 8000.0,
+      "home_on_configure": true,
+      "command_timeout_ms": 500.0
+    },
+    "cameras": [
+      {
+        "id": "camera_main",
+        "type": "zed_camera",
+        "serial_number": "51287468",
+        "resolution": "HD1200",
+        "fps": 30,
+        "use_depth": false
+      },
+      {
+        "id": "camera_left",
+        "type": "zed_camera",
+        "serial_number": "97900849",
+        "resolution": "HD1200",
+        "fps": 30,
+        "use_depth": false
+      },
+      {
+        "id": "camera_right",
+        "type": "zed_camera",
+        "serial_number": "97525506",
+        "resolution": "HD1200",
+        "fps": 30,
+        "use_depth": false
+      }
+    ]
+  },
+  "teleop": {
+    "enabled": true,
+    "rate_hz": 1000.0,
+    "pairs": [
+      {
+        "leader": "glide_left",
+        "follower": "follower_left",
+        "space": "joint"
+      },
+      {
+        "leader": "glide_right",
+        "follower": "follower_right",
+        "space": "joint"
+      },
+      {
+        "leader": "base_leader",
+        "follower": "trossen_base",
+        "space": "base"
+      }
+    ]
+  },
+  "producers": [
+    {
+      "type": "trossen_arm",
+      "hardware_id": "follower_left",
+      "stream_id": "follower_left",
+      "poll_rate_hz": 30.0,
+      "use_device_time": false
+    },
+    {
+      "type": "trossen_arm",
+      "hardware_id": "follower_right",
+      "stream_id": "follower_right",
+      "poll_rate_hz": 30.0,
+      "use_device_time": false
+    },
+    {
+      "type": "trossen_arm",
+      "hardware_id": "glide_left",
+      "stream_id": "glide_left",
+      "poll_rate_hz": 30.0,
+      "use_device_time": false
+    },
+    {
+      "type": "trossen_arm",
+      "hardware_id": "glide_right",
+      "stream_id": "glide_right",
+      "poll_rate_hz": 30.0,
+      "use_device_time": false
+    },
+    {
+      "type": "trossen_base",
+      "hardware_id": "trossen_base",
+      "stream_id": "trossen_base",
+      "poll_rate_hz": 30.0,
+      "use_device_time": false
+    },
+    {
+      "type": "zed_camera",
+      "hardware_id": "camera_main",
+      "stream_id": "camera_main",
+      "poll_rate_hz": 30.0,
+      "encoding": "bgr8",
+      "use_device_time": true
+    },
+    {
+      "type": "zed_camera",
+      "hardware_id": "camera_left",
+      "stream_id": "camera_left",
+      "poll_rate_hz": 30.0,
+      "encoding": "bgr8",
+      "use_device_time": true
+    },
+    {
+      "type": "zed_camera",
+      "hardware_id": "camera_right",
+      "stream_id": "camera_right",
+      "poll_rate_hz": 30.0,
+      "encoding": "bgr8",
+      "use_device_time": true
+    }
+  ],
+  "backend": {
+    "root": "~/trossen_data",
+    "dataset_id": "rivet_dataset",
+    "compression": "",
+    "chunk_size_bytes": 4194304
+  },
+  "session": {
+    "max_duration": 50.0,
+    "max_episodes": 40,
+    "backend_type": "trossen_mcap",
+    "reset_duration": 5.0
+  }
+}

--- a/examples/trossen_rivet/trossen_rivet.cpp
+++ b/examples/trossen_rivet/trossen_rivet.cpp
@@ -31,6 +31,7 @@
 #include "trossen_sdk/configuration/cli_parser.hpp"
 #include "trossen_sdk/configuration/loaders/json_loader.hpp"
 #include "trossen_sdk/configuration/sdk_config.hpp"
+#include "trossen_sdk/hw/active_hardware_registry.hpp"
 #include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
 #include "trossen_sdk/hw/hardware_registry.hpp"
 #include "trossen_sdk/hw/session_control/session_control_capable.hpp"
@@ -462,6 +463,14 @@ int main(int argc, char** argv) {
   };
   trossen::utils::print_final_summary(
     final_stats.total_episodes_completed, root, extra_info);
+
+  // HardwareRegistry::create() registered every component in the ActiveHardwareRegistry,
+  // whose backing map is a function-local static. Returning without this leaves that map
+  // holding the last shared_ptr to each component, so the destructors run during static
+  // destruction — after libcudart has unloaded. A ZED camera closing there fails every
+  // CUDA call with cudaErrorCudartUnloading and may leave the Argus provider claimed,
+  // which then breaks the *next* run's stream start. Release them while CUDA is alive.
+  trossen::hw::ActiveHardwareRegistry::clear();
 
   return 0;
 }

--- a/examples/trossen_rivet/trossen_rivet.cpp
+++ b/examples/trossen_rivet/trossen_rivet.cpp
@@ -1,0 +1,467 @@
+/**
+ * @file trossen_rivet.cpp
+ * @brief Rivet demo (2 glides, 2 followers, 1 mobile base, 3 cameras)
+ *
+ * The Rivet is the Workbench on a drivable platform: the same two Glide handles
+ * driving the same two follower arms, plus a holonomic swerve base with a
+ * vertical lift that the handles also steer.
+ *
+ * Two teleop roles over the same two physical handles, which is the part worth
+ * understanding before reading further. The arms are joint-space pairs; the base
+ * is a base-space pair whose leader synthesizes velocity from the handles'
+ * joysticks and buttons. GlideSession arbitrates so no two components read the
+ * same stick or button.
+ *
+ * Requires TROSSEN_ENABLE_RIVET, which gates the trossen_base library this
+ * links against. The handle layer itself is not gated — see trossen_workbench
+ * for the same rig without the base.
+ */
+
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "libtrossen_arm/trossen_arm.hpp"
+#include "nlohmann/json.hpp"
+#include "trossen_sdk/configuration/cli_parser.hpp"
+#include "trossen_sdk/configuration/loaders/json_loader.hpp"
+#include "trossen_sdk/configuration/sdk_config.hpp"
+#include "trossen_sdk/hw/arm/trossen_arm_component.hpp"
+#include "trossen_sdk/hw/hardware_registry.hpp"
+#include "trossen_sdk/hw/session_control/session_control_capable.hpp"
+#include "trossen_sdk/hw/teleop/teleop_capable.hpp"
+#include "trossen_sdk/hw/teleop/teleop_factory.hpp"
+#include "trossen_sdk/observer/observer_registry.hpp"
+#include "trossen_sdk/runtime/producer_registry.hpp"
+#include "trossen_sdk/runtime/push_producer_registry.hpp"
+#include "trossen_sdk/runtime/session_manager.hpp"
+
+#include "trossen_sdk/utils/app_utils.hpp"
+
+static void print_usage(const char* program) {
+  std::cout <<
+    "Usage: " << program << " [OPTIONS]\n"
+    "\n"
+    "Options:\n"
+    "  --config PATH      Path to robot config JSON\n"
+    "                     [default: examples/trossen_rivet/config.json]\n"
+    "  --set KEY=VALUE    Override a config value using dot notation (repeatable)\n"
+    "  --dump-config      Print merged config as JSON and exit\n"
+    "  --help             Show this help and exit\n"
+    "\n"
+    "Examples:\n"
+    "  " << program << "\n"
+    "  " << program << " --config examples/trossen_rivet/config.json\n"
+    "  " << program << " --set hardware.arms.glide_left.ip_address=192.168.1.2\n"
+    "  " << program << " --set session.max_duration=30\n"
+    "  " << program << " --dump-config\n";
+}
+
+int main(int argc, char** argv) {
+  // Flush every line immediately so progress (and the last line before any
+  // stall) is always visible — important for a long-running, hardware-driven
+  // recording loop.
+  std::cout << std::unitbuf;
+
+  trossen::configuration::CliParser cli(argc, argv);
+
+  if (cli.has_flag("help")) {
+    print_usage(argv[0]);
+    return 0;
+  }
+
+  const std::string config_path =
+    cli.get_string("config", "examples/trossen_rivet/config.json");
+
+  if (!std::filesystem::exists(config_path)) {
+    std::cerr << "Error: config file not found: " << config_path << "\n";
+    return 1;
+  }
+
+  // Load JSON and apply CLI overrides
+  auto j = trossen::configuration::JsonLoader::load(config_path);
+  const auto overrides = cli.get_set_overrides();
+  if (!overrides.empty()) {
+    j = trossen::configuration::merge_overrides(j, overrides);
+  }
+
+  if (cli.has_flag("dump-config")) {
+    trossen::configuration::dump_config(j, "Trossen Rivet Config");
+    return 0;
+  }
+
+  // Parse unified robot config
+  auto cfg = trossen::configuration::SdkConfig::from_json(j);
+
+  // Populate GlobalConfig so SessionManager picks up session + backend settings
+  cfg.populate_global_config();
+
+  const std::string root = cfg.mcap_backend.root;
+
+  // Derive per-type rates from the producer list
+  float joint_rate_hz = 30.0f;
+  float camera_fps = 30.0f;
+  for (const auto& p : cfg.producers) {
+    if (p.type == "zed_camera" || p.type == "realsense_camera" ||
+        p.type == "opencv_camera") {
+      camera_fps = p.poll_rate_hz;
+      break;
+    }
+  }
+
+  std::vector<std::string> config_lines = {
+    "Config file:          " + config_path,
+    "Root directory:       " + root,
+    "Backend:              " + cfg.session.backend_type,
+    "Robot name:           " + cfg.robot_name
+  };
+
+  trossen::utils::print_config_banner("Trossen Rivet Demo Usage", config_lines);
+
+  trossen::utils::install_signal_handler();
+  std::filesystem::create_directories(root);
+
+  // ──────────────────────────────────────────────────────────
+  // Initialize arm hardware from config
+  // ──────────────────────────────────────────────────────────
+
+  std::cout << "Initializing hardware...\n";
+
+  // Arms first. Every one is a plain trossen_arm: the two Glide handles are
+  // passive leaders (`actuated: false`) and the two `pro` arms are followers, a
+  // distinction that lives entirely in their config rather than in their type.
+  std::unordered_map<std::string,
+    std::shared_ptr<trossen::hw::arm::TrossenArmComponent>> arm_components;
+
+  for (const auto& [id, arm_cfg] : cfg.hardware.arms) {
+    auto component = trossen::hw::HardwareRegistry::create(
+      "trossen_arm", id, arm_cfg.to_json(), true);
+    arm_components[id] =
+      std::dynamic_pointer_cast<trossen::hw::arm::TrossenArmComponent>(component);
+    std::cout << "  [ok] Arm [" << id << "] configured (" << arm_cfg.ip_address
+              << ", " << arm_cfg.model
+              << (arm_cfg.actuated ? "" : ", passive leader") << ")\n";
+  }
+
+  // Then the controls — after the arms, because glide_arm_input resolves the
+  // handle arms above by id out of the active registry. Nothing in the SDK
+  // enforces that order; it is this call sequence, which is why a lookup miss
+  // reports the ordering rather than a bare "not found".
+  std::unordered_map<std::string,
+    std::shared_ptr<trossen::hw::HardwareComponent>> controls;
+
+  // Anything that can drive session transitions gets attached to the manager
+  // below. Collected by interface rather than by type so a different button
+  // source needs no change here.
+  std::vector<std::shared_ptr<trossen::hw::session_control::SessionControlCapable>>
+    session_ctrls;
+
+  for (const auto& [id, ctrl_cfg] : cfg.hardware.controls) {
+    auto component = trossen::hw::HardwareRegistry::create(
+      ctrl_cfg.type, id, ctrl_cfg.to_json(), true);
+    controls[id] = component;
+
+    if (auto sc = std::dynamic_pointer_cast<
+          trossen::hw::session_control::SessionControlCapable>(component)) {
+      session_ctrls.push_back(sc);
+    }
+
+    std::cout << "  [ok] Control [" << id << "] configured (type="
+              << ctrl_cfg.type << ")\n";
+  }
+
+  // The base last, because configure() is the slowest step in the whole
+  // bring-up: it waits for the base to report ready and then re-homes the
+  // swerve modules, which is tens of seconds. Everything above has already
+  // failed fast by the time this blocks, so a config typo does not cost a
+  // homing cycle before it is reported.
+  //
+  // Created through the registry by `type` rather than by naming the class, so
+  // the same code brings up a differential-drive slate_base. Registered active
+  // so the base-space teleop pair below can resolve it by id.
+  std::shared_ptr<trossen::hw::HardwareComponent> base_component;
+  std::string base_id;
+
+  if (cfg.hardware.mobile_base.has_value()) {
+    const auto& base_cfg = *cfg.hardware.mobile_base;
+    base_id = base_cfg.type;
+    base_component = trossen::hw::HardwareRegistry::create(
+      base_cfg.type, base_id, base_cfg.to_json(), true);
+    std::cout << "  [ok] Base [" << base_id << "] configured\n";
+  } else {
+    // Not fatal: the arms and handles above are a working Workbench. Said out
+    // loud because a Rivet whose base silently did not appear looks like a base
+    // that failed to move.
+    std::cout << "  [--] No hardware.mobile_base in config; running without a base\n";
+  }
+
+  // ──────────────────────────────────────────────────────────
+  // Session Manager + producers
+  // ──────────────────────────────────────────────────────────
+
+  trossen::runtime::SessionManager mgr;
+  std::cout << "\nInitialized Session Manager\n";
+  std::cout << "  Starting episode index: " << mgr.stats().current_episode_index << "\n";
+  if (mgr.stats().current_episode_index > 0) {
+    std::cout << "  (Resuming from existing episodes in directory)\n";
+  }
+  std::cout << "\n";
+
+  // Pre-initialize camera hardware (keyed by camera id for producer lookup)
+  std::unordered_map<std::string,
+    std::shared_ptr<trossen::hw::HardwareComponent>> camera_components;
+  std::unordered_map<std::string,
+    const trossen::configuration::CameraConfig*> camera_cfg_map;
+  for (const auto& cam_cfg : cfg.hardware.cameras) {
+    auto cam_component = trossen::hw::HardwareRegistry::create(
+      cam_cfg.type, cam_cfg.id, cam_cfg.to_json());
+    camera_components[cam_cfg.id] = cam_component;
+    camera_cfg_map[cam_cfg.id] = &cam_cfg;
+    std::cout << "  [ok] Camera [" << cam_cfg.id << "] initialized ("
+              << cam_cfg.serial_number << ")\n";
+  }
+
+  std::cout << "Creating producers...\n";
+
+  // One producer per entry in the producers list
+  for (const auto& prod_cfg : cfg.producers) {
+    const auto period =
+      std::chrono::milliseconds(static_cast<int>(1000.0f / prod_cfg.poll_rate_hz));
+
+    if (arm_components.count(prod_cfg.hardware_id)) {
+      auto prod = trossen::runtime::ProducerRegistry::create(
+        prod_cfg.type,
+        arm_components.at(prod_cfg.hardware_id),
+        prod_cfg.to_registry_json());
+      mgr.add_producer(prod, period);
+      std::cout << "  [ok] Arm producer [" << prod_cfg.stream_id << "] ("
+                << prod_cfg.poll_rate_hz << " Hz)\n";
+    } else if (controls.count(prod_cfg.hardware_id)) {
+      auto prod = trossen::runtime::ProducerRegistry::create(
+        prod_cfg.type,
+        controls.at(prod_cfg.hardware_id),
+        prod_cfg.to_registry_json());
+      mgr.add_producer(prod, period);
+      std::cout << "  [ok] Component producer [" << prod_cfg.stream_id << "] (type="
+                << prod_cfg.type << ", " << prod_cfg.poll_rate_hz << " Hz)\n";
+    } else if (base_component && prod_cfg.hardware_id == base_id) {
+      auto prod = trossen::runtime::ProducerRegistry::create(
+        prod_cfg.type, base_component, prod_cfg.to_registry_json());
+      mgr.add_producer(prod, period);
+      std::cout << "  [ok] Base producer [" << prod_cfg.stream_id << "] ("
+                << prod_cfg.poll_rate_hz << " Hz)\n";
+    } else if (camera_components.count(prod_cfg.hardware_id)) {
+      const auto* cam = camera_cfg_map.at(prod_cfg.hardware_id);
+      if (trossen::runtime::PushProducerRegistry::is_registered(prod_cfg.type)) {
+        auto prod = trossen::runtime::PushProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_push_producer(prod);
+        std::cout << "  [ok] Camera producer (push) [" << prod_cfg.stream_id << "] ("
+                  << cam->width << "x" << cam->height << ")\n";
+      } else {
+        auto prod = trossen::runtime::ProducerRegistry::create(
+          prod_cfg.type,
+          camera_components.at(prod_cfg.hardware_id),
+          prod_cfg.to_registry_json(cam->width, cam->height, cam->fps));
+        mgr.add_producer(prod, period);
+        std::cout << "  [ok] Camera producer [" << prod_cfg.stream_id << "] ("
+                  << prod_cfg.poll_rate_hz << " Hz, "
+                  << cam->width << "x" << cam->height << ")\n";
+      }
+    }
+  }
+
+  std::cout << "\nProducers registered. Ready to record.\n";
+
+  // ──────────────────────────────────────────────────────────
+  // Observers: registered once, started lazily on first episode, persist across episodes.
+  // ──────────────────────────────────────────────────────────
+
+  if (!cfg.observers.empty()) {
+    std::cout << "Creating observers...\n";
+    // Fail loud on construction errors so a typo'd observer type or missing build flag
+    // does not silently leave the operator with an empty viewer. On failure we print a
+    // diagnostic hint (registered types + rerun build flag) and `return 1`. Returning
+    // (rather than rethrowing) keeps `mgr` in scope so its destructor runs ~SessionManager
+    // -> shutdown(), which joins producer threads cleanly; an exception escaping main()
+    // would invoke std::terminate before unwinding on most GCC builds.
+    for (const auto& obs_cfg : cfg.observers) {
+      if (!obs_cfg.enabled) {
+        std::cout << "  [disabled] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " (skipped: enabled=false)\n";
+        continue;
+      }
+      try {
+        auto obs = trossen::observer::ObserverRegistry::create(
+          obs_cfg.type, obs_cfg.raw_json);
+        mgr.add_observer(obs);
+        std::cout << "  [ok] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " subscriptions=" << obs_cfg.subscriptions.size() << "\n";
+      } catch (const std::exception& e) {
+        // Observers are non-essential by design: a missing/misconfigured one logs and
+        // is skipped, so recording continues without the visual stream. The hint below
+        // points at the build flag for the common "type not registered" case.
+        std::cerr << "  [skip] Observer [" << obs_cfg.id << "] type=" << obs_cfg.type
+                  << " failed to construct: " << e.what() << "\n";
+        const auto types =
+          trossen::observer::ObserverRegistry::get_registered_types();
+        std::cerr << "         Registered observer types:";
+        for (const auto& t : types) std::cerr << " " << t;
+        std::cerr << "\n";
+        if (!trossen::observer::ObserverRegistry::is_registered(obs_cfg.type)) {
+          std::cerr << "         Hint: type '" << obs_cfg.type
+                    << "' is not registered. Rebuild with the matching CMake option "
+                    << "(e.g. -DTROSSEN_ENABLE_RERUN_OBSERVER=ON for the 'rerun' type) "
+                    << "or set 'enabled': false on this observer to silence the warning.\n";
+        }
+        continue;
+      }
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────
+  // Teleop controllers
+  // ──────────────────────────────────────────────────────────
+
+  auto controllers = trossen::hw::teleop::create_controllers_from_global_config();
+
+  // Hand the controllers to the SessionManager, which owns their per-episode
+  // lifecycle: before each episode it pauses the mirror, re-homes any arm that
+  // opted into the episode lifecycle (episode_lifecycle_enabled in its config),
+  // and re-arms teleop; it starts mirroring when recording goes live, resets
+  // between episodes, and stops teleop at shutdown.
+  const bool has_teleop = !controllers.empty();
+  for (auto& ctrl : controllers) mgr.add_teleop(std::move(ctrl));
+
+  // ──────────────────────────────────────────────────────────
+  // Session control from the Glide handle buttons
+  // ──────────────────────────────────────────────────────────
+
+  // attach_session_control() installs the callbacks and then starts the source,
+  // in that order — after start() the poller reads the callbacks without
+  // locking, so it must not be started first.
+  //
+  // Return rather than let attach throw: the manager holds one source at a time
+  // and rejects a second, and an exception escaping main() would terminate
+  // before `mgr` unwound, leaving its producer threads unjoined.
+  if (session_ctrls.size() > 1) {
+    std::cerr << "Error: " << session_ctrls.size() << " session-control sources in "
+              << "hardware.controls; the session accepts one. Remove the extras.\n";
+    return 1;
+  }
+  for (auto& sc : session_ctrls) {
+    mgr.attach_session_control(sc);
+  }
+  if (!session_ctrls.empty()) {
+    std::cout << "\nSession control live on the Glide buttons: start/next, "
+                 "stop session, re-record.\n";
+  }
+
+  // ──────────────────────────────────────────────────────────
+  // Register lifecycle callbacks
+  // ──────────────────────────────────────────────────────────
+
+  // Count depth-capable cameras once for sanity checks
+  int depth_cameras = 0;
+  for (const auto& cam : cfg.hardware.cameras) {
+    if (cam.use_depth) ++depth_cameras;
+  }
+
+  // After each episode: print a summary and run sanity checks. (Teleop reset and
+  // arm re-homing are owned by the SessionManager.)
+  mgr.on_episode_ended([&](const trossen::runtime::SessionManager::Stats& stats) {
+    trossen::utils::print_episode_summary(stats.current_episode_path, stats);
+
+    trossen::utils::SanityCheckConfig sanity_cfg{
+      stats.elapsed.count(),
+      static_cast<int>(cfg.hardware.arms.size()),
+      joint_rate_hz,
+      static_cast<int>(cfg.hardware.cameras.size()),
+      static_cast<int>(camera_fps),
+      5.0,
+      depth_cameras
+    };
+    perform_sanity_check(stats.current_episode_index, stats.records_written_current, sanity_cfg);
+  });
+
+  // Shutdown: the SessionManager stops teleop and returns those arms to rest.
+  // If teleop is disabled (no controllers), return each arm to rest directly so
+  // they don't stay in their last commanded pose.
+  //
+  // The base needs the same treatment for a sharper reason than the arms do: its
+  // wheels HOLD their last commanded velocity and its servicing thread re-asserts
+  // that every tick, so a base left mid-command keeps driving. Reached through
+  // BaseSpaceTeleop rather than its concrete type, so this stays correct for any
+  // base the config names.
+  mgr.on_pre_shutdown([&]() {
+    if (!has_teleop) {
+      for (auto& [id, arm] : arm_components) arm->end_teleop();
+      if (auto base = trossen::hw::teleop::as_capable<
+            trossen::hw::teleop::BaseSpaceTeleop>(base_component)) {
+        base->end_teleop();
+      }
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Episode loop
+  // ──────────────────────────────────────────────────────────
+
+  while (true) {
+    if (trossen::utils::g_stop_requested) {
+      std::cout << "\n\nStopping at user request (Ctrl+C).\n";
+      break;
+    }
+
+    mgr.print_episode_header();
+
+    if (!mgr.start_episode()) {
+      break;
+    }
+
+    std::cout << "Recording...\n";
+
+    auto action = mgr.monitor_episode();
+
+    if (action == trossen::runtime::UserAction::kReRecord) {
+      continue;
+    }
+
+    if (mgr.is_episode_active()) {
+      mgr.stop_episode();
+    }
+
+    if (trossen::utils::g_stop_requested) {
+      std::cout << "\nStopping at user request (Ctrl+C).\n";
+      break;
+    }
+
+    action = mgr.wait_for_reset();
+    if (action == trossen::runtime::UserAction::kStop) break;
+    if (action == trossen::runtime::UserAction::kReRecord) {
+      continue;
+    }
+  }
+
+  // shutdown() calls stop_episode() (no-op if already stopped) then on_pre_shutdown
+  mgr.shutdown();
+
+  const auto final_stats = mgr.stats();
+  std::vector<std::string> extra_info = {
+    "Data streams:         " + std::to_string(cfg.hardware.arms.size()) + " arms + " +
+      std::to_string(cfg.hardware.cameras.size()) + " cameras + " +
+      std::to_string(cfg.hardware.controls.size()) + " controls" +
+      (base_component ? " + 1 base" : "")
+  };
+  trossen::utils::print_final_summary(
+    final_stats.total_episodes_completed, root, extra_info);
+
+  return 0;
+}

--- a/examples/trossen_workbench/config.json
+++ b/examples/trossen_workbench/config.json
@@ -3,7 +3,7 @@
   "hardware": {
     "arms": {
       "glide_left": {
-        "ip_address": "192.168.0.3",
+        "ip_address": "192.168.7.3",
         "model": "glide_left",
         "end_effector": "wxai_v0_leader",
         "actuated": false,
@@ -13,7 +13,7 @@
         "gripper_feedback_offset": 6.5
       },
       "glide_right": {
-        "ip_address": "192.168.0.2",
+        "ip_address": "192.168.7.2",
         "model": "glide_right",
         "end_effector": "wxai_v0_leader",
         "actuated": false,
@@ -23,7 +23,7 @@
         "gripper_feedback_offset": 6.5
       },
       "follower_left": {
-        "ip_address": "192.168.1.4",
+        "ip_address": "192.168.8.5",
         "model": "pro",
         "end_effector": "pro_base",
         "write_moving_time_s": 0.3,
@@ -35,7 +35,7 @@
         "smoothing_d_cutoff_hz": 1.0
       },
       "follower_right": {
-        "ip_address": "192.168.1.5",
+        "ip_address": "192.168.8.4",
         "model": "pro",
         "end_effector": "pro_base",
         "write_moving_time_s": 0.3,
@@ -67,7 +67,7 @@
       {
         "id": "camera_main",
         "type": "zed_camera",
-        "serial_number": "51287468",
+        "serial_number": "55839703",
         "resolution": "HD1200",
         "fps": 30,
         "use_depth": false
@@ -75,7 +75,7 @@
       {
         "id": "camera_left",
         "type": "zed_camera",
-        "serial_number": "97900849",
+        "serial_number": "99926920",
         "resolution": "HD1200",
         "fps": 30,
         "use_depth": false

--- a/include/trossen_sdk/hw/glide/glide_base_component.hpp
+++ b/include/trossen_sdk/hw/glide/glide_base_component.hpp
@@ -42,28 +42,35 @@ namespace trossen::hw::glide {
  * the whole mapping is declarative: discovering that "raise" is really bit 4 is
  * a config edit, not a rebuild.
  *
- * ### Which axis is which on a Rivet (2026-08-11)
+ * ### Which axis is which on a Rivet (2026-08-25)
  *
  * The driver reports each stick only as "0 to 4095" with no physical direction,
- * so every one of these flags was arrived at by driving the base and watching
- * it. What is solid is the axis ASSIGNMENT: on `glide_left` fore/aft lives on
- * `joystick_x` and left/right on `joystick_y` — swapped from what the config
- * originally assumed — while on `glide_right` yaw lives on `joystick_x`. The two
- * handles are different mirrored models and do not agree, so neither can be
- * inferred from the other; that inference is what produced two wrong signs
- * before the flags converged on what the Rivet preset ships:
+ * so these flags are established by driving the base and watching it.
  *
- *     angular:  joystick_x, invert true
- *     forward:  joystick_x, invert false
- *     lateral:  joystick_y, invert true
+ * They are not a property of the handle alone. The base controller's own axis
+ * convention sits underneath them, and it changed: base_controller 1fd57f2b
+ * moved the swerve geometry to ROS convention (X forward, Y left). Before that
+ * X was left and Y was backward, and this preset carried a transposition to
+ * compensate. Firmware containing 1fd57f2b removes the transposition, so the
+ * compensating preset drove fore/aft on the wrong stick axis until the sources
+ * were swapped back.
  *
- * The SIGNS are operator-verified, not probed — nobody has yet read the raw
- * counts while pushing the stick a known way. So treat them as "what the robot
- * did" rather than as a derivation, and do not re-derive other flags from them.
+ * Against firmware containing 1fd57f2b, operator-verified on 2026-08-25:
  *
- * If translation direction ever changes between BRINGUPS with nothing edited,
- * stop chasing these flags — that is the swerve modules' homed zero landing half
- * a turn out, and a sign flip will only be right until the next restart.
+ *     angular:  glide_right joystick_x, invert false
+ *     forward:  glide_left  joystick_y, invert true
+ *     lateral:  glide_left  joystick_x, invert true
+ *
+ * The two handles are mirrored models and do not agree, so neither can be
+ * inferred from the other.
+ *
+ * Check the firmware convention before changing a flag. A preset that
+ * transposes fore/aft and left/right is a base_controller axis convention
+ * change, not a handle problem, and no sign flip will fix it.
+ *
+ * If translation direction changes between BRINGUPS with nothing edited, that
+ * is the swerve modules' homed zero landing half a turn out, and a sign flip
+ * will only be right until the next restart.
  *
  * Expected JSON:
  * @code


### PR DESCRIPTION
## Summary

`trossen_rivet` — the Workbench example plus a mobile base. Two Glide handles driving two follower arms **and** a holonomic swerve base with a vertical lift.

Three files, matching the house style every other example follows: `trossen_rivet.cpp` + `config.json` + `README.md`.

## Each handle drives two followers at once

The part worth understanding before reading the code:

| The handle's… | drives | via |
|---|---|---|
| joint motion | the follower arm on that side | a joint-space teleop pair |
| joystick and buttons | the mobile base | a base-space teleop pair |

`GlideSession` arbitrates the inputs so no two components read the same stick or button — a config that double-binds one is rejected at startup rather than producing two things moving from one press.

## Derived from the shipped Workbench, not from older Rivet sources

The two mains share ~90%, so this is the Workbench main plus four base-specific additions. Porting an older Rivet main instead would have reintroduced four things this stack already fixed: `hardware.components`, the old `attach_control` signature, the missing multi-source guard, and the removed `generate_episode_path` helper.

What the base adds:

1. **Construction from `hardware.mobile_base`** through the registry by `type` — so the same code brings up a `slate_base`. This is the consumer for the `type` field added in #296.
2. **A producer branch** for the base.
3. **A teleop pair** (`base_leader` → `trossen_base`, space `base`).
4. **A teardown that halts the wheels.**

**Ordering, deliberately:** the base is constructed **last**. `configure()` waits for the base to report ready and then re-homes the swerve modules — tens of seconds, and the slowest step in the whole bring-up. Everything else has already failed fast by then, so a config typo does not cost a homing cycle before it is reported.

**Teardown matters more here than for the arms.** The wheels *hold* their last commanded velocity and the servicing thread re-asserts it every tick, so a base left mid-command keeps driving. Reached through `BaseSpaceTeleop` rather than the concrete type, so it stays correct for any base the config names.

A missing `mobile_base` is not fatal — the arms and handles alone are a working Workbench — but it says so out loud, because a Rivet whose base silently did not appear looks like a base that failed to move.

## config.json is regenerated, not copied

Built programmatically from the shipped Workbench config plus the base, so the two examples cannot drift on what they share.

**Stripped, all verified absent:** `haptic_*` (D4), `input_timeout_ms` (D8), `led_*` (D15), `estop_battery_percent` (D22), and `leader_timeout_ms` — whose stall watchdog is deferred (D1), so the preset's key would configure nothing.

**Command clamps ported in** — the example had none, which looked like an oversight rather than a decision. Using the **exact-2° values PR 07 ships** (`1.5358897 / 3.1066861 / 2.3212879`), not the preset's, which differ in the 4th decimal. **J0 is hand-measured and mirrored** — left `−1.1…0.8`, right `−0.8…1.1`. It is the shoulder-yaw stop keeping the arms off each other and the chassis, and the one bound that must not be copied across; mirroring it wrong points both arms into the same space.

**The base's component id is its `type`.** `hardware.mobile_base` is singular with no `id` field, so the id has to come from somewhere; this follows the existing SLATE precedent exactly, where `trossen_mobile_ai` uses id == `hardware_id` == `stream_id` == `"slate_base"`.

## The README is new, and corrects two things the old docs had wrong

This example has never had a `README.md` — its documentation was `BRINGUP.md` plus `GLIDE_CONTROLS.md`, neither of which exists in this tree. Checking every operator-facing claim against the generated config found two errors worth not shipping:

- `GLIDE_CONTROLS.md` says *"The other buttons on either handle do nothing on this robot."* **False** — the left handle's bits 0/1/2 are start / stop\_session / rerecord. An operator following it would not know how to start an episode.
- Its closing section documents the **lift buttons being lit**, dim-then-bright. Those LEDs are gone with D15.

The button map is stated as the physical cross with the **0 = top, 1 = left, 2 = bottom, 3 = right** warning, including that bits 1 and 3 were documented backwards until 2026-08-07 and that nothing validates a bit beyond its range.

Also folded in, because these are the questions this rig actually generates: why the diagonal is not faster than straight ahead (radial dead zone, not two independent axes); why the base halts itself, **and that it does not catch a handle that goes quiet while still reporting its last stick value**; that a direction change between bring-ups with nothing edited is the homed zero landing half a turn out, so do not chase it with sign flips; and that the base's twist is a command echo rather than a measurement.

## Test Plan

- [x] `TROSSEN_ENABLE_RIVET=ON` (installed `trossen_base`): clean full build from scratch, binary produced, loads its config, `--dump-config` renders it
- [x] `--set hardware.mobile_base.max_linear_mps=0.3` reaches the new keys (the object-keyed schema from D19; an array here would throw `type_error.305`)
- [x] Default configuration: **399/399**, and **zero** rivet targets — the gate excludes the example, not just the library
- [x] `"space": "base"` verified against `kSpaceDescriptors`; clamp arrays verified length 7 with J0 mirrored
- [x] pre-commit clean
- [ ] Not exercised on Rivet hardware

## Notes for review

- Resolves the `TODO: RENAME?? @schromya` from the old example header by **deciding**: the name stays `trossen_rivet`, matching the product, the rig hostnames (`rivet-01`, `rivet-02`) and the preset it derives from.
- The IP table is `rivet-01`'s; `rivet-02` uses a different assignment, and the README says so rather than presenting one rig's wiring as universal.
- **Inconsistency worth a decision:** `trossen_workbench` (#295) drives the same two `pro` followers with **no command clamps**. The plan scoped the clamp port to this PR, but arm-on-arm collision applies to a Workbench too — only the chassis half of the rationale is Rivet-specific. Adding the same clamps there is a small follow-up if wanted.
